### PR TITLE
EvaluationEnvironment classloader fixes

### DIFF
--- a/src/main/java/gololang/EvaluationEnvironment.java
+++ b/src/main/java/gololang/EvaluationEnvironment.java
@@ -58,7 +58,7 @@ import java.util.*;
  */
 public class EvaluationEnvironment {
 
-  private final GoloClassLoader goloClassLoader = new GoloClassLoader();
+  private final GoloClassLoader goloClassLoader;
   private final List<String> imports = new LinkedList<>();
 
   private static String anonymousFilename() {
@@ -67,6 +67,22 @@ public class EvaluationEnvironment {
 
   private static String anonymousModuleName() {
     return "module anonymous" + System.nanoTime();
+  }
+
+  /**
+   * Creates an evaluation environment using the current thread context classloader.
+   */
+  public EvaluationEnvironment() {
+    this(Thread.currentThread().getContextClassLoader());
+  }
+
+  /**
+   * Creates an evaluation environment using a parent classloader.
+   *
+   * @param parentClassLoader the parent classloader.
+   */
+  public EvaluationEnvironment(ClassLoader parentClassLoader) {
+    goloClassLoader = new GoloClassLoader(parentClassLoader);
   }
 
   /**


### PR DESCRIPTION
This allows a parent classloader to be specified, or else the current
thread context classloader is being used.
