### PR TITLE
Standard Augmentation Iterable

### DIFF
--- a/src/main/golo/standard-augmentations.golo
+++ b/src/main/golo/standard-augmentations.golo
@@ -19,7 +19,7 @@
 module gololang.StandardAugmentations
 
 
-function newWithSameType = |this| {
+local function _newWithSameType = |this| {
   try {
     return this: getClass(): newInstance()
   } catch (e) {
@@ -75,7 +75,7 @@ augment java.lang.Iterable {
 
 augment java.util.Collection {
 
-  function newWithSameType = |this| -> gololang.StandardAugmentations.newWithSameType(this)
+  function newWithSameType = |this| -> _newWithSameType(this)
 
 }
 
@@ -254,7 +254,7 @@ augment java.util.Map {
 
   function unmodifiableView = |this| -> java.util.Collections.unmodifiableMap(this)
 
-  function newWithSameType = |this| -> gololang.StandardAugmentations.newWithSameType(this)
+  function newWithSameType = |this| -> _newWithSameType(this)
 
   function filter = |this, pred| {
     let filtered = this: newWithSameType()


### PR DESCRIPTION
Currently the augmentation are mainly on the `java.util.Collection` where they could be directly done against the  `java.lang.Iterable` root class.So I try to factorize them.
_NB: `j.u.Map` is not an instance of `j.l.Iterable`..._

I also took the opportunity to factorize the  `newWithSameType`. Indeed, the PR https://github.com/golo-lang/golo-lang/pull/24 defined some default implementations for `j.u.Map` in the `j.u.Collection` and then redefine the `newWithSameType` method in the Map augmentation. So, the default Map implementation is never used...

To ease the management I externalized the method outside the augmentations.
_I could not defined it as a `local` functions due to visibility issues_
