### PR TITLE
add golo syntax markers in asciidoc documents

### DIFF
--- a/doc/adapters.asciidoc
+++ b/doc/adapters.asciidoc
@@ -18,7 +18,7 @@ http://www.sparkjava.com/[Spark micro-framework].
 Spark requires route handlers to extend an abstract base class called `spark.Route`. The following
 code snippet does just that:
 
-[source,text]
+[source,golo]
 ----
 module sparky
 
@@ -60,7 +60,7 @@ checks on them a in: `(foo oftype gololang.GoloAdapter.class)`.
 
 This is as easy as providing a `java.lang.Iterable` as part of the configuration:
 
-[source,text]
+[source,golo]
 ----
 let result = array[1, 2, 3]                                      
 let conf = map[                                                  
@@ -87,7 +87,7 @@ method? In Java, you would use a `super` reference, but Golo does not provide th
 Instead, you can override methods, and have the parent class implementation given to you as a
 method handle parameter:
 
-[source,text]
+[source,golo]
 ----
 let conf = map[                                        
   ["overrides", map[                                   
@@ -109,7 +109,7 @@ that providing both a star implementation and a star override is an error.
 
 Let us see a concrete example:
 
-[source,text]
+[source,golo]
 ----
 let carbonCopy = list[] <1>                              
 let conf = map[                                       

--- a/doc/augmentations.asciidoc
+++ b/doc/augmentations.asciidoc
@@ -15,7 +15,7 @@ Golo provides a more limited but explicit way to add methods to existing classes
 Let us motivate the value of *augmentations* by starting with the following example. Suppose that we would
 like a function to wrap a string with a left and right string. We could do that in Golo as follows:
 
-[source,text]
+[source,golo]
 ----
 function wrap = |left, str, right| -> left + str + right
 
@@ -31,7 +31,7 @@ method to all instances of `java.lang.String` instead?
 
 Defining an augmentation is a matter of adding a `augment` block in a module:
 
-[source,text]
+[source,golo]
 ----
 module foo
 
@@ -54,7 +54,7 @@ It is a good convention to name the receiver `this`, but you are free to call it
 
 Also, augmentation functions can take variable-arity arguments, as in:
 
-[source,text]
+[source,golo]
 ----
 augment java.lang.String {
 
@@ -74,7 +74,7 @@ function varargs = -> "a": concatWith("b", "c", "d")
 It should be noted that augmentations work with class hierarchies too. The following example adds an
 augmentation to `java.util.Collection`, which also adds it to concrete subclasses such as `java.util.LinkedList`:
 
-[source,text]
+[source,golo]
 ----
 augment java.util.Collection {
   function plop = |this| -> "plop!"
@@ -97,7 +97,7 @@ augmentations can make them available through imports.
 Suppose that you want to define augmentations for dealing with URLs from strings. You could define a
 `string-url-augmentations.golo` module source as follows:
 
-[source,text]
+[source,golo]
 ----
 module my.StringUrlAugmentations
 
@@ -118,7 +118,7 @@ augment java.lang.String {
 
 Then, a module willing to take advantage of those augmentations can simply import their defining module:
 
-[source,text]
+[source,golo]
 ----
 module my.App
 

--- a/doc/basics.asciidoc
+++ b/doc/basics.asciidoc
@@ -17,7 +17,7 @@ Editor and IDE support for Golo is available for:
 Golo source code need to be placed in _modules_. Module names are
 separated with dots, as in:
 
-[source,text]
+[source,golo]
 ----
 Foo
 foo.Bar
@@ -32,7 +32,7 @@ letter.
 A Golo module can be executable if it has a _function_ named `main` and
 that takes an argument for the JVM program arguments:
 
-[source,text]
+[source,golo]
 ----
 module hello.World
 
@@ -86,7 +86,7 @@ You may also pass arguments to the `main` function by appending `--args`
 on the command line invocation. Suppose that we have a module `EchoArgs`
 as follows:
 
-[source,text]
+[source,golo]
 ----
 module EchoArgs
 
@@ -186,7 +186,7 @@ A zsh script can be found in `share/shell-completion/` called `golo-zsh-completi
 
 Golo comments start with a `#`, just like in Bash, Python or Ruby:
 
-[source,text]
+[source,golo]
 ----
 # This is a comment
 println("WTF?") # it works here, too
@@ -206,7 +206,7 @@ compilation error.
 
 Here are a few examples:
 
-[source,text]
+[source,golo]
 ----
 # Ok
 var i = 3
@@ -223,7 +223,7 @@ var foo
 Valid names contain upper and lower case letters within the `[a..z]` range, underscores (`_`),
 dollar symbols (`$`) and numbers. In any case, an identifier must not start with a number.
 
-[source,text]
+[source,golo]
 ----
 # Ok, but not necessarily great for humans...
 let _$_f_o_$$666 = 666
@@ -452,7 +452,7 @@ invoke instance methods.
 You could for instance call the `toString()` method that any Java object has, and print it out as
 follows:
 
-[source,text]
+[source,golo]
 ----
 println(123: toString())
 println(someObject: toString())
@@ -478,7 +478,7 @@ be invoked on arrays:
 
 Given a reference `a` on some array:
 
-[source,text]
+[source,golo]
 ----
 # Gets the element at index 0
 a: get(0)

--- a/doc/closures.asciidoc
+++ b/doc/closures.asciidoc
@@ -6,7 +6,7 @@ Golo supports *closures*, which means that functions can be treated as first-cla
 
 Defining a closure is straightforward as it derives from the way a function can be defined:
 
-[source,text]
+[source,golo]
 ----
 let adder = |a, b| {
   return a + b
@@ -17,7 +17,7 @@ At runtime, a closure is an instance of `java.lang.invoke.MethodHandle`. This me
 all the operations that method handles support, such as invoking them or inserting arguments as
 illustrated in the following example:
 
-[source,text]
+[source,golo]
 ----
 let adder = |a, b| {
   return a + b
@@ -35,14 +35,14 @@ As one would expect, this prints `3` and `12`.
 Golo supports a compact form of closures for the cases where their body consists of a single
 expression. The example above can be simplified as:
 
-[source,text]
+[source,golo]
 ----
 let adder = |a, b| -> a + b
 ----
 
 You may also use this compact form when defining regular functions, as in:
 
-[source,text]
+[source,golo]
 ----
 module Foo
 
@@ -62,7 +62,7 @@ While you may take advantage of closures being method handles and call them usin
 When you have a reference to a closure, you may simply call it as a regular function. The previous
 `adder` example can be equivalently rewritten as:
 
-[source,text]
+[source,golo]
 ----
 let adder = |a, b| -> a + b
 println(adder(1, 2))
@@ -75,7 +75,7 @@ println(addToTen(2))
 
 Closures have access to the lexical scope of their defining environment. Consider this example:
 
-[source,text]
+[source,golo]
 ----
 function plus_3 = {
   let foo = 3
@@ -89,7 +89,7 @@ expect. The `foo` reference is said to have been *captured* and made available i
 It is important to **note that captured references are constants within the closure**. Consider the
 following example:
 
-[source,text]
+[source,golo]
 ----
 var a = 1
 let f = {
@@ -104,7 +104,7 @@ constant references, this results in a compilation error.
 That being said, a closure has a reference on the same object as its defining environment, so a
 mutable object is a sensible way to pass data back from a closure as a side-effect, as in:
 
-[source,text]
+[source,golo]
 ----
 let list = java.util.LinkedList()
 let pump_it = {
@@ -128,7 +128,7 @@ to an instance of a specific interface.
 
 Here is how one could pass an action listener to a `javax.swing.JButton`:
 
-[source,text]
+[source,golo]
 ----
 let button = JButton("Click me!")
 let handler = |event| -> println("Clicked!")
@@ -138,7 +138,7 @@ button: addActionListener(asInterfaceInstance(ActionListener.class, handler))
 Because the `asInterfaceInstance` call consumes some readability budget, you may refactor it with a
 local function as in:
 
-[source,text]
+[source,golo]
 ----
 local function listener = |handler| -> asInterfaceInstance(ActionListener.class, handler)
 
@@ -150,7 +150,7 @@ button: addActionListener(listener(|event| -> println("Clicked!")))
 Here is another example that uses the `java.util.concurrent` APIs to obtain an executor, pass it a
 task, fetch the result with a `Future` object then shut it down:
 
-[source,text]
+[source,golo]
 ----
 function give_me_hey = {
   let executor = Executors.newSingleThreadExecutor()
@@ -166,7 +166,7 @@ function give_me_hey = {
 When a function or method parameter of a Java API expects a single method interface type, you
 can pass a closure directly, as in:
 
-[source,text]
+[source,golo]
 ----
 # (...)
 let button = JButton("Click me!")
@@ -183,7 +183,7 @@ Instead of using `asInterfaceInstance`, you may use a *class augmentation* which
 documentation. In short, it allows you to call a `to` method on instances of `MethodHandle`, which
 in turn calls `asInterfaceInstance`. Back to the previous examples, the next 2 lines are equivalent:
 
-[source,text]
+[source,golo]
 ----
 # Calling asInterfaceInstance
 future = executor: submit(asInterfaceInstance(Callable.class, -> "hey!"))
@@ -197,7 +197,7 @@ future = executor: submit((-> "hey!"): to(Callable.class))
 You may also take advantage of the predefined `fun` function to obtain a reference to a closure, as
 in:
 
-[source,text]
+[source,golo]
 ----
 import golotest.Closures
 
@@ -217,7 +217,7 @@ function call_local_fun = {
 
 Last but not least, we have an even shorter notation if function are not overridden:
 
-[source,text]
+[source,golo]
 ----
 import golotest.Closures
 
@@ -241,7 +241,7 @@ Because closure references are just instances of `java.lang.invoke.MethodHandle`
 first argument using the `bindTo(value)` method. If you need to bind an argument at another position
 than 0, you may take advantage of the `bindAt(position, value)` augmentation:
 
-[source,text]
+[source,golo]
 ----
 let diff = |a, b| -> a - b
 let minus10 = diff: bindAt(1, 10)
@@ -252,7 +252,7 @@ println(minus10(20))
 
 You may compose function using the `andThen` augmentation method:
 
-[source,text]
+[source,golo]
 ----
 let f = (|x| -> x + 1): andThen(|x| -> x - 10): andThen(|x| -> x * 100)
 
@@ -265,14 +265,14 @@ println(f(4))
 Given that functions are first-class objects in Golo, you may define functions (or closures) that
 return functions, as in:
 
-[source,text]
+[source,golo]
 ----
 let f = |x| -> |y| -> |z| -> -> x + y + z
 ----
 
 You could use intermediate references to use the `f` function above:
 
-[source,text]
+[source,golo]
 ----
 let f1 = f(1)
 let f2 = f1(2)
@@ -284,7 +284,7 @@ println(f3())
 
 Golo supports a nicer syntax if you don't need intermediate references:
 
-[source,text]
+[source,golo]
 ----
 # Prints '6'
 println(f(1)(2)(3)())

--- a/doc/control-flow.asciidoc
+++ b/doc/control-flow.asciidoc
@@ -6,7 +6,7 @@ Control flow in Golo is imperative and has the usual constructions found in upst
 
 Golo supports the traditional `if` / `else` constructions, as in:
 
-[source,text]
+[source,golo]
 ----
 if goloIsGreat() {
   println("Golo Golo")
@@ -29,7 +29,7 @@ elaborated expression, though.
 Golo offers a versatile `case` construction for conditional branching. It may be used in place of
 multiple nested `if` / `else` statements, as in:
 
-[source,text]
+[source,golo]
 ----
 function what = |obj| {
   case {
@@ -50,7 +50,7 @@ A `case` statement requires at least 1 `when` clause and a mandatory `otherwise`
 is being associated with a block. It is semantically equivalent to the corresponding `if` / `else`
 chain:
 
-[source,text]
+[source,golo]
 ----
 function what = |obj| {
   if obj oftype String.class {
@@ -74,7 +74,7 @@ other languages it is not fully equivalent, as Golo does not support destructuri
 
 `match` is a great addition to the Golo programmer:
 
-[source,text]
+[source,golo]
 ----
 let item = "foo@bar.com"
 
@@ -99,7 +99,7 @@ clause.
 
 While loops in Golo are straightforward:
 
-[source,text]
+[source,golo]
 ----
 function times = |n| {
   var times = 0
@@ -120,7 +120,7 @@ This is the most versatile loop construction, as it features:
 
 The following function shows a `for` loop:
 
-[source,text]
+[source,golo]
 ----
 function fact = |value, n| {
   var result = 1
@@ -144,7 +144,7 @@ Again, this choice is dictated by the pursue of simplicity.
 Golo provides a "for each" style of iteration over iterable elements. Any object that is an instance
 of `java.lang.Iterable` can be used in `foreach` loops, as in:
 
-[source,text]
+[source,golo]
 ----
 function concat_to_string = |iterable| {
   var result = ""
@@ -176,7 +176,7 @@ Like in Java and many other languages:
 
 Consider the following contrived example:
 
-[source,text]
+[source,golo]
 ----
 module test
  

--- a/doc/dynamic-evaluation.asciidoc
+++ b/doc/dynamic-evaluation.asciidoc
@@ -8,7 +8,7 @@ code, or when used from a polyglot JVM application that embeds Golo.
 
 The code of a complete module can be evaluated by the `asModule` method:
 
-[source,text]
+[source,golo]
 ----
 let env = gololang.EvaluationEnvironment()
 let code =
@@ -34,7 +34,7 @@ class loader cannot load classes with the same name twice.
 The `anonymousModule` method is similar to `asModule`, except that the code to evaluate is free of
 `module` declaration:
 
-[source,text]
+[source,golo]
 ----
 let env = gololang.EvaluationEnvironment()
 let code =
@@ -56,7 +56,7 @@ suitable in cases where the same code is to be re-evaluated several times.
 
 The `asFunction` and `def` methods evaluate function code. Here is how `asFunction` can be used:
 
-[source,text]
+[source,golo]
 ----
 let env = gololang.EvaluationEnvironment()
 let code = "return (a + b) * 2"
@@ -67,7 +67,7 @@ println(f(10, 20))
 It evaluates straight code as the body of a function. Note that `imports` can be used to specify
 `import` statements to be available while evaluation the code:
 
-[source,text]
+[source,golo]
 ----
 env:
   imports("java.util.LinkedList", "java.util.HashMap"):
@@ -77,7 +77,7 @@ let m = HashMap()""")
 
 The `def` method is similar, except that it has the parameters definition in the code to evaluate:
 
-[source,text]
+[source,golo]
 ----
 let env = gololang.EvaluationEnvironment()
 let code = "|a, b| -> (a + b) * 2"
@@ -89,7 +89,7 @@ println(f(10, 20))
 
 The first form of `run` method works as follows:
 
-[source,text]
+[source,golo]
 ----
 let env = gololang.EvaluationEnvironment()
 let code = """println(">>> run")
@@ -102,7 +102,7 @@ println(env: run(code)) # => "w00t"x3 and "666"
 
 The second form allows passing parameter values in a map:
 
-[source,text]
+[source,golo]
 ----
 let env = gololang.EvaluationEnvironment()
 let code = """println(">>> run_map")

--- a/doc/dynamic-objects.asciidoc
+++ b/doc/dynamic-objects.asciidoc
@@ -7,7 +7,7 @@ think of it as an enhancement over using hash maps and putting closures in them.
 
 Creating a dynamic object is as simple as calling the `DynamicObject` function:
 
-[source,text]
+[source,golo]
 ----
 let foo = DynamicObject()
 ----
@@ -31,7 +31,7 @@ Dynamic objects have the following *reserved* methods, that is, methods that you
 
 Defining values also defines getter and setter methods, as illustrated by the next example:
 
-[source,text]
+[source,golo]
 ----
 let person = DynamicObject(): 
   define("name", "MrBean"):
@@ -48,7 +48,7 @@ println(person: name())
 Calling a setter method for a non-existent property defines it, hence the previous example can be
 rewritten as:
 
-[source,text]
+[source,golo]
 ----
 let person = DynamicObject(): name("MrBean"): email("mrbean@gmail.com")
 
@@ -68,7 +68,7 @@ as you want.
 
 Here is an example where we define a `toString`-style of method:
 
-[source,text]
+[source,golo]
 ----
 local function mrbean = -> DynamicObject(): 
   name("Mr Bean"): 
@@ -128,7 +128,7 @@ methods).**
 The `properties()` method returns a set of entries, as instances of `java.util.Map.Entry`. You can
 thus write code such as:
 
-[source,text]
+[source,golo]
 ----
 function dump = |obj| {
   foreach prop in obj: properties() {
@@ -147,7 +147,7 @@ Here is an example of how to define a fallback.
 
 NOTE: Calling a setter method for a non-existent property defines it, thus the fallback is not applicable for setters.
 
-[source,text]
+[source,golo]
 ----
 let dynob = DynamicObject():
   fallback(|this, method, args...| {

--- a/doc/exceptions.asciidoc
+++ b/doc/exceptions.asciidoc
@@ -13,7 +13,7 @@ Golo provides 2 predefined functions for raising exceptions:
 
 Throwing an exception is thus as easy as:
 
-[source,text]
+[source,golo]
 -----------------------
 if somethingIsWrong() {
   raise("Woops!")
@@ -26,7 +26,7 @@ Of course not every exception shall be an instance of `java.lang.RuntimeExceptio
 specialized type is required, you may simply instantiate a Java exception and throw it using the
 `throw` keyword as in the following example:
 
-[source,text]
+[source,golo]
 ---------------------------------------
 module golotest.execution.Exceptions
 
@@ -45,7 +45,7 @@ regarding the handling of `finally` blocks.
 
 The following snippets show each exception handling form.
 
-[source,text]
+[source,golo]
 --------------------------------------
 # Good old try / catch
 try {

--- a/doc/functions.asciidoc
+++ b/doc/functions.asciidoc
@@ -7,7 +7,7 @@ call some.
 
 Golo modules can define functions as follows:
 
-[source,text]
+[source,golo]
 ----
 module sample
 
@@ -18,7 +18,7 @@ function hello = {
 
 In turn, you may invoke a function with a familiar notation:
 
-[source,text]
+[source,golo]
 ----
 let str = hello()
 ----
@@ -31,7 +31,7 @@ and that a few keystrokes in favour of readability is still a good deal.
 Still, you may omit `return` statements if your function does not return
 a value:
 
-[source,text]
+[source,golo]
 ----
 function printer = { 
   println("Hey!")
@@ -41,7 +41,7 @@ function printer = {
 If you do so, the function will actually return `null`, hence `result`
 in the next statement is `null`:
 
-[source,text]
+[source,golo]
 ----
 # result will be null
 let result = printer()
@@ -51,7 +51,7 @@ let result = printer()
 
 Of course functions may take some parameters, as in:
 
-[source,text]
+[source,golo]
 ----
 function addition = |a, b| {
   return a + b
@@ -62,7 +62,7 @@ NOTE: Parameters are constant references, hence they cannot be reassigned.
 
 Invoking functions that take parameters is straightforward, too:
 
-[source,text]
+[source,golo]
 ----
 let three = addition(1, 2)
 let hello_world = addition("hello ", "world!")
@@ -73,7 +73,7 @@ let hello_world = addition("hello ", "world!")
 Functions may take a varying number of parameters. To define one, just
 add `...` to the last parameter name:
 
-[source,text]
+[source,golo]
 ----
 function foo = |a, b, c...| {
   # ...
@@ -88,7 +88,7 @@ Calling variable-arity functions does not requiring wrapping the last
 arguments in an array. While invoking the `foo` function above, the
 following examples are legit:
 
-[source,text]
+[source,golo]
 ----
 # a=1, b=2, c=[]
 foo(1, 2)
@@ -103,7 +103,7 @@ foo(1, 2, 3, 4)
 Because the parameter that catches the last arguments is an array, you
 may call array methods. Given:
 
-[source,text]
+[source,golo]
 ----
 function elementAt = |index, args...| {
   return args: get(index)
@@ -112,7 +112,7 @@ function elementAt = |index, args...| {
 
 then:
 
-[source,text]
+[source,golo]
 ----
 # prints "2"
 println(elementAt(1, 1, 2, 3))
@@ -122,7 +122,7 @@ println(elementAt(1, 1, 2, 3))
 
 Suppose that we have a module `foo.Bar`:
 
-[source,text]
+[source,golo]
 ----
 module foo.Bar
 
@@ -134,14 +134,14 @@ function f = {
 We can invoke `f` from another module by prefixing it with its module
 name:
 
-[source,text]
+[source,golo]
 ----
 let r = foo.Bar.f()
 ----
 
 Of course, we may also take advantage of an `import` statement:
 
-[source,text]
+[source,golo]
 ----
 module Somewhere.Else
 
@@ -163,7 +163,7 @@ function.
 Last but not least, you may prepend the last piece of the module name. The following invocations are
 equivalent:
 
-[source,text]
+[source,golo]
 ----
 module Somewhere.Else
 
@@ -189,7 +189,7 @@ Golo modules have a set of implicit imports:
 By default, functions are visible outside of their module. You may
 restrict the visibility of a function by using the `local` keyword:
 
-[source,text]
+[source,golo]
 ----
 module Foo
 
@@ -206,7 +206,7 @@ Here, `b` is visible while `a` can only be invoked from within the `Foo`
 module. Given another module called `Bogus`, the following would fail at
 runtime:
 
-[source,text]
+[source,golo]
 ----
 module Bogus
 

--- a/doc/java-interop.asciidoc
+++ b/doc/java-interop.asciidoc
@@ -9,7 +9,7 @@ This `main` method can servers as a JVM entry point.
 
 Suppose that we have the following Golo module:
 
-[source,text]
+[source,golo]
 ----
 module mainEntryPoint
 
@@ -33,7 +33,7 @@ $
 
 Golo can invoke public Java static methods by treating them as functions:
 
-[source,text]
+[source,golo]
 ------------------------
 module sample
 
@@ -53,7 +53,7 @@ When you have an object, you may invoke its methods using the `:` operator.
 
 The following would call the `toString` method of any kind, then print it:
 
-[source,text]
+[source,golo]
 ----------------------------------------
 println(">>> " + someObject: toString())
 ----------------------------------------
@@ -78,7 +78,7 @@ This is quite useful when querying data models where `null` values could be retu
 elegantly combined with the `orIfNull` operator to return a default value, as illustrated by the
 following example:
 
-[source,text]
+[source,golo]
 ----
 let person = dao: findByName("Mr Bean")
 let city = person?: address()?: city() orIfNull "n/a"
@@ -86,7 +86,7 @@ let city = person?: address()?: city() orIfNull "n/a"
 
 This is more elegant than, say:
 
-[source,text]
+[source,golo]
 ----
 let person = dao: findByName("Mr Bean")
 var city = "n/a"
@@ -109,7 +109,7 @@ calling its constructor is done as if it was just another function.
 
 As an example, we may allocate a `java.util.LinkedList` as follows:
 
-[source,text]
+[source,golo]
 ---------------------
 module sample
 
@@ -122,7 +122,7 @@ function aList = {
 
 Another example would be using a `java.lang.StringBuilder`.
 
-[source,text]
+[source,golo]
 --------------------------------------
 function str_build = {
   return java.lang.StringBuilder("h"):
@@ -141,7 +141,7 @@ As one would expect, the `str_build` function above gives the `"hello"` string.
 Golo treats public static fields as function, so one could get the maximum value for an `Integer` as
 follows:
 
-[source,text]
+[source,golo]
 --------------------------------------
 module samples.MaxInt
 
@@ -171,7 +171,7 @@ public class Foo {
 
 We can access the `bar` field as follows:
 
-[source,text]
+[source,golo]
 ----
 let foo = Foo()
 
@@ -197,7 +197,7 @@ public class Foo {
 
 We can set all fields by chaining invocations as in:
 
-[source,text]
+[source,golo]
 ----
 let foo = Foo(): bar(1): baz(2)
 ----
@@ -223,7 +223,7 @@ public class Foo {
 **Golo resolves methods first, fields last.** Hence, the following Golo code will resolve the
 `bar()` method, not the `bar` field:
 
-[source,text]
+[source,golo]
 ----
 let foo = Foo()
 
@@ -248,7 +248,7 @@ The rules to deal with them in Golo are as follows.
 
 Let us consider the following example:
 
-[source,text]
+[source,golo]
 --------------------------------------------------------------------------
 module sample.EnumsThreadState
 
@@ -290,7 +290,7 @@ operator tokens.
 However, you may find yourself in a situation where you need to invoke a Java method whose name is
 a Golo operator, such as:
 
-[source,text]
+[source,golo]
 -------------------------------------
 # Function call
 is()
@@ -304,7 +304,7 @@ identifiers.
 
 The solution is to use *escaping*, by prefixing identifiers with a backtick, as in:
 
-[source,text]
+[source,golo]
 ---------------------------------------
 # Function call
 `is()
@@ -335,7 +335,7 @@ public class Foo {
 
 This would work with a Golo module defined as in:
 
-[source,text]
+[source,golo]
 ----
 module foo.Bar
 

--- a/doc/pitfalls.asciidoc
+++ b/doc/pitfalls.asciidoc
@@ -11,7 +11,7 @@ will make some of the following mistakes early on.
 Golo does not have a `new` operator for allocating objects. Instead, one should just call a
 constructor as a function:
 
-[source,text]
+[source,golo]
 ----
 # Good
 let foo = java.util.LinkedList()
@@ -28,7 +28,7 @@ resolve names of types, functions, and so on.
 You must think of `import` statements as a notational shortcut, nothing else. Golo tries to resolve
 a name as-is, then tries to complete with every import until a match is found.
 
-[source,text]
+[source,golo]
 ----
 import java.util
 import java.util.concurrent.AtomicInteger
@@ -52,7 +52,7 @@ many languages.
 
 This is a common mistake!
 
-[source,text]
+[source,golo]
 ----
 # Calls toString() on foo
 foo: toString()
@@ -66,7 +66,7 @@ foo.toString()
 One thing to keep in mind is that `match` returns a value, and that it is not a closure unless you
 want it to.
 
-[source,text]
+[source,golo]
 ----
 let foo = match {
   case plop then 1

--- a/doc/predefined-functions.asciidoc
+++ b/doc/predefined-functions.asciidoc
@@ -7,7 +7,7 @@ useful functions.
 
 `print` and `println` do just what you would expect.
 
-[source,text]
+[source,golo]
 ----
 print("Hey")
 println()
@@ -24,7 +24,7 @@ string.
 disabled. It always returns a string.  There are also `secureReadPassword()` and
 `secureReadPassword(strPassword)` variants that return a `char[]` array.
 
-[source,text]
+[source,golo]
 ----
 let name = readln("what's your name? ")
 let value = readln()
@@ -36,7 +36,7 @@ let pwd = readpwd("type your password:")
 `raise` can be used to throw a `java.lang.RuntimeException`. It comes in two forms: one with a
 message as a string, and one with a message and a cause.
 
-[source,text]
+[source,golo]
 ----
 try { 
   ... 
@@ -54,7 +54,7 @@ Preconditions are useful, especially in a dynamically-typed language.
 `require` can check for a boolean expression along with an error message. In case of error, it
 throws an `AssertionError`.
 
-[source,text]
+[source,golo]
 ----
 function foo = |a| {
   require(a oftype String.class, "a must be a String")
@@ -64,7 +64,7 @@ function foo = |a| {
 
 You may also use `requireNotNull` that... well... checks that its argument is not `null`:
 
-[source,text]
+[source,golo]
 ----
 function foo = |a| {
   requireNotNull(a)
@@ -82,7 +82,7 @@ Golo provides functions to deal with Java arrays (`Object[]`).
 * the `alength` function returns the length of an array,
 * the `atoList` function calls the `java.util.Arrays.asList(values...)` method.
 
-[source,text]
+[source,golo]
 ----
 let a = Array(1, 2, 3)
 require(alength(a) == 3, "a must be of length 3")
@@ -99,7 +99,7 @@ object methods instead: `get`, `set`, `length`, ...
 
 The `range` function yields an iterable range over either `Integer` or `Long` bounds:
 
-[source,text]
+[source,golo]
 ----
 # Prints 1 2 (...) 100
 foreach i in range(1, 101) {
@@ -123,7 +123,7 @@ The lower bound is inclusive, the upper bound is exclusive.
 Given a closure reference or a method handle, one can convert it to an instance of an interface with
 a single method declaration, as in:
 
-[source,text]
+[source,golo]
 ----
 local function listener = |handler| -> asInterfaceInstance(ActionListener.class, handler)
 
@@ -135,7 +135,7 @@ button: addActionListener(listener(|event| -> println("Clicked!")))
 It is possible to test if an object is a closure or not with the `isClosure` function. This is
 useful to support values and delayed evaluation, as in:
 
-[source,text]
+[source,golo]
 ----
 if isClosure(value) {
   map: put(key, value())
@@ -146,7 +146,7 @@ if isClosure(value) {
 
 You can get a reference to a closure using the predefined `fun` function:
 
-[source,text]
+[source,golo]
 ----
 import golotest.Closures
 
@@ -161,7 +161,7 @@ function call_local_fun = {
 Because functions may be overloaded, there is a form that accepts an extra parameter for specifying
 the number of parameters:
 
-[source,text]
+[source,golo]
 ----
 import golotest.Closures
 
@@ -177,7 +177,7 @@ function call_local_fun = {
 
 Sometimes it is very desirable to read the content of a text file. The `fileToText` function does just that:
 
-[source,text]
+[source,golo]
 ----
 let text = fileToText("/some/file.txt", "UTF-8")
 ----
@@ -187,7 +187,7 @@ represents the encoding charset, either as a `java.lang.String` or a `java.nio.c
 
 We can write some text to a file, too:
 
-[source,text]
+[source,golo]
 ----
 textToFile("Hello, world!", "/foo/bar.txt")
 ----
@@ -199,7 +199,7 @@ then we suggest that you look into the `java.nio.file` package.
 
 In addition, if you need to verify that a file exists, you can use the `fileExists` function.
 
-[source,text]
+[source,golo]
 ----
 if fileExists("/foo/bar.txt") {
   println("file found!")
@@ -223,7 +223,7 @@ Instead, we provide 3 helper functions.
 
 `mapEntry` gives instances of `java.util.AbstractMap.SimpleEntry`, and is used as follows:
 
-[source,text]
+[source,golo]
 ----
 let e = mapEntry("foo", "bar")
 

--- a/doc/templates.asciidoc
+++ b/doc/templates.asciidoc
@@ -7,7 +7,7 @@ compiles template text into Golo functions.
 
 Consider the following example.
 
-[source,text]
+[source,golo]
 ----
 let template = """
 <%@params posts %>
@@ -36,7 +36,7 @@ let template = """
 
 This multi-line string has a Golo template. It can be compiled into a function as follows:
 
-[source,text]
+[source,golo]
 ----
 let tpl = gololang.TemplateEngine(): compile(template)
 println(tpl(someDataModel: posts()))

--- a/doc/workers.asciidoc
+++ b/doc/workers.asciidoc
@@ -51,7 +51,7 @@ the `awaitTermination`, `isShutdown` and `isTerminated` methods whose semantics 
 Worker functions take a single parameter which is the message to be received. To obtain a port, you
 need to call the `spawn(target)` function of a worker environment, as in:
 
-[source,text]
+[source,golo]
 ----
 let env = WorkerEnvironment.builder(): withFixedThreadPool()
 let port = env: spawn(|message| -> println(">>> " + message))
@@ -59,7 +59,7 @@ let port = env: spawn(|message| -> println(">>> " + message))
 
 A port provides a `send(message)` method:
 
-[source,text]
+[source,golo]
 ----
 port: send("hello"): send("world")
 ----
@@ -70,7 +70,7 @@ Messages are being put in a queue, and eventually dispatched to the function tha
 
 To better understand how workers can be used, here is a (fairly useless) example:
 
-[source,text]
+[source,golo]
 ----
 module SampleWithWorkers
 


### PR DESCRIPTION
For this to be taken into account, the pygments lexer for golo must be first installed
