### PR TITLE
Add sum() and product() methods to Iterables and Maps

### DIFF
--- a/src/main/golo/standard-augmentations.golo
+++ b/src/main/golo/standard-augmentations.golo
@@ -143,6 +143,22 @@ augment java.lang.Iterable {
   function exists = |this, pred| ->
     this: filter(pred): size() > 0
 
+  function sum = |this| {
+    let start = {
+      case {
+        when this: get(0) oftype java.lang.Number.class { return 0 }
+        otherwise {
+          return ""
+        }
+      }
+    }
+    return this: reduce(start(), |initial, next| -> initial + next)
+  }
+
+  function product = |this| {
+    return this: reduce(1, |initial, next| -> initial * next)
+  }
+
 }
 
 # ............................................................................................... #
@@ -437,6 +453,26 @@ augment java.util.Map {
 
   function exists = |this, pred| ->
     this: filter(pred): size() > 0
+
+  function sum = |this| {
+    let start = |what| {
+      case {
+        when what oftype java.lang.Number.class { return 0 }
+        otherwise {
+          return ""
+        }
+      }
+    }
+    foreach (entry in this: entrySet()) {
+      return this: reduce(start(entry: getValue()), |initial, key, value| -> initial + value)
+      break
+    }
+  }
+
+  function product = |this| {
+    return this: reduce(1, |initial, key, value| -> initial * value)
+  }
+
 }
 
 # ............................................................................................... #

--- a/src/test/java/gololang/StandardAugmentationsTest.java
+++ b/src/test/java/gololang/StandardAugmentationsTest.java
@@ -213,6 +213,55 @@ public class StandardAugmentationsTest {
   }
 
   @Test
