### PR TITLE
Add hasMethod to DynamicObject

### DIFF
--- a/doc/dynamic-objects.asciidoc
+++ b/doc/dynamic-objects.asciidoc
@@ -23,6 +23,7 @@ Dynamic objects have the following *reserved* methods, that is, methods that you
 - `freeze()` locks an object, and calling `define` will raise an `IllegalStateException`, and
 - `isFrozen()` checks whether a dynamic object is frozen or not, and
 - `properties()` gives the set of entries in the dynamic object, and
+- `hasMethod(name)` checks if a method is defined or not in the dynamic object, and
 - `invoker(name, type)` which is mostly used by the Golo runtime internals.
 
 === Defining values ===

--- a/src/main/java/fr/insalyon/citi/golo/runtime/MethodInvocationSupport.java
+++ b/src/main/java/fr/insalyon/citi/golo/runtime/MethodInvocationSupport.java
@@ -74,6 +74,7 @@ public class MethodInvocationSupport {
       add("freeze");
       add("properties");
       add("invoker");
+      add("hasMethod");
     }
   };
 

--- a/src/main/java/gololang/DynamicObject.java
+++ b/src/main/java/gololang/DynamicObject.java
@@ -153,6 +153,20 @@ public final class DynamicObject {
     }
   }
 
+  /**
+   * Verify if a method is defined for the dynamic object.
+   *
+   * @param method the method name.
+   * @return {@code true} if method is defined, {@code false} otherwise.
+   */
+  public boolean hasMethod(String method) {
+    Object obj = properties.get(method);
+    if (obj != null) {
+      return (obj instanceof MethodHandle);
+    }
+    return false;
+  }
+
   private static final MethodHandle MAP_GET;
   private static final MethodHandle MAP_PUT;
   private static final MethodHandle IS_MH_1;


### PR DESCRIPTION
Use case : verify if a method is define in a DynamicObject

Today, i've to do that :

```
let isImplemented = |method, object| {
  let properties = object: properties(): filter(|property|-> property: getKey(): equals(method))
  if properties: size(): equals(1) {
    return isClosure(properties :iterator(): next(): getValue())
  }
  return false  
}

let isObservable = |object| {
  return isImplemented("attach", object) and isImplemented("notify", object) 
}  
```

Now i could write this :

```
let isObservable = |object| {
  return object: hasMethod("attach") and object: hasMethod("notify") 
}
```
