### PR TITLE
[471130] Guarded loops

### DIFF
--- a/doc/control-flow.asciidoc
+++ b/doc/control-flow.asciidoc
@@ -164,6 +164,32 @@ You may use parenthesis around a `foreach` expression, so `foreach (foo in bar)`
 NOTE: Although Java arrays (`Object[]`) are not real objects, they can be used with `foreach` loops.
 Golo provides a `iterator()` method for them.
 
+=== `foreach` loops with a guard ===
+
+There is a variant of the `foreach` loop with a `when` guard.
+
+The following code:
+
+[source,golo]
+----
+foreach item in collection {
+  if item < 10 {
+    println(item)
+  }
+}
+----
+
+can be simplified as:
+
+[source,golo]
+----
+foreach item in collection when item < 10 {
+  println(item)
+}
+----
+
+The `when` guard can be any expression that evaluates to a boolean.
+
 === `break` and `continue` ===
 
 Although not strictly necessary, the `break` and `continue` statements can be useful to simplify

--- a/samples/echo-args.golo
+++ b/samples/echo-args.golo
@@ -23,4 +23,9 @@ function main = |args| {
   foreach i in range(0, args: length()) {
     println("  #" + i + " -> " + args: get(i))
   }
+
+  println("With a foreach and a guard to keep arguments with at least 3 characters:")
+  foreach arg in args when arg: length() > 2 {
+    println("  " + arg)
+  }
 }

--- a/src/main/jjtree/Golo.jjt
+++ b/src/main/jjtree/Golo.jjt
@@ -980,9 +980,9 @@ void ForEachLoop():
 {
   <FOREACH>
   (
-    (elementId=<IDENTIFIER> <IN> ExpressionStatement())
+    (elementId=<IDENTIFIER> <IN> ExpressionStatement() (<WHEN> ExpressionStatement())?)
     |
-    ("(" elementId=<IDENTIFIER> <IN> ExpressionStatement() ")")
+    ("(" elementId=<IDENTIFIER> <IN> ExpressionStatement() (<WHEN> ExpressionStatement())? ")")
   )
   Block()
   {

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -417,6 +417,9 @@ public class CompileAndRunTest {
 
     Method concat_to_string = moduleClass.getMethod("concat_to_string", Object.class);
     assertThat((String) concat_to_string.invoke(null, asList("a", "b", "c")), is("abc"));
+
+    Method foreach_guarded = moduleClass.getMethod("foreach_guarded", Object.class);
+    assertThat(foreach_guarded.invoke(null, asList(666, 2, 3, 4, 5, 10, 999)), is("66610999"));
   }
 
   @Test(expectedExceptions = GoloCompilationException.class)

--- a/src/test/resources/for-execution/loopings.golo
+++ b/src/test/resources/for-execution/loopings.golo
@@ -24,3 +24,11 @@ function concat_to_string = |iterable| {
   }
   return result
 }
+
+function foreach_guarded = |iterable| {
+  var result = ""
+  foreach item in iterable when item >= 10 {
+    result = result + item
+  }
+  return result
+}

--- a/src/test/resources/for-parsing-and-compilation/loops.golo
+++ b/src/test/resources/for-parsing-and-compilation/loops.golo
@@ -58,3 +58,9 @@ function for_each = |iterable| {
     println(elem)
   }
 }
+
+function for_each_guarded = |iterable| {
+  foreach elem in iterable when elem < 10 {
+    println(elem)
+  }
+}


### PR DESCRIPTION
This introduces support for guards in foreach loops, as in:

```golo
foreach arg in args when arg: length() > 2 {
  println("  " + arg)
}
```

This is syntaxic sugar, equivalent to:

```golo
foreach arg in args {
  if arg: length() > 2 {
    println("  " + arg)
  }
}
```