### PR TITLE
[471709] Exception when comparing numbers

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/runtime/OperatorSupport.java
+++ b/src/main/java/fr/insalyon/citi/golo/runtime/OperatorSupport.java
@@ -12,6 +12,7 @@ package fr.insalyon.citi.golo.runtime;
 import java.lang.invoke.*;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.Objects;
 
 import static java.lang.invoke.MethodHandles.guardWithTest;
 import static java.lang.invoke.MethodHandles.insertArguments;
@@ -43,14 +44,6 @@ public class OperatorSupport {
       add("is");
       add("isnt");
       add("oftype");
-
-      add("equals");
-      add("notequals");
-
-      add("more");
-      add("less");
-      add("moreorequals");
-      add("lessorequals");
 
       add("orifnull");
     }
@@ -170,507 +163,1111 @@ public class OperatorSupport {
     return callSite;
   }
 
-  // arithmetic (generated, use generate_math.rb) ......................................................................
+  // primitive specific arithmetic and comparisons (generated, use generate_math.rb) ......................................................................
 
+  // BEGIN GENERATED
   public static Object plus(Character a, Character b) {
-    return a + b;
+    return ((char) a) + ((char) b);
   }
 
   public static Object minus(Character a, Character b) {
-    return a - b;
+    return ((char) a) - ((char) b);
   }
 
   public static Object divide(Character a, Character b) {
-    return a / b;
+    return ((char) a) / ((char) b);
   }
 
   public static Object times(Character a, Character b) {
-    return a * b;
+    return ((char) a) * ((char) b);
   }
 
   public static Object modulo(Character a, Character b) {
-    return a % b;
+    return ((char) a) % ((char) b);
+  }
+
+  public static Object equals(Character a, Character b) {
+    return ((char) a) == ((char) b);
+  }
+
+  public static Object notequals(Character a, Character b) {
+    return ((char) a) != ((char) b);
+  }
+
+  public static Object less(Character a, Character b) {
+    return ((char) a) < ((char) b);
+  }
+
+  public static Object lessorequals(Character a, Character b) {
+    return ((char) a) <= ((char) b);
+  }
+
+  public static Object more(Character a, Character b) {
+    return ((char) a) > ((char) b);
+  }
+
+  public static Object moreorequals(Character a, Character b) {
+    return ((char) a) >= ((char) b);
   }
 
   public static Object plus(Integer a, Integer b) {
-    return a + b;
+    return ((int) a) + ((int) b);
   }
 
   public static Object minus(Integer a, Integer b) {
-    return a - b;
+    return ((int) a) - ((int) b);
   }
 
   public static Object divide(Integer a, Integer b) {
-    return a / b;
+    return ((int) a) / ((int) b);
   }
 
   public static Object times(Integer a, Integer b) {
-    return a * b;
+    return ((int) a) * ((int) b);
   }
 
   public static Object modulo(Integer a, Integer b) {
-    return a % b;
+    return ((int) a) % ((int) b);
+  }
+
+  public static Object equals(Integer a, Integer b) {
+    return ((int) a) == ((int) b);
+  }
+
+  public static Object notequals(Integer a, Integer b) {
+    return ((int) a) != ((int) b);
+  }
+
+  public static Object less(Integer a, Integer b) {
+    return ((int) a) < ((int) b);
+  }
+
+  public static Object lessorequals(Integer a, Integer b) {
+    return ((int) a) <= ((int) b);
+  }
+
+  public static Object more(Integer a, Integer b) {
+    return ((int) a) > ((int) b);
+  }
+
+  public static Object moreorequals(Integer a, Integer b) {
+    return ((int) a) >= ((int) b);
   }
 
   public static Object plus(Long a, Long b) {
-    return a + b;
+    return ((long) a) + ((long) b);
   }
 
   public static Object minus(Long a, Long b) {
-    return a - b;
+    return ((long) a) - ((long) b);
   }
 
   public static Object divide(Long a, Long b) {
-    return a / b;
+    return ((long) a) / ((long) b);
   }
 
   public static Object times(Long a, Long b) {
-    return a * b;
+    return ((long) a) * ((long) b);
   }
 
   public static Object modulo(Long a, Long b) {
-    return a % b;
+    return ((long) a) % ((long) b);
+  }
+
+  public static Object equals(Long a, Long b) {
+    return ((long) a) == ((long) b);
+  }
+
+  public static Object notequals(Long a, Long b) {
+    return ((long) a) != ((long) b);
+  }
+
+  public static Object less(Long a, Long b) {
+    return ((long) a) < ((long) b);
+  }
+
+  public static Object lessorequals(Long a, Long b) {
+    return ((long) a) <= ((long) b);
+  }
+
+  public static Object more(Long a, Long b) {
+    return ((long) a) > ((long) b);
+  }
+
+  public static Object moreorequals(Long a, Long b) {
+    return ((long) a) >= ((long) b);
   }
 
   public static Object plus(Double a, Double b) {
-    return a + b;
+    return ((double) a) + ((double) b);
   }
 
   public static Object minus(Double a, Double b) {
-    return a - b;
+    return ((double) a) - ((double) b);
   }
 
   public static Object divide(Double a, Double b) {
-    return a / b;
+    return ((double) a) / ((double) b);
   }
 
   public static Object times(Double a, Double b) {
-    return a * b;
+    return ((double) a) * ((double) b);
   }
 
   public static Object modulo(Double a, Double b) {
-    return a % b;
+    return ((double) a) % ((double) b);
+  }
+
+  public static Object equals(Double a, Double b) {
+    return ((double) a) == ((double) b);
+  }
+
+  public static Object notequals(Double a, Double b) {
+    return ((double) a) != ((double) b);
+  }
+
+  public static Object less(Double a, Double b) {
+    return ((double) a) < ((double) b);
+  }
+
+  public static Object lessorequals(Double a, Double b) {
+    return ((double) a) <= ((double) b);
+  }
+
+  public static Object more(Double a, Double b) {
+    return ((double) a) > ((double) b);
+  }
+
+  public static Object moreorequals(Double a, Double b) {
+    return ((double) a) >= ((double) b);
   }
 
   public static Object plus(Float a, Float b) {
-    return a + b;
+    return ((float) a) + ((float) b);
   }
 
   public static Object minus(Float a, Float b) {
-    return a - b;
+    return ((float) a) - ((float) b);
   }
 
   public static Object divide(Float a, Float b) {
-    return a / b;
+    return ((float) a) / ((float) b);
   }
 
   public static Object times(Float a, Float b) {
-    return a * b;
+    return ((float) a) * ((float) b);
   }
 
   public static Object modulo(Float a, Float b) {
-    return a % b;
+    return ((float) a) % ((float) b);
+  }
+
+  public static Object equals(Float a, Float b) {
+    return ((float) a) == ((float) b);
+  }
+
+  public static Object notequals(Float a, Float b) {
+    return ((float) a) != ((float) b);
+  }
+
+  public static Object less(Float a, Float b) {
+    return ((float) a) < ((float) b);
+  }
+
+  public static Object lessorequals(Float a, Float b) {
+    return ((float) a) <= ((float) b);
+  }
+
+  public static Object more(Float a, Float b) {
+    return ((float) a) > ((float) b);
+  }
+
+  public static Object moreorequals(Float a, Float b) {
+    return ((float) a) >= ((float) b);
   }
 
   public static Object plus(Character a, Integer b) {
-    return ((int) a) + b;
+    return ((int) a) + ((int) b);
   }
 
   public static Object minus(Character a, Integer b) {
-    return ((int) a) - b;
+    return ((int) a) - ((int) b);
   }
 
   public static Object divide(Character a, Integer b) {
-    return ((int) a) / b;
+    return ((int) a) / ((int) b);
   }
 
   public static Object times(Character a, Integer b) {
-    return ((int) a) * b;
+    return ((int) a) * ((int) b);
   }
 
   public static Object modulo(Character a, Integer b) {
-    return ((int) a) % b;
+    return ((int) a) % ((int) b);
+  }
+
+  public static Object equals(Character a, Integer b) {
+    return ((int) a) == ((int) b);
+  }
+
+  public static Object notequals(Character a, Integer b) {
+    return ((int) a) != ((int) b);
+  }
+
+  public static Object less(Character a, Integer b) {
+    return ((int) a) < ((int) b);
+  }
+
+  public static Object lessorequals(Character a, Integer b) {
+    return ((int) a) <= ((int) b);
+  }
+
+  public static Object more(Character a, Integer b) {
+    return ((int) a) > ((int) b);
+  }
+
+  public static Object moreorequals(Character a, Integer b) {
+    return ((int) a) >= ((int) b);
   }
 
   public static Object plus(Character a, Long b) {
-    return ((long) a) + b;
+    return ((long) a) + ((long) b);
   }
 
   public static Object minus(Character a, Long b) {
-    return ((long) a) - b;
+    return ((long) a) - ((long) b);
   }
 
   public static Object divide(Character a, Long b) {
-    return ((long) a) / b;
+    return ((long) a) / ((long) b);
   }
 
   public static Object times(Character a, Long b) {
-    return ((long) a) * b;
+    return ((long) a) * ((long) b);
   }
 
   public static Object modulo(Character a, Long b) {
-    return ((long) a) % b;
+    return ((long) a) % ((long) b);
+  }
+
+  public static Object equals(Character a, Long b) {
+    return ((long) a) == ((long) b);
+  }
+
+  public static Object notequals(Character a, Long b) {
+    return ((long) a) != ((long) b);
+  }
+
+  public static Object less(Character a, Long b) {
+    return ((long) a) < ((long) b);
+  }
+
+  public static Object lessorequals(Character a, Long b) {
+    return ((long) a) <= ((long) b);
+  }
+
+  public static Object more(Character a, Long b) {
+    return ((long) a) > ((long) b);
+  }
+
+  public static Object moreorequals(Character a, Long b) {
+    return ((long) a) >= ((long) b);
   }
 
   public static Object plus(Character a, Double b) {
-    return ((double) a) + b;
+    return ((double) a) + ((double) b);
   }
 
   public static Object minus(Character a, Double b) {
-    return ((double) a) - b;
+    return ((double) a) - ((double) b);
   }
 
   public static Object divide(Character a, Double b) {
-    return ((double) a) / b;
+    return ((double) a) / ((double) b);
   }
 
   public static Object times(Character a, Double b) {
-    return ((double) a) * b;
+    return ((double) a) * ((double) b);
   }
 
   public static Object modulo(Character a, Double b) {
-    return ((double) a) % b;
+    return ((double) a) % ((double) b);
+  }
+
+  public static Object equals(Character a, Double b) {
+    return ((double) a) == ((double) b);
+  }
+
+  public static Object notequals(Character a, Double b) {
+    return ((double) a) != ((double) b);
+  }
+
+  public static Object less(Character a, Double b) {
+    return ((double) a) < ((double) b);
+  }
+
+  public static Object lessorequals(Character a, Double b) {
+    return ((double) a) <= ((double) b);
+  }
+
+  public static Object more(Character a, Double b) {
+    return ((double) a) > ((double) b);
+  }
+
+  public static Object moreorequals(Character a, Double b) {
+    return ((double) a) >= ((double) b);
   }
 
   public static Object plus(Character a, Float b) {
-    return ((float) a) + b;
+    return ((float) a) + ((float) b);
   }
 
   public static Object minus(Character a, Float b) {
-    return ((float) a) - b;
+    return ((float) a) - ((float) b);
   }
 
   public static Object divide(Character a, Float b) {
-    return ((float) a) / b;
+    return ((float) a) / ((float) b);
   }
 
   public static Object times(Character a, Float b) {
-    return ((float) a) * b;
+    return ((float) a) * ((float) b);
   }
 
   public static Object modulo(Character a, Float b) {
-    return ((float) a) % b;
+    return ((float) a) % ((float) b);
+  }
+
+  public static Object equals(Character a, Float b) {
+    return ((float) a) == ((float) b);
+  }
+
+  public static Object notequals(Character a, Float b) {
+    return ((float) a) != ((float) b);
+  }
+
+  public static Object less(Character a, Float b) {
+    return ((float) a) < ((float) b);
+  }
+
+  public static Object lessorequals(Character a, Float b) {
+    return ((float) a) <= ((float) b);
+  }
+
+  public static Object more(Character a, Float b) {
+    return ((float) a) > ((float) b);
+  }
+
+  public static Object moreorequals(Character a, Float b) {
+    return ((float) a) >= ((float) b);
   }
 
   public static Object plus(Integer a, Long b) {
-    return ((long) a) + b;
+    return ((long) a) + ((long) b);
   }
 
   public static Object minus(Integer a, Long b) {
-    return ((long) a) - b;
+    return ((long) a) - ((long) b);
   }
 
   public static Object divide(Integer a, Long b) {
-    return ((long) a) / b;
+    return ((long) a) / ((long) b);
   }
 
   public static Object times(Integer a, Long b) {
-    return ((long) a) * b;
+    return ((long) a) * ((long) b);
   }
 
   public static Object modulo(Integer a, Long b) {
-    return ((long) a) % b;
+    return ((long) a) % ((long) b);
+  }
+
+  public static Object equals(Integer a, Long b) {
+    return ((long) a) == ((long) b);
+  }
+
+  public static Object notequals(Integer a, Long b) {
+    return ((long) a) != ((long) b);
+  }
+
+  public static Object less(Integer a, Long b) {
+    return ((long) a) < ((long) b);
+  }
+
+  public static Object lessorequals(Integer a, Long b) {
+    return ((long) a) <= ((long) b);
+  }
+
+  public static Object more(Integer a, Long b) {
+    return ((long) a) > ((long) b);
+  }
+
+  public static Object moreorequals(Integer a, Long b) {
+    return ((long) a) >= ((long) b);
   }
 
   public static Object plus(Integer a, Double b) {
-    return ((double) a) + b;
+    return ((double) a) + ((double) b);
   }
 
   public static Object minus(Integer a, Double b) {
-    return ((double) a) - b;
+    return ((double) a) - ((double) b);
   }
 
   public static Object divide(Integer a, Double b) {
-    return ((double) a) / b;
+    return ((double) a) / ((double) b);
   }
 
   public static Object times(Integer a, Double b) {
-    return ((double) a) * b;
+    return ((double) a) * ((double) b);
   }
 
   public static Object modulo(Integer a, Double b) {
-    return ((double) a) % b;
+    return ((double) a) % ((double) b);
+  }
+
+  public static Object equals(Integer a, Double b) {
+    return ((double) a) == ((double) b);
+  }
+
+  public static Object notequals(Integer a, Double b) {
+    return ((double) a) != ((double) b);
+  }
+
+  public static Object less(Integer a, Double b) {
+    return ((double) a) < ((double) b);
+  }
+
+  public static Object lessorequals(Integer a, Double b) {
+    return ((double) a) <= ((double) b);
+  }
+
+  public static Object more(Integer a, Double b) {
+    return ((double) a) > ((double) b);
+  }
+
+  public static Object moreorequals(Integer a, Double b) {
+    return ((double) a) >= ((double) b);
   }
 
   public static Object plus(Integer a, Float b) {
-    return ((float) a) + b;
+    return ((float) a) + ((float) b);
   }
 
   public static Object minus(Integer a, Float b) {
-    return ((float) a) - b;
+    return ((float) a) - ((float) b);
   }
 
   public static Object divide(Integer a, Float b) {
-    return ((float) a) / b;
+    return ((float) a) / ((float) b);
   }
 
   public static Object times(Integer a, Float b) {
-    return ((float) a) * b;
+    return ((float) a) * ((float) b);
   }
 
   public static Object modulo(Integer a, Float b) {
-    return ((float) a) % b;
+    return ((float) a) % ((float) b);
+  }
+
+  public static Object equals(Integer a, Float b) {
+    return ((float) a) == ((float) b);
+  }
+
+  public static Object notequals(Integer a, Float b) {
+    return ((float) a) != ((float) b);
+  }
+
+  public static Object less(Integer a, Float b) {
+    return ((float) a) < ((float) b);
+  }
+
+  public static Object lessorequals(Integer a, Float b) {
+    return ((float) a) <= ((float) b);
+  }
+
+  public static Object more(Integer a, Float b) {
+    return ((float) a) > ((float) b);
+  }
+
+  public static Object moreorequals(Integer a, Float b) {
+    return ((float) a) >= ((float) b);
   }
 
   public static Object plus(Long a, Double b) {
-    return ((double) a) + b;
+    return ((double) a) + ((double) b);
   }
 
   public static Object minus(Long a, Double b) {
-    return ((double) a) - b;
+    return ((double) a) - ((double) b);
   }
 
   public static Object divide(Long a, Double b) {
-    return ((double) a) / b;
+    return ((double) a) / ((double) b);
   }
 
   public static Object times(Long a, Double b) {
-    return ((double) a) * b;
+    return ((double) a) * ((double) b);
   }
 
   public static Object modulo(Long a, Double b) {
-    return ((double) a) % b;
+    return ((double) a) % ((double) b);
+  }
+
+  public static Object equals(Long a, Double b) {
+    return ((double) a) == ((double) b);
+  }
+
+  public static Object notequals(Long a, Double b) {
+    return ((double) a) != ((double) b);
+  }
+
+  public static Object less(Long a, Double b) {
+    return ((double) a) < ((double) b);
+  }
+
+  public static Object lessorequals(Long a, Double b) {
+    return ((double) a) <= ((double) b);
+  }
+
+  public static Object more(Long a, Double b) {
+    return ((double) a) > ((double) b);
+  }
+
+  public static Object moreorequals(Long a, Double b) {
+    return ((double) a) >= ((double) b);
   }
 
   public static Object plus(Long a, Float b) {
-    return ((float) a) + b;
+    return ((float) a) + ((float) b);
   }
 
   public static Object minus(Long a, Float b) {
-    return ((float) a) - b;
+    return ((float) a) - ((float) b);
   }
 
   public static Object divide(Long a, Float b) {
-    return ((float) a) / b;
+    return ((float) a) / ((float) b);
   }
 
   public static Object times(Long a, Float b) {
-    return ((float) a) * b;
+    return ((float) a) * ((float) b);
   }
 
   public static Object modulo(Long a, Float b) {
-    return ((float) a) % b;
+    return ((float) a) % ((float) b);
+  }
+
+  public static Object equals(Long a, Float b) {
+    return ((float) a) == ((float) b);
+  }
+
+  public static Object notequals(Long a, Float b) {
+    return ((float) a) != ((float) b);
+  }
+
+  public static Object less(Long a, Float b) {
+    return ((float) a) < ((float) b);
+  }
+
+  public static Object lessorequals(Long a, Float b) {
+    return ((float) a) <= ((float) b);
+  }
+
+  public static Object more(Long a, Float b) {
+    return ((float) a) > ((float) b);
+  }
+
+  public static Object moreorequals(Long a, Float b) {
+    return ((float) a) >= ((float) b);
   }
 
   public static Object plus(Double a, Float b) {
-    return a + ((double) b);
+    return ((double) a) + ((double) b);
   }
 
   public static Object minus(Double a, Float b) {
-    return a - ((double) b);
+    return ((double) a) - ((double) b);
   }
 
   public static Object divide(Double a, Float b) {
-    return a / ((double) b);
+    return ((double) a) / ((double) b);
   }
 
   public static Object times(Double a, Float b) {
-    return a * ((double) b);
+    return ((double) a) * ((double) b);
   }
 
   public static Object modulo(Double a, Float b) {
-    return a % ((double) b);
+    return ((double) a) % ((double) b);
+  }
+
+  public static Object equals(Double a, Float b) {
+    return ((double) a) == ((double) b);
+  }
+
+  public static Object notequals(Double a, Float b) {
+    return ((double) a) != ((double) b);
+  }
+
+  public static Object less(Double a, Float b) {
+    return ((double) a) < ((double) b);
+  }
+
+  public static Object lessorequals(Double a, Float b) {
+    return ((double) a) <= ((double) b);
+  }
+
+  public static Object more(Double a, Float b) {
+    return ((double) a) > ((double) b);
+  }
+
+  public static Object moreorequals(Double a, Float b) {
+    return ((double) a) >= ((double) b);
   }
 
   public static Object plus(Integer a, Character b) {
-    return a + ((int) b);
+    return ((int) a) + ((int) b);
   }
 
   public static Object minus(Integer a, Character b) {
-    return a - ((int) b);
+    return ((int) a) - ((int) b);
   }
 
   public static Object divide(Integer a, Character b) {
-    return a / ((int) b);
+    return ((int) a) / ((int) b);
   }
 
   public static Object times(Integer a, Character b) {
-    return a * ((int) b);
+    return ((int) a) * ((int) b);
   }
 
   public static Object modulo(Integer a, Character b) {
-    return a % ((int) b);
+    return ((int) a) % ((int) b);
+  }
+
+  public static Object equals(Integer a, Character b) {
+    return ((int) a) == ((int) b);
+  }
+
+  public static Object notequals(Integer a, Character b) {
+    return ((int) a) != ((int) b);
+  }
+
+  public static Object less(Integer a, Character b) {
+    return ((int) a) < ((int) b);
+  }
+
+  public static Object lessorequals(Integer a, Character b) {
+    return ((int) a) <= ((int) b);
+  }
+
+  public static Object more(Integer a, Character b) {
+    return ((int) a) > ((int) b);
+  }
+
+  public static Object moreorequals(Integer a, Character b) {
+    return ((int) a) >= ((int) b);
   }
 
   public static Object plus(Long a, Character b) {
-    return a + ((long) b);
+    return ((long) a) + ((long) b);
   }
 
   public static Object minus(Long a, Character b) {
-    return a - ((long) b);
+    return ((long) a) - ((long) b);
   }
 
   public static Object divide(Long a, Character b) {
-    return a / ((long) b);
+    return ((long) a) / ((long) b);
   }
 
   public static Object times(Long a, Character b) {
-    return a * ((long) b);
+    return ((long) a) * ((long) b);
   }
 
   public static Object modulo(Long a, Character b) {
-    return a % ((long) b);
+    return ((long) a) % ((long) b);
+  }
+
+  public static Object equals(Long a, Character b) {
+    return ((long) a) == ((long) b);
+  }
+
+  public static Object notequals(Long a, Character b) {
+    return ((long) a) != ((long) b);
+  }
+
+  public static Object less(Long a, Character b) {
+    return ((long) a) < ((long) b);
+  }
+
+  public static Object lessorequals(Long a, Character b) {
+    return ((long) a) <= ((long) b);
+  }
+
+  public static Object more(Long a, Character b) {
+    return ((long) a) > ((long) b);
+  }
+
+  public static Object moreorequals(Long a, Character b) {
+    return ((long) a) >= ((long) b);
   }
 
   public static Object plus(Double a, Character b) {
-    return a + ((double) b);
+    return ((double) a) + ((double) b);
   }
 
   public static Object minus(Double a, Character b) {
-    return a - ((double) b);
+    return ((double) a) - ((double) b);
   }
 
   public static Object divide(Double a, Character b) {
-    return a / ((double) b);
+    return ((double) a) / ((double) b);
   }
 
   public static Object times(Double a, Character b) {
-    return a * ((double) b);
+    return ((double) a) * ((double) b);
   }
 
   public static Object modulo(Double a, Character b) {
-    return a % ((double) b);
+    return ((double) a) % ((double) b);
+  }
+
+  public static Object equals(Double a, Character b) {
+    return ((double) a) == ((double) b);
+  }
+
+  public static Object notequals(Double a, Character b) {
+    return ((double) a) != ((double) b);
+  }
+
+  public static Object less(Double a, Character b) {
+    return ((double) a) < ((double) b);
+  }
+
+  public static Object lessorequals(Double a, Character b) {
+    return ((double) a) <= ((double) b);
+  }
+
+  public static Object more(Double a, Character b) {
+    return ((double) a) > ((double) b);
+  }
+
+  public static Object moreorequals(Double a, Character b) {
+    return ((double) a) >= ((double) b);
   }
 
   public static Object plus(Float a, Character b) {
-    return a + ((float) b);
+    return ((float) a) + ((float) b);
   }
 
   public static Object minus(Float a, Character b) {
-    return a - ((float) b);
+    return ((float) a) - ((float) b);
   }
 
   public static Object divide(Float a, Character b) {
-    return a / ((float) b);
+    return ((float) a) / ((float) b);
   }
 
   public static Object times(Float a, Character b) {
-    return a * ((float) b);
+    return ((float) a) * ((float) b);
   }
 
   public static Object modulo(Float a, Character b) {
-    return a % ((float) b);
+    return ((float) a) % ((float) b);
+  }
+
+  public static Object equals(Float a, Character b) {
+    return ((float) a) == ((float) b);
+  }
+
+  public static Object notequals(Float a, Character b) {
+    return ((float) a) != ((float) b);
+  }
+
+  public static Object less(Float a, Character b) {
+    return ((float) a) < ((float) b);
+  }
+
+  public static Object lessorequals(Float a, Character b) {
+    return ((float) a) <= ((float) b);
+  }
+
+  public static Object more(Float a, Character b) {
+    return ((float) a) > ((float) b);
+  }
+
+  public static Object moreorequals(Float a, Character b) {
+    return ((float) a) >= ((float) b);
   }
 
   public static Object plus(Long a, Integer b) {
-    return a + ((long) b);
+    return ((long) a) + ((long) b);
   }
 
   public static Object minus(Long a, Integer b) {
-    return a - ((long) b);
+    return ((long) a) - ((long) b);
   }
 
   public static Object divide(Long a, Integer b) {
-    return a / ((long) b);
+    return ((long) a) / ((long) b);
   }
 
   public static Object times(Long a, Integer b) {
-    return a * ((long) b);
+    return ((long) a) * ((long) b);
   }
 
   public static Object modulo(Long a, Integer b) {
-    return a % ((long) b);
+    return ((long) a) % ((long) b);
+  }
+
+  public static Object equals(Long a, Integer b) {
+    return ((long) a) == ((long) b);
+  }
+
+  public static Object notequals(Long a, Integer b) {
+    return ((long) a) != ((long) b);
+  }
+
+  public static Object less(Long a, Integer b) {
+    return ((long) a) < ((long) b);
+  }
+
+  public static Object lessorequals(Long a, Integer b) {
+    return ((long) a) <= ((long) b);
+  }
+
+  public static Object more(Long a, Integer b) {
+    return ((long) a) > ((long) b);
+  }
+
+  public static Object moreorequals(Long a, Integer b) {
+    return ((long) a) >= ((long) b);
   }
 
   public static Object plus(Double a, Integer b) {
-    return a + ((double) b);
+    return ((double) a) + ((double) b);
   }
 
   public static Object minus(Double a, Integer b) {
-    return a - ((double) b);
+    return ((double) a) - ((double) b);
   }
 
   public static Object divide(Double a, Integer b) {
-    return a / ((double) b);
+    return ((double) a) / ((double) b);
   }
 
   public static Object times(Double a, Integer b) {
-    return a * ((double) b);
+    return ((double) a) * ((double) b);
   }
 
   public static Object modulo(Double a, Integer b) {
-    return a % ((double) b);
+    return ((double) a) % ((double) b);
+  }
+
+  public static Object equals(Double a, Integer b) {
+    return ((double) a) == ((double) b);
+  }
+
+  public static Object notequals(Double a, Integer b) {
+    return ((double) a) != ((double) b);
+  }
+
+  public static Object less(Double a, Integer b) {
+    return ((double) a) < ((double) b);
+  }
+
+  public static Object lessorequals(Double a, Integer b) {
+    return ((double) a) <= ((double) b);
+  }
+
+  public static Object more(Double a, Integer b) {
+    return ((double) a) > ((double) b);
+  }
+
+  public static Object moreorequals(Double a, Integer b) {
+    return ((double) a) >= ((double) b);
   }
 
   public static Object plus(Float a, Integer b) {
-    return a + ((float) b);
+    return ((float) a) + ((float) b);
   }
 
   public static Object minus(Float a, Integer b) {
-    return a - ((float) b);
+    return ((float) a) - ((float) b);
   }
 
   public static Object divide(Float a, Integer b) {
-    return a / ((float) b);
+    return ((float) a) / ((float) b);
   }
 
   public static Object times(Float a, Integer b) {
-    return a * ((float) b);
+    return ((float) a) * ((float) b);
   }
 
   public static Object modulo(Float a, Integer b) {
-    return a % ((float) b);
+    return ((float) a) % ((float) b);
+  }
+
+  public static Object equals(Float a, Integer b) {
+    return ((float) a) == ((float) b);
+  }
+
+  public static Object notequals(Float a, Integer b) {
+    return ((float) a) != ((float) b);
+  }
+
+  public static Object less(Float a, Integer b) {
+    return ((float) a) < ((float) b);
+  }
+
+  public static Object lessorequals(Float a, Integer b) {
+    return ((float) a) <= ((float) b);
+  }
+
+  public static Object more(Float a, Integer b) {
+    return ((float) a) > ((float) b);
+  }
+
+  public static Object moreorequals(Float a, Integer b) {
+    return ((float) a) >= ((float) b);
   }
 
   public static Object plus(Double a, Long b) {
-    return a + ((double) b);
+    return ((double) a) + ((double) b);
   }
 
   public static Object minus(Double a, Long b) {
-    return a - ((double) b);
+    return ((double) a) - ((double) b);
   }
 
   public static Object divide(Double a, Long b) {
-    return a / ((double) b);
+    return ((double) a) / ((double) b);
   }
 
   public static Object times(Double a, Long b) {
-    return a * ((double) b);
+    return ((double) a) * ((double) b);
   }
 
   public static Object modulo(Double a, Long b) {
-    return a % ((double) b);
+    return ((double) a) % ((double) b);
+  }
+
+  public static Object equals(Double a, Long b) {
+    return ((double) a) == ((double) b);
+  }
+
+  public static Object notequals(Double a, Long b) {
+    return ((double) a) != ((double) b);
+  }
+
+  public static Object less(Double a, Long b) {
+    return ((double) a) < ((double) b);
+  }
+
+  public static Object lessorequals(Double a, Long b) {
+    return ((double) a) <= ((double) b);
+  }
+
+  public static Object more(Double a, Long b) {
+    return ((double) a) > ((double) b);
+  }
+
+  public static Object moreorequals(Double a, Long b) {
+    return ((double) a) >= ((double) b);
   }
 
   public static Object plus(Float a, Long b) {
-    return a + ((float) b);
+    return ((float) a) + ((float) b);
   }
 
   public static Object minus(Float a, Long b) {
-    return a - ((float) b);
+    return ((float) a) - ((float) b);
   }
 
   public static Object divide(Float a, Long b) {
-    return a / ((float) b);
+    return ((float) a) / ((float) b);
   }
 
   public static Object times(Float a, Long b) {
-    return a * ((float) b);
+    return ((float) a) * ((float) b);
   }
 
   public static Object modulo(Float a, Long b) {
-    return a % ((float) b);
+    return ((float) a) % ((float) b);
+  }
+
+  public static Object equals(Float a, Long b) {
+    return ((float) a) == ((float) b);
+  }
+
+  public static Object notequals(Float a, Long b) {
+    return ((float) a) != ((float) b);
+  }
+
+  public static Object less(Float a, Long b) {
+    return ((float) a) < ((float) b);
+  }
+
+  public static Object lessorequals(Float a, Long b) {
+    return ((float) a) <= ((float) b);
+  }
+
+  public static Object more(Float a, Long b) {
+    return ((float) a) > ((float) b);
+  }
+
+  public static Object moreorequals(Float a, Long b) {
+    return ((float) a) >= ((float) b);
   }
 
   public static Object plus(Float a, Double b) {
-    return ((double) a) + b;
+    return ((double) a) + ((double) b);
   }
 
   public static Object minus(Float a, Double b) {
-    return ((double) a) - b;
+    return ((double) a) - ((double) b);
   }
 
   public static Object divide(Float a, Double b) {
-    return ((double) a) / b;
+    return ((double) a) / ((double) b);
   }
 
   public static Object times(Float a, Double b) {
-    return ((double) a) * b;
+    return ((double) a) * ((double) b);
   }
 
   public static Object modulo(Float a, Double b) {
-    return ((double) a) % b;
+    return ((double) a) % ((double) b);
   }
