### PR TITLE
New gradle project and Gradle 2.0 compatibility

### DIFF
--- a/src/main/resources/new-project/gradle/build.gradle
+++ b/src/main/resources/new-project/gradle/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.golo-lang:gradle-golo-plugin:0.1'
+        classpath 'org.golo-lang:gradle-golo-plugin:0.4'
     }
 }
 


### PR DESCRIPTION
Use newly released gradle-golo-plugin 0.4 to make new gradle project build and run with Gradle 2.0.
