### PR TITLE
Fix Blanklines in Case and Match Branching

### DIFF
--- a/src/main/jjtree/Golo.jjt
+++ b/src/main/jjtree/Golo.jjt
@@ -988,18 +988,18 @@ void ConditionalBranching(): {}
 
 void Case(): {}
 {
-  <CASE> "{" (BlankLine())?
-    ( <WHEN> ExpressionStatement() Block() (BlankLine())? )+
-    <OTHERWISE> Block() (BlankLine())?
+  <CASE> "{" BlankLines()
+    ( <WHEN> ExpressionStatement() Block() BlankLines() )+
+    <OTHERWISE> Block() BlankLines()
   "}"
 }
 
 void Match(): {}
 {
-  <MATCH> "{" (BlankLine())?
-    ( <WHEN> (BlankLine())? ExpressionStatement() (BlankLine())? 
-      <THEN> (BlankLine())? ExpressionStatement() (BlankLine())? )+
-    <OTHERWISE>  (BlankLine())? ExpressionStatement() (BlankLine())?
+  <MATCH> "{" BlankLines()
+    ( <WHEN> BlankLines() ExpressionStatement() BlankLines()
+      <THEN> BlankLines() ExpressionStatement() BlankLines() )+
+    <OTHERWISE>  BlankLines() ExpressionStatement() BlankLines()
   "}"
 }
 

--- a/src/test/resources/for-parsing-and-compilation/conditionals.golo
+++ b/src/test/resources/for-parsing-and-compilation/conditionals.golo
@@ -46,9 +46,34 @@ function dans_la_case = | obj | {
   }
 }
 
+function dans_la_case_il_y_a_de_l_espace = | obj | {
+  case {
+
+    when obj oftype String.class {
+      return "String"
+    }
+    #Comment or blank lines can be inserted
+    when obj oftype Integer.class {
+      return "Integer"
+    }
+
+    otherwise {
+      return "alien"
+    }
+  }
+}
+
 function dans_ton_match = |obj| -> match {
   when obj oftype String.class then "String"
   when obj oftype Integer.class then "Integer"
+  otherwise "alien"
+}
+
+function dans_ton_match_il_y_a_de_l_espace = |obj| -> match {
+
+  when obj oftype String.class then "String"
+  when obj oftype Integer.class then "Integer"
+  #Comment or blank lines can be inserted
   otherwise "alien"
 }
 


### PR DESCRIPTION
It was not possible to insert a blankline or comments inside Case and Match blocks.
To fix it, I just replaced the "(BlankLine())?" by "BlankLines()"
