### PR TITLE
Fixes nested try/catch bytecode generation

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
@@ -591,12 +591,12 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
       rethrowEnd = new Label();
     }
 
-    methodVisitor.visitTryCatchBlock(tryStart, tryEnd, catchStart, null);
     methodVisitor.visitLabel(tryStart);
     tryCatchFinally.getTryBlock().accept(this);
     if (tryCatchFinally.isTryCatch() || tryCatchFinally.isTryCatchFinally()) {
       methodVisitor.visitJumpInsn(GOTO, catchEnd);
     }
+    methodVisitor.visitTryCatchBlock(tryStart, tryEnd, catchStart, null);
     methodVisitor.visitLabel(tryEnd);
 
     if (tryCatchFinally.isTryFinally()) {

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -652,6 +652,9 @@ public class CompileAndRunTest {
     } catch (InvocationTargetException expected) {
       assertThat(expected.getCause().getMessage(), is("Hello"));
     }
+
+    Method nested_try = moduleClass.getMethod("nested_try");
+    assertThat(nested_try.invoke(null), is((Object) "ok"));
   }
 
   @Test

--- a/src/test/resources/for-execution/exceptions.golo
+++ b/src/test/resources/for-execution/exceptions.golo
@@ -43,3 +43,15 @@ function try_finally = {
 function raising = {
   raise("Hello")
 }
+
+function nested_try = {
+  try {
+    try {
+      raise("a")
+    } catch (ok) {
+      return "ok"
+    }
+  } catch (failed) {
+    return "failed"
+  }
+}


### PR DESCRIPTION
The try/catch instruction generation has been reordered so that the following code has correct
semantics:

```
function nested_try = {
  try {
    try {
      raise("a")
    } catch (ok) {
      return "ok"
    }
  } catch (failed) {
    return "failed"
  }
}
```

It properly returns "ok" instead of "failed" which is what the previous implementation would yield.