+  public void list_sum_int() throws Throwable {
+    Method list_sum_int = moduleClass.getMethod("list_sum_int");
+    Object result = list_sum_int.invoke(null);
+    assertThat((Integer) result, is(6));
+  }
+
+  @Test
+  public void list_sum_double() throws Throwable {
+    Method list_sum_double = moduleClass.getMethod("list_sum_double");
+    Object result = list_sum_double.invoke(null);
+    assertThat((Double) result, is(6.0));
+  }
+
+  @Test
+  public void list_sum_string() throws Throwable {
+    Method list_sum_string = moduleClass.getMethod("list_sum_string");
+    Object result = list_sum_string.invoke(null);
+    assertThat((String) result, is("123"));
+  }
+
+  @Test
+  public void list_sum_string_int() throws Throwable {
+    Method list_sum_string_int = moduleClass.getMethod("list_sum_string_int");
+    Object result = list_sum_string_int.invoke(null);
+    assertThat((String) result, is("123"));
+  }
+
+  @Test
+  public void list_sum_int_string() throws Throwable {
+    Method list_sum_int_string = moduleClass.getMethod("list_sum_int_string");
+    Object result = list_sum_int_string.invoke(null);
+    assertThat((String) result, is("33"));
+  }
+
+  @Test
+  public void list_product_int() throws Throwable {
+    Method list_product_int = moduleClass.getMethod("list_product_int");
+    Object result = list_product_int.invoke(null);
+    assertThat((Integer) result, is(24));
+  }
+
+  @Test
+  public void list_product_double() throws Throwable {
+    Method list_product_double = moduleClass.getMethod("list_product_double");
+    Object result = list_product_double.invoke(null);
+    assertThat((Double) result, is(24.0));
+  }
+
+  @Test
   public void sets_has_single() throws Throwable {
     Method sets_has_single = moduleClass.getMethod("sets_has_single");
     assertThat((Boolean) sets_has_single.invoke(null), is(true));
@@ -406,6 +455,55 @@ public class StandardAugmentationsTest {
     Method maps_not_exists = moduleClass.getMethod("maps_not_exists");
     Object result = maps_not_exists.invoke(null);
     assertThat((Boolean) result, is(false));
+  }
+
+  @Test
+  public void maps_sum_int() throws Throwable {
+    Method maps_sum_int = moduleClass.getMethod("maps_sum_int");
+    Object result = maps_sum_int.invoke(null);
+    assertThat((Integer) result, is(6));
+  }
+
+  @Test
+  public void maps_sum_double() throws Throwable {
+    Method maps_sum_double = moduleClass.getMethod("maps_sum_double");
+    Object result = maps_sum_double.invoke(null);
+    assertThat((Double) result, is(6.0));
+  }
+
+  @Test
+  public void maps_sum_string() throws Throwable {
+    Method maps_sum_string = moduleClass.getMethod("maps_sum_string");
+    Object result = maps_sum_string.invoke(null);
+    assertThat((String) result, is("321"));
+  }
+
+  @Test
+  public void maps_sum_string_int() throws Throwable {
+    Method maps_sum_string_int = moduleClass.getMethod("maps_sum_string_int");
+    Object result = maps_sum_string_int.invoke(null);
+    assertThat((String) result, is("321"));
+  }
+
+  @Test
+  public void maps_sum_int_string() throws Throwable {
+    Method maps_sum_int_string = moduleClass.getMethod("maps_sum_int_string");
+    Object result = maps_sum_int_string.invoke(null);
+    assertThat((String) result, is("51"));
+  }
+
+  @Test
+  public void maps_product_int() throws Throwable {
+    Method maps_product_int = moduleClass.getMethod("maps_product_int");
+    Object result = maps_product_int.invoke(null);
+    assertThat((Integer) result, is(24));
+  }
+
+  @Test
+  public void maps_product_double() throws Throwable {
+    Method maps_product_double = moduleClass.getMethod("maps_product_double");
+    Object result = maps_product_double.invoke(null);
+    assertThat((Double) result, is(24.0));
   }
 
   @Test

--- a/src/test/resources/for-test/bootstrapped-standard-augmentations.golo
+++ b/src/test/resources/for-test/bootstrapped-standard-augmentations.golo
@@ -85,6 +85,20 @@ function list_not_exists = {
  return list_data(): exists(|item| -> item >= 5)
 }
 
+function list_sum_int = -> list[1, 2, 3]: sum()
+
+function list_sum_double = -> list[1.0, 2.0, 3.0]: sum()
+
+function list_sum_string = -> list["1", "2", "3"]: sum()
+
+function list_sum_string_int = -> list["1", 2, 3]: sum()
+
+function list_sum_int_string = -> list[1, 2, "3"]: sum()
+
+function list_product_int = -> list[1, 2, 3, 4]: product()
+
+function list_product_double = -> list[1.0, 2.0, 3.0, 4.0]: product()
+
 # ............................................................................................... #
 
 local function set_data = {
@@ -172,6 +186,20 @@ function maps_exists = {
 function maps_not_exists = {
  return map_data(): exists(|key, item| -> item >= 5)
 }
+
+function maps_sum_int = -> map[[1,3],[2,2],[3,1]]: sum()
+
+function maps_sum_double = -> map[[1,3.0],[2,2.0],[3,1.0]]: sum()
+
+function maps_sum_string = -> map[[1,"3"],[2,"2"],[3,"1"]]: sum()
+
+function maps_sum_string_int = -> map[[1,"3"],[2,2],[3,1]]: sum()
+
+function maps_sum_int_string = -> map[[1,3],[2,2],[3,"1"]]: sum()
+
+function maps_product_int = -> map[[1,4],[2,3],[3,2],[4,1]]: product()
+
+function maps_product_double = -> map[[1,4.0],[2,3.0],[3,2.0],[4,1.0]]: product()
 
 # ............................................................................................... #
 


### PR DESCRIPTION
## Use cases

```
list[1,3,5]: sum() # return 9
list[1,"3",5]: sum() # return "135"
list[2,3,5]: product() # return 30

map[[1,3],[2,2],[3,1]]: sum() # return 6
map[[1,4],[2,3],[3,2],[4,1]]: product() # return 24

# etc...
```
