### PR TITLE
Immutable struct instances factory function

### DIFF
--- a/doc/structs.asciidoc
+++ b/doc/structs.asciidoc
@@ -73,6 +73,30 @@ running it prints the following console output:
 struct Point{x=1, y=2}
 ----
 
+=== Immutable structs ===
+
+Structure instances are mutable by default. Golo generates a factory function with the `Immutable`
+prefix to directly build immutable instances:
+
+----
+module test
+
+struct Point = { x, y }
+
+function main = |args| {
+
+  let p = ImmutablePoint(1, 2)
+  println(p)
+
+  try {
+    # Fails! (p is immutable)
+    p: x(100)
+  } catch (expected) {
+    println(expected: getMessage())
+  }
+}
+----
+
 === Copying ===
 
 Instances of a structure provide copying methods:
@@ -133,9 +157,8 @@ p3 == p4 true
 #p4 994
 ----
 
-
-TIP: It is recommended that you use `frozenCopy()` when you can, especially when storing values into
-collections.
+TIP: It is recommended that you use `Immutable<name of struct>(...)` or `frozenCopy()` when you can,
+especially when storing values into collections.
 
 === Helper methods ===
 

--- a/samples/structs.golo
+++ b/samples/structs.golo
@@ -56,6 +56,14 @@ function main = |args| {
   println("p1: set(\"x\", 10) " + p1: set("x", 10))
   println("p1: move(10, 5) " + p1: move(10, 5))
   println("p1: relative(11, 6) " + p1: relative(11, 6))
+
+  let p5 = ImmutablePoint(10, 20)
+  println("p5: " + p5)
+  try {
+    p5: x(100)
+  } catch (expected) {
+    println("p5 is immutable, so... " + expected: getMessage())
+  }
 }
 
 

--- a/src/main/java/fr/insalyon/citi/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -135,6 +135,19 @@ class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     block.addStatement(new ReturnStatement(call));
     module.addFunction(factory);
 
+    factory = new GoloFunction("Immutable" + node.getName(), PUBLIC, MODULE);
+    factory.setParameterNames(new LinkedList<>(node.getMembers()));
+    call = new FunctionInvocation(structClass.toString() + "." + JavaBytecodeStructGenerator.IMMUTABLE_FACTORY_METHOD);
+    table = context.referenceTableStack.peek().fork();
+    block = new Block(table);
+    for (String member : node.getMembers()) {
+      call.addArgument(new ReferenceLookup(member));
+      table.add(new LocalReference(CONSTANT, member));
+    }
+    factory.setBlock(block);
+    block.addStatement(new ReturnStatement(call));
+    module.addFunction(factory);
+
     return data;
   }
 

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -1058,6 +1058,12 @@ public class CompileAndRunTest {
     assertThat(tuple.get(2), not(tuple.get(4)));
     assertThat(tuple.get(2), not(tuple.get(5)));
     assertThat(tuple.get(2), not(tuple.get(0)));
+
+    Method immutable_factory = moduleClass.getMethod("immutable_factory");
+    result = immutable_factory.invoke(null);
+    assertThat(result, instanceOf(Tuple.class));
+    tuple = (Tuple) result;
+    assertThat(tuple.get(0), is(tuple.get(1)));
   }
 
   @Test

--- a/src/test/resources/for-execution/structs.golo
+++ b/src/test/resources/for-execution/structs.golo
@@ -23,6 +23,10 @@ function mrbean_frozenCopy = {
   return [bean, bean: frozenCopy()]
 }
 
+function immutable_factory = {
+  return [ImmutableContact("Mr Bean", "mrbean@outlook.com"), Contact("Mr Bean", "mrbean@outlook.com"): frozenCopy()]
+}
+
 function mrbean_hashCode = -> [
   Contact("Mr Bean", "mrbean@outlook.com"),
   Contact("Mr Bean", "mrbean@outlook.com"),


### PR DESCRIPTION
This allows for the direct creation of frozen / immutable struct
instances. A helper factory function is inserted in the declaring
module.

The helper function name is 'Immutable'<name of the struct>.
