### PR TITLE
Use platform dependent line separator in multiline test

### DIFF
--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -104,7 +104,7 @@ public class CompileAndRunTest {
     assertThat(str, is(expected));
 
     Method multiline = moduleClass.getMethod("multiline");
-    assertThat((String) multiline.invoke(null), is("This is\n*awesome*"));
+    assertThat((String) multiline.invoke(null), is("This is" + System.getProperty("line.separator") + "*awesome*"));
 
     Method nasty_multiline = moduleClass.getMethod("nasty_multiline");
     assertThat((String) nasty_multiline.invoke(null), is("Damn!=\\\"\"\"="));


### PR DESCRIPTION
Fix failing "multiline" test under Windows because of Carriage Return Line Feed.
