### PR TITLE
Make ASTStructDeclaration implements NamedNode

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTStructDeclaration.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTStructDeclaration.java
@@ -19,7 +19,7 @@ package fr.insalyon.citi.golo.compiler.parser;
 import java.util.LinkedHashSet;
 import java.util.List;
 
-public class ASTStructDeclaration extends GoloASTNode {
+public class ASTStructDeclaration extends GoloASTNode implements NamedNode {
 
   private String name;
   private LinkedHashSet<String> members;


### PR DESCRIPTION
The methods was implemented, but the interface was not declared.

Fix #182 