+
+  public static Object equals(Float a, Double b) {
+    return ((double) a) == ((double) b);
+  }
+
+  public static Object notequals(Float a, Double b) {
+    return ((double) a) != ((double) b);
+  }
+
+  public static Object less(Float a, Double b) {
+    return ((double) a) < ((double) b);
+  }
+
+  public static Object lessorequals(Float a, Double b) {
+    return ((double) a) <= ((double) b);
+  }
+
+  public static Object more(Float a, Double b) {
+    return ((double) a) > ((double) b);
+  }
+
+  public static Object moreorequals(Float a, Double b) {
+    return ((double) a) >= ((double) b);
+  }
+
+
+  // END GENERATED
 
   // arithmetic fallbacks .............................................................................................
 
@@ -703,27 +1300,18 @@ public class OperatorSupport {
     return builder.toString();
   }
 
-  // comparisons ......................................................................................................
+  // comparisons fallback .............................................................................................
 
-  public static Object equals_noguard(Object a, Object b) {
-    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
-      return compareNumbers(a, b) == 0;
-    }
-    return (a == b) || ((a != null) && a.equals(b));
+  public static Object equals_fallback(Object a, Object b) {
+    return Objects.equals(a, b);
   }
 
-  public static Object notequals_noguard(Object a, Object b) {
-    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
-      return compareNumbers(a, b) != 0;
-    }
-    return (a != b) && (((a != null) && !a.equals(b)) || ((b != null) && !b.equals(a)));
+  public static Object notequals_fallback(Object a, Object b) {
+    return !Objects.equals(a, b);
   }
 
   @SuppressWarnings("unchecked")
