### PR TITLE
Switch to insertion-ordered sets and maps in the IR

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/compiler/ir/ClosureReference.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/ir/ClosureReference.java
@@ -16,13 +16,13 @@
 
 package fr.insalyon.citi.golo.compiler.ir;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class ClosureReference extends ExpressionStatement {
 
   private final GoloFunction target;
-  private final Set<String> capturedReferenceNames = new HashSet<>();
+  private final Set<String> capturedReferenceNames = new LinkedHashSet<>();
 
   public ClosureReference(GoloFunction target) {
     super();

--- a/src/main/java/fr/insalyon/citi/golo/compiler/ir/GoloModule.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/ir/GoloModule.java
@@ -18,10 +18,7 @@ package fr.insalyon.citi.golo.compiler.ir;
 
 import fr.insalyon.citi.golo.compiler.PackageAndClass;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
@@ -29,10 +26,10 @@ import static java.util.Collections.unmodifiableSet;
 public final class GoloModule extends GoloElement {
 
   private final PackageAndClass packageAndClass;
-  private final Set<ModuleImport> imports = new HashSet<>();
-  private final Set<GoloFunction> functions = new HashSet<>();
-  private final Map<String, Set<GoloFunction>> augmentations = new HashMap<>();
-  private final Set<Struct> structs = new HashSet<>();
+  private final Set<ModuleImport> imports = new LinkedHashSet<>();
+  private final Set<GoloFunction> functions = new LinkedHashSet<>();
+  private final Map<String, Set<GoloFunction>> augmentations = new LinkedHashMap<>();
+  private final Set<Struct> structs = new LinkedHashSet<>();
 
   public static final ModuleImport PREDEF = new ModuleImport(
       PackageAndClass.fromString("gololang.Predefined"));

--- a/src/main/java/fr/insalyon/citi/golo/compiler/ir/ReferenceTable.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/ir/ReferenceTable.java
@@ -24,7 +24,7 @@ import static java.util.Collections.unmodifiableSet;
 public final class ReferenceTable {
 
   private ReferenceTable parent;
-  private final Map<String, LocalReference> table = new HashMap<>();
+  private final Map<String, LocalReference> table = new LinkedHashMap<>();
 
   public ReferenceTable() {
     this(null);
@@ -67,7 +67,7 @@ public final class ReferenceTable {
   }
 
   public Set<String> symbols() {
-    HashSet<String> localSymbols = new HashSet<>(table.keySet());
+    LinkedHashSet<String> localSymbols = new LinkedHashSet<>(table.keySet());
     if (parent != null) {
       localSymbols.addAll(parent.symbols());
     }
@@ -75,7 +75,7 @@ public final class ReferenceTable {
   }
 
   public Collection<LocalReference> references() {
-    Collection<LocalReference> localReferences = new HashSet<>(table.values());
+    Collection<LocalReference> localReferences = new LinkedHashSet<>(table.values());
     if (parent != null) {
       for (LocalReference ref : parent.references()) {
         if (!table.containsKey(ref.getName())) {


### PR DESCRIPTION
Fixes #85.

The side effect is also a predictible IR and bytecode generation across
compilations, which is useful for, say, diagnosis.
