### PR TITLE
Partial evaluation of boolean expressions

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/runtime/OperatorSupport.java
+++ b/src/main/java/fr/insalyon/citi/golo/runtime/OperatorSupport.java
@@ -754,14 +754,6 @@ public class OperatorSupport {
 
   // logic ............................................................................................................
 
-  public static Object and(Boolean a, Boolean b) {
-    return a && b;
-  }
-
-  public static Object or(Boolean a, Boolean b) {
-    return a || b;
-  }
-
   public static Object not(Boolean a) {
     return !a;
   }

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -259,7 +259,22 @@ public class CompileAndRunTest {
   }
 
   @Test
-  public void test_operators() throws ClassNotFoundException, IOException, ParseException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+  public void test_booleans() throws Throwable {
+    Class<?> moduleClass = compileAndLoadGoloModule(SRC, "booleans.golo");
+
+    moduleClass.getMethod("and_logic").invoke(null);
+
+    moduleClass.getMethod("or_logic").invoke(null);
+
+    Method and_shortcut = moduleClass.getMethod("and_shortcut");
+    assertThat((String) and_shortcut.invoke(null), is("Ok"));
+
+    Method or_shortcut = moduleClass.getMethod("or_shortcut");
+    assertThat((String) or_shortcut.invoke(null), is("Ok"));
+  }
+
+  @Test
+  public void test_operators() throws Throwable {
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "operators.golo");
 
     Method plus_one = moduleClass.getMethod("plus_one", Object.class);

--- a/src/test/java/fr/insalyon/citi/golo/runtime/OperatorSupportTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/runtime/OperatorSupportTest.java
@@ -217,36 +217,6 @@ public class OperatorSupportTest {
   }
 
   @Test
-  public void check_and() throws Throwable {
-    MethodHandle handle = OperatorSupport.bootstrap(lookup(), "and", BINOP_TYPE, 2).dynamicInvoker();
-    assertThat((Boolean) handle.invokeWithArguments(true, true), is(true));
-    assertThat((Boolean) handle.invokeWithArguments(false, true), is(false));
-    assertThat((Boolean) handle.invokeWithArguments(true, false), is(false));
-    assertThat((Boolean) handle.invokeWithArguments(false, false), is(false));
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void check_and_rejects_non_booleans() throws Throwable {
-    MethodHandle handle = OperatorSupport.bootstrap(lookup(), "and", BINOP_TYPE, 2).dynamicInvoker();
-    handle.invokeWithArguments("foo", "bar");
-  }
-
-  @Test
-  public void check_or() throws Throwable {
-    MethodHandle handle = OperatorSupport.bootstrap(lookup(), "or", BINOP_TYPE, 2).dynamicInvoker();
-    assertThat((Boolean) handle.invokeWithArguments(true, true), is(true));
-    assertThat((Boolean) handle.invokeWithArguments(false, true), is(true));
-    assertThat((Boolean) handle.invokeWithArguments(true, false), is(true));
-    assertThat((Boolean) handle.invokeWithArguments(false, false), is(false));
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void check_or_rejects_non_booleans() throws Throwable {
-    MethodHandle handle = OperatorSupport.bootstrap(lookup(), "or", BINOP_TYPE, 2).dynamicInvoker();
-    handle.invokeWithArguments("foo", "bar");
-  }
-
-  @Test
   public void check_not() throws Throwable {
     MethodHandle handle = OperatorSupport.bootstrap(lookup(), "not", UNOP_TYPE, 1).dynamicInvoker();
     assertThat((Boolean) handle.invokeWithArguments(true), is(false));

--- a/src/test/resources/for-execution/booleans.golo
+++ b/src/test/resources/for-execution/booleans.golo
@@ -1,0 +1,49 @@
+module golotest.execution.Booleans
+
+function and_logic = {
+  if (true and true) != true {
+    raise("woops")
+  }
+  if (false and true) != false {
+    raise("woops")
+  }
+  if (true and false) != false {
+    raise("woops")
+  }
+  if (false and false) != false {
+    raise("woops")
+  }
+}
+
+function or_logic = {
+  if (true or true) != true {
+    raise("woops")
+  }
+  if (false or true) != true {
+    raise("woops")
+  }
+  if (true or false) != true {
+    raise("woops")
+  }
+  if (false or false) != false {
+    raise("woops")
+  }
+}
+
+function and_shortcut = {
+  let foo = null
+  if (foo isnt null) and (foo: bogus() == 666) {
+    return "WTF"
+  } else {
+    return "Ok"
+  }
+}
+
+function or_shortcut = {
+  let foo = null
+  if (true) or (foo: plop()) {
+    return "Ok"
+  } else {
+    return "WTF"
+  }
+}


### PR DESCRIPTION
The previous implementation evaluated both sides of a boolean expression, meaning that:

```
(foo isnt null) and (foo: bar())
```

would raise a NPE when `foo` is null, as `foo: bar()` would be evaluated, too. This commit shortcuts
evaluation of `and` and `or`.

Fixes #36