-  public static Object less_noguard(Object a, Object b) {
-    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
-      return compareNumbers(a, b) < 0;
-    }
+  public static Object less_fallback(Object a, Object b) {
     if (bothNotNull(a, b) && isComparable(a) && isComparable(b)) {
       return ((Comparable) a).compareTo(b) < 0;
     }
@@ -731,10 +1319,7 @@ public class OperatorSupport {
   }
 
   @SuppressWarnings("unchecked")
-  public static Object lessorequals_noguard(Object a, Object b) {
-    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
-      return compareNumbers(a, b) <= 0;
-    }
+  public static Object lessorequals_fallback(Object a, Object b) {
     if (bothNotNull(a, b) && isComparable(a) && isComparable(b)) {
       return ((Comparable) a).compareTo(b) <= 0;
     }
@@ -742,10 +1327,7 @@ public class OperatorSupport {
   }
 
   @SuppressWarnings("unchecked")
-  public static Object more_noguard(Object a, Object b) {
-    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
-      return compareNumbers(a, b) > 0;
-    }
+  public static Object more_fallback(Object a, Object b) {
     if (bothNotNull(a, b) && isComparable(a) && isComparable(b)) {
       return ((Comparable) a).compareTo(b) > 0;
     }
@@ -753,10 +1335,7 @@ public class OperatorSupport {
   }
 
   @SuppressWarnings("unchecked")
-  public static Object moreorequals_noguard(Object a, Object b) {
-    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
-      return compareNumbers(a, b) >= 0;
-    }
+  public static Object moreorequals_fallback(Object a, Object b) {
     if (bothNotNull(a, b) && isComparable(a) && isComparable(b)) {
       return ((Comparable) a).compareTo(b) >= 0;
     }
@@ -808,14 +1387,6 @@ public class OperatorSupport {
 
   private static boolean isComparable(Object obj) {
     return obj instanceof Comparable<?>;
-  }
-
-  private static int compareNumbers(Object a, Object b) {
-    return Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
-  }
-
-  private static boolean isNumber(Object obj) {
-    return obj instanceof Number;
   }
 
   private static boolean isClass(Object obj) {

--- a/src/main/java/fr/insalyon/citi/golo/runtime/OperatorSupport.java
+++ b/src/main/java/fr/insalyon/citi/golo/runtime/OperatorSupport.java
@@ -706,15 +706,24 @@ public class OperatorSupport {
   // comparisons ......................................................................................................
 
   public static Object equals_noguard(Object a, Object b) {
+    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
+      return compareNumbers(a, b) == 0;
+    }
     return (a == b) || ((a != null) && a.equals(b));
   }
 
   public static Object notequals_noguard(Object a, Object b) {
+    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
+      return compareNumbers(a, b) != 0;
+    }
     return (a != b) && (((a != null) && !a.equals(b)) || ((b != null) && !b.equals(a)));
   }
 
   @SuppressWarnings("unchecked")
   public static Object less_noguard(Object a, Object b) {
+    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
+      return compareNumbers(a, b) < 0;
+    }
     if (bothNotNull(a, b) && isComparable(a) && isComparable(b)) {
       return ((Comparable) a).compareTo(b) < 0;
     }
@@ -723,6 +732,9 @@ public class OperatorSupport {
 
   @SuppressWarnings("unchecked")
   public static Object lessorequals_noguard(Object a, Object b) {
+    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
+      return compareNumbers(a, b) <= 0;
+    }
     if (bothNotNull(a, b) && isComparable(a) && isComparable(b)) {
       return ((Comparable) a).compareTo(b) <= 0;
     }
@@ -731,6 +743,9 @@ public class OperatorSupport {
 
   @SuppressWarnings("unchecked")
   public static Object more_noguard(Object a, Object b) {
+    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
+      return compareNumbers(a, b) > 0;
+    }
     if (bothNotNull(a, b) && isComparable(a) && isComparable(b)) {
       return ((Comparable) a).compareTo(b) > 0;
     }
@@ -739,6 +754,9 @@ public class OperatorSupport {
 
   @SuppressWarnings("unchecked")
   public static Object moreorequals_noguard(Object a, Object b) {
+    if (bothNotNull(a, b) && isNumber(a) && isNumber(b)) {
+      return compareNumbers(a, b) >= 0;
+    }
     if (bothNotNull(a, b) && isComparable(a) && isComparable(b)) {
       return ((Comparable) a).compareTo(b) >= 0;
     }
@@ -790,6 +808,14 @@ public class OperatorSupport {
 
   private static boolean isComparable(Object obj) {
     return obj instanceof Comparable<?>;
+  }
+
+  private static int compareNumbers(Object a, Object b) {
+    return Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
+  }
+
+  private static boolean isNumber(Object obj) {
+    return obj instanceof Number;
   }
 
   private static boolean isClass(Object obj) {

--- a/src/main/ruby/generate_math.rb
+++ b/src/main/ruby/generate_math.rb
@@ -9,14 +9,21 @@
 
 TYPES = [ :Character, :Integer, :Long, :Double, :Float ]
 
-OPS = [ :plus, :minus, :divide, :times, :modulo ]
+OPS = [ :plus, :minus, :divide, :times, :modulo,
+        :equals, :notequals, :less, :lessorequals, :more, :moreorequals ]
 
 OPS_SYMB = {
   :plus => '+',
   :minus => '-',
   :times => '*',
   :divide => '/',
-  :modulo => '%'
+  :modulo => '%',
+  :less => '<',
+  :more => '>',
+  :lessorequals => '<=',
+  :moreorequals => '>=',
+  :equals => '==',
+  :notequals => '!='
 }
 
 PRIM = {
@@ -37,9 +44,9 @@ WEIGHT = {
 
 TYPES.each do |type|
   OPS.each do |op|
-    puts "public static Object #{op}(#{type} a, #{type} b) {"
-    puts "  return a #{OPS_SYMB[op]} b;"
-    puts "}"
+    puts "  public static Object #{op}(#{type} a, #{type} b) {"
+    puts "    return ((#{PRIM[type]}) a) #{OPS_SYMB[op]} ((#{PRIM[type]}) b);"
+    puts "  }"
     puts
   end
 end
@@ -50,13 +57,14 @@ combinations.each do |pair|
   left = pair[0]
   right = pair[1]
   OPS.each do |op|
-    puts "public static Object #{op}(#{left} a, #{right} b) {"
+    puts "  public static Object #{op}(#{left} a, #{right} b) {"
     if WEIGHT[left] < WEIGHT[right]
-      puts "  return ((#{PRIM[right]}) a) #{OPS_SYMB[op]} b;"
+        type = PRIM[right]
     else
-      puts "  return a #{OPS_SYMB[op]} ((#{PRIM[left]}) b);"
+        type = PRIM[left]
     end
-    puts "}"
+    puts "    return ((#{type}) a) #{OPS_SYMB[op]} ((#{type}) b);"
+    puts "  }"
     puts
   end
 end

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -383,6 +383,9 @@ public class CompileAndRunTest {
 
     Method null_guarded = moduleClass.getMethod("null_guarded");
     assertThat((String) null_guarded.invoke(null), is("n/a"));
+
+    Method polymorphic_number_comparison = moduleClass.getMethod("polymorphic_number_comparison");
+    assertThat((Boolean) polymorphic_number_comparison.invoke(null), is(true));
   }
 
   @Test

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -327,16 +327,23 @@ public class CompileAndRunTest {
 
     Method half = moduleClass.getMethod("half", Object.class);
     assertThat((Integer) half.invoke(null, 12), is(6));
+    assertThat((Integer) half.invoke(null, 'T'), is(42));
 
     Method twice = moduleClass.getMethod("twice", Object.class);
     assertThat((Integer) twice.invoke(null, 6), is(12));
+    assertThat((Integer) twice.invoke(null, '*'), is(84));
     assertThat((String) twice.invoke(null, "Plop"), is("PlopPlop"));
 
     Method compute_92 = moduleClass.getMethod("compute_92");
     assertThat((Integer) compute_92.invoke(null), is(92));
 
     Method eq = moduleClass.getMethod("eq", Object.class, Object.class);
+    assertThat((Boolean) eq.invoke(null, 'a', 'a'), is(true));
+    assertThat((Boolean) eq.invoke(null, '*', 42), is(true));
+    assertThat((Boolean) eq.invoke(null, 'a', 'b'), is(false));
+    assertThat((Boolean) eq.invoke(null, 66.6, 66.6), is(true));
     assertThat((Boolean) eq.invoke(null, 666, 666), is(true));
+    assertThat((Boolean) eq.invoke(null, 666, 666.0), is(true));
     assertThat((Boolean) eq.invoke(null, 999, 666), is(false));
 
     Method at_least_5 = moduleClass.getMethod("at_least_5", Object.class);

--- a/src/test/resources/for-execution/operators.golo
+++ b/src/test/resources/for-execution/operators.golo
@@ -82,44 +82,43 @@ function polymorphic_number_comparison = {
   let left = list[1, 1_L, 1.0, 1.0_F]
   let right = list[2, 2_L, 1.1, 1.1_F]
 
-  var res = true
   foreach a in left {
     foreach b in right {
-      res = res and (not (a == b))
-      res = res and (not (b == a))
-      res = res and (b != a)
-      res = res and (a != b)
+      require((not (a == b)), "equals failed")
+      require((not (b == a)), "equals failed")
+      require((b != a), "not equals failed")
+      require((a != b), "not equals failed")
       
-      res = res and (a <= b)
-      res = res and (not (a >= b))
-      res = res and (b >= a)
-      res = res and (not (b <= a))
+      require((a <= b), "less or equals failed")
+      require((not (a >= b)), "more or equals failed")
+      require((b >= a), "more or equals failed")
+      require((not (b <= a)), "less or equals failed")
 
-      res = res and (a < b)
-      res = res and (not (a > b))
-      res = res and (b > a)
-      res = res and (not (b < a))
+      require((a < b), "less failed")
+      require((not (a > b)), "more failed")
+      require((b > a), "more failed")
+      require((not (b < a)), "less failed")
     }
   }
 
   foreach a in left {
     foreach b in left {
-      res = res and (a == b)
-      res = res and (b == a)
-      res = res and (not (a != b))
-      res = res and (not (b != a))
+      require((a == b), "equals failed")
+      require((b == a), "equals failed")
+      require((not (a != b)), "not equals failed")
+      require((not (b != a)), "not equals failed")
       
-      res = res and (a <= b)
-      res = res and (a >= b)
-      res = res and (b >= a)
-      res = res and (b <= a)
+      require((a <= b), "less or equals failed")
+      require((a >= b), "more or equals failed")
+      require((b >= a), "more or equals failed")
+      require((b <= a), "less or equals failed")
 
-      res = res and (not (a < b))
-      res = res and (not (a > b))
-      res = res and (not (b > a))
-      res = res and (not (b < a))
+      require((not (a < b)), "less failed")
+      require((not (a > b)), "more failed")
+      require((not (b > a)), "more failed")
+      require((not (b < a)), "less failed")
     }
   }
 
-  return res
+  return true
 }

--- a/src/test/resources/for-execution/operators.golo
+++ b/src/test/resources/for-execution/operators.golo
@@ -77,3 +77,49 @@ function null_guarded = {
   let map = map[]
   return map: get("bogus") orIfNull "n/a"
 }
+
+function polymorphic_number_comparison = {
+  let left = list[1, 1_L, 1.0, 1.0_F]
+  let right = list[2, 2_L, 1.1, 1.1_F]
+
+  var res = true
+  foreach a in left {
+    foreach b in right {
+      res = res and (not (a == b))
+      res = res and (not (b == a))
+      res = res and (b != a)
+      res = res and (a != b)
+      
+      res = res and (a <= b)
+      res = res and (not (a >= b))
+      res = res and (b >= a)
+      res = res and (not (b <= a))
+
+      res = res and (a < b)
+      res = res and (not (a > b))
+      res = res and (b > a)
+      res = res and (not (b < a))
+    }
+  }
+
+  foreach a in left {
+    foreach b in left {
+      res = res and (a == b)
+      res = res and (b == a)
+      res = res and (not (a != b))
+      res = res and (not (b != a))
+      
+      res = res and (a <= b)
+      res = res and (a >= b)
+      res = res and (b >= a)
+      res = res and (b <= a)
+
+      res = res and (not (a < b))
+      res = res and (not (a > b))
+      res = res and (not (b > a))
+      res = res and (not (b < a))
+    }
+  }
+
+  return res
+}

--- a/src/test/resources/for-execution/unions.golo
+++ b/src/test/resources/for-execution/unions.golo
@@ -80,7 +80,6 @@ function test_hashcode = {
   let t1 = Tree.Node(Tree.Node(Tree.Leaf(1), Tree.Empty()), Tree.Leaf(0))
   let t2 = Tree.Node(Tree.Node(Tree.Leaf(1), Tree.Empty()), Tree.Leaf(0))
   require(t1: hashCode() == t2: hashCode(), "hashcode")
-
 }
 
 # ............................................................................................... #


### PR DESCRIPTION
The implementation of comparison operators was done using `compareTo`,
which fails when comparing two numbers of different classes.

The bug is fixed by using `Double.compare` on the two numbers
`doubleValue` when both values are instances of `Number`, falling back
to `compareTo` otherwise.

The same is done for equality, since until now, golo considered
`1 != 1.0`. When the two values are numbers, the double value is
compared by value, `equals` is called otherwise.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=471709