### PR TITLE
Feature/simple destruct

### DIFF
--- a/doc/augmentations.asciidoc
+++ b/doc/augmentations.asciidoc
@@ -298,3 +298,5 @@ println(m: getOrElse("foo", -> "bar"))
 
 The full set of standard augmentations is documented in the generated *golodoc* (hint: look for
 `doc/golodoc` in the Golo distribution).
+
+

--- a/doc/basics.asciidoc
+++ b/doc/basics.asciidoc
@@ -453,6 +453,14 @@ let lst = list[1, 2, 3, 4, 5]
 let head, tail... = lst        # head = 1, tail = [2, 3, 4, 5]
 ----
 
+Already defined variables can also be assigned with destructuring. For
+instance, one can easily swap two variables:
+[source,golo]
+----
+var a, b = [1, 2]  # a = 1, b = 2
+a, b = [b, a]      # a = 2, b = 1
+----
+
 Destucturing can also be used in
 xref:_span_class_monospaced_foreach_span_loops[`foreach` loops]:
 [source,golo]

--- a/doc/basics.asciidoc
+++ b/doc/basics.asciidoc
@@ -409,6 +409,61 @@ let b = -> [2, 'b']
 let m = map[a(), b()]
 ----
 
+=== Destructuring ===
+
+Golo supports simple destructuring, that is automatic extraction of values
+from an object and assignment to multiple variables in one instruction.
+
+For instance, using destructuring on a tuple:
+[source,golo]
+----
+let a, b = [1, 2]
+# a = 1, b = 2
+----
+
+If there are more variables than values, an exception is raised. If there are
+fewer, the remaining values are ignored. A special syntax is available to
+assign the rest of the values, similar to varargs notation. For instance:
+
+[source,golo]
+----
+let a, b, c = [1, 2]               # raises an exception
+let a, b = [1, 2, 3]               # a = 1, b = 2, 3 ignored
+let a, b, c... = [1, 2, 3, 4, 5]   # a = 1, b = 2, c = [3, 4, 5]
+----
+
+Any object having a `destruct()` method returning a tuple can be used in
+destructuring assignments. Golo specific data structures and some Java native
+ones can be destructured. Augmentations can be used to make an existing class
+destructurable.
+
+For instance, xref:_structs[golo structures] are destructurable:
+[source,golo]
+----
+struct Point = {x, y}
+#...
+let p = Point(42, 1337)
+let x, y = p   # x = 42, y = 1337
+----
+
+as well as java lists:
+[source,golo]
+----
+let lst = list[1, 2, 3, 4, 5]
+let head, tail... = lst        # head = 1, tail = [2, 3, 4, 5]
+----
+
+Destucturing can also be used in
+xref:_span_class_monospaced_foreach_span_loops[`foreach` loops]:
+[source,golo]
+----
+foreach key, value in myMap: entrySet() {
+  # do something...
+}
+----
+
+
+
 === Operators ===
 
 Golo supports the following <<operators,set of operators>>.

--- a/src/main/golo/standard-augmentations.golo
+++ b/src/main/golo/standard-augmentations.golo
@@ -284,6 +284,12 @@ augment java.util.Collection {
   ----
   function newWithSameType = |this| -> _newWithSameType(this)
 
+  ----
+  Destructuration helper.
+  
+  * return a tuple of the values
+  ----
+  function destruct = |this| -> Tuple.fromArray(this: toArray())
 }
 
 # ............................................................................................... #
@@ -496,13 +502,6 @@ augment java.util.List {
   needed since for Golo everything is an `Object` and `remove` is overloaded.
   ----
   function removeAt = |this, idx| -> removeByIndex(this, idx)
-
-  ----
-  Destructuration helper.
-  
-  * return a tuple of the values
-  ----
-  function destruct = |this| -> Tuple.fromArray(this: toArray())
 }
 
 # ............................................................................................... #

--- a/src/main/golo/standard-augmentations.golo
+++ b/src/main/golo/standard-augmentations.golo
@@ -798,6 +798,13 @@ augment java.util.Map {
     this: filter(pred): size() > 0
 }
 
+
+augment java.util.Map$Entry {
+  ----
+  Destructurate a map entry in key and value
+  ----
+  function destruct = |this| -> [ this: getKey(), this: getValue() ]
+}
 # ............................................................................................... #
 
 ----

--- a/src/main/golo/standard-augmentations.golo
+++ b/src/main/golo/standard-augmentations.golo
@@ -496,6 +496,13 @@ augment java.util.List {
   needed since for Golo everything is an `Object` and `remove` is overloaded.
   ----
   function removeAt = |this, idx| -> removeByIndex(this, idx)
+
+  ----
+  Destructuration helper.
+  
+  * return a tuple of the values
+  ----
+  function destruct = |this| -> Tuple.fromArray(this: toArray())
 }
 
 # ............................................................................................... #

--- a/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTDestructuringAssignment.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTDestructuringAssignment.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2012-2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package fr.insalyon.citi.golo.compiler.parser;
+
+import java.util.List;
+import java.util.ArrayList;
+import static java.util.Collections.unmodifiableList;
+
+public class ASTDestructuringAssignment extends GoloASTNode {
+
+  private ASTLetOrVar.Type type;
+  private List<String> names;
+  private boolean isVarargs = false;
+
+  public ASTDestructuringAssignment(int id) {
+    super(id);
+  }
+
+  public ASTDestructuringAssignment(GoloParser p, int id) {
+    super(p, id);
+  }
+
+  public ASTLetOrVar.Type getType() {
+    return type;
+  }
+
+  public void setType(ASTLetOrVar.Type type) {
+    this.type = type;
+  }
+
+  public List<String> getNames() {
+    return unmodifiableList(names);
+  }
+
+  public void setNames(List<String> names) {
+    this.names = new ArrayList<>();
+    this.names.addAll(names);
+  }
+
+  public void setVarargs(boolean b) {
+    this.isVarargs = b;
+  }
+
+  public boolean isVarargs() {
+    return this.isVarargs;
+  }
+
+  @Override
+  public String toString() {
+    return "ASTDestructuringAssignment{" +
+        "type=" + type +
+        ", names=" + names +
+        ", varargs=" + isVarargs +
+      "}";
+  }
+
+  @Override
+  public Object jjtAccept(GoloParserVisitor visitor, Object data) {
+    return visitor.visit(this, data);
+  }
+}

--- a/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTDestructuringAssignment.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTDestructuringAssignment.java
@@ -16,7 +16,7 @@ import static java.util.Collections.unmodifiableList;
 public class ASTDestructuringAssignment extends GoloASTNode {
 
   private ASTLetOrVar.Type type;
-  private List<String> names;
+  private List<String> names = new ArrayList<>();
   private boolean isVarargs = false;
 
   public ASTDestructuringAssignment(int id) {
@@ -40,7 +40,7 @@ public class ASTDestructuringAssignment extends GoloASTNode {
   }
 
   public void setNames(List<String> names) {
-    this.names = new ArrayList<>();
+    this.names.clear();
     this.names.addAll(names);
   }
 

--- a/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTForEachLoop.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/parser/ASTForEachLoop.java
@@ -9,9 +9,14 @@
 
 package fr.insalyon.citi.golo.compiler.parser;
 
+import java.util.List;
+import java.util.LinkedList;
+
 public class ASTForEachLoop extends GoloASTNode {
 
   private String elementIdentifier;
+  private List<String> names = new LinkedList<>();
+  private boolean isVarargs = false;
 
   public ASTForEachLoop(int id) {
     super(id);
@@ -27,6 +32,23 @@ public class ASTForEachLoop extends GoloASTNode {
 
   public void setElementIdentifier(String elementIdentifier) {
     this.elementIdentifier = elementIdentifier;
+  }
+
+  public List<String> getNames() {
+    return this.names;
+  }
+
+  public void setNames(List<String> names) {
+    this.names.clear();
+    this.names.addAll(names);
+  }
+
+  public void setVarargs(boolean b) {
+    this.isVarargs = b;
+  }
+
+  public boolean isVarargs() {
+    return this.isVarargs;
   }
 
   @Override

--- a/src/main/java/fr/insalyon/citi/golo/doc/ModuleDocumentation.java
+++ b/src/main/java/fr/insalyon/citi/golo/doc/ModuleDocumentation.java
@@ -244,6 +244,11 @@ class ModuleDocumentation implements DocumentationElement {
     }
 
     @Override
+    public Object visit(ASTDestructuringAssignment node, Object data) {
+      return data;
+    }
+
+    @Override
     public Object visit(ASTContinue node, Object data) {
       return data;
     }

--- a/src/main/java/gololang/AbstractRange.java
+++ b/src/main/java/gololang/AbstractRange.java
@@ -12,7 +12,6 @@ package gololang;
 import java.util.AbstractCollection;
 import java.util.Iterator;
 import java.util.Arrays;
-import java.util.LinkedList;
 
 abstract class AbstractRange<T extends Comparable<T>> extends AbstractCollection<T> implements Range<T> {
   private final T from;
@@ -133,10 +132,12 @@ abstract class AbstractRange<T extends Comparable<T>> extends AbstractCollection
   }
 
   public Tuple destruct() {
-    LinkedList<T> vals = new LinkedList<>();
+    Object[] data = new Object[this.size()];
+    int i = 0;
     for (T v : this) {
-      vals.add(v);
+      data[i] = v;
+      i++;
     }
-    return Tuple.fromArray(vals.toArray());
+    return Tuple.fromArray(data);
   }
 }

--- a/src/main/java/gololang/AbstractRange.java
+++ b/src/main/java/gololang/AbstractRange.java
@@ -12,6 +12,7 @@ package gololang;
 import java.util.AbstractCollection;
 import java.util.Iterator;
 import java.util.Arrays;
+import java.util.LinkedList;
 
 abstract class AbstractRange<T extends Comparable<T>> extends AbstractCollection<T> implements Range<T> {
   private final T from;
@@ -129,5 +130,13 @@ abstract class AbstractRange<T extends Comparable<T>> extends AbstractCollection
   @Override
   public boolean isEmpty() {
     return from.compareTo(to) >= 0;
+  }
+
+  public Tuple destruct() {
+    LinkedList<T> vals = new LinkedList<>();
+    for (T v : this) {
+      vals.add(v);
+    }
+    return Tuple.fromArray(vals.toArray());
   }
 }

--- a/src/main/java/gololang/GoloStruct.java
+++ b/src/main/java/gololang/GoloStruct.java
@@ -54,6 +54,15 @@ public abstract class GoloStruct implements Iterable<Tuple> {
   public abstract Tuple values();
 
   /**
+   * Destructuration helper.
+   *
+   * @return a tuple with the current values.
+   */
+  public Tuple destruct() { 
+    return values();
+  }
+
+  /**
    * Gets a member value by name.
    *
    * @param member the member name.

--- a/src/main/java/gololang/LazyList.java
+++ b/src/main/java/gololang/LazyList.java
@@ -232,6 +232,16 @@ public class LazyList implements Collection<Object>, HeadTail<Object> {
     return this.asList().toArray(a);
   }
 
+
+  /**
+   * Destructuration helper.
+   *
+   * @return a tuple of head and tail
+   */
+  public Tuple destruct() {
+    return new Tuple(head(), tail());
+  }
+
   /**
    * Returns the element at the specified position in this list.
    * <p>

--- a/src/main/java/gololang/Tuple.java
+++ b/src/main/java/gololang/Tuple.java
@@ -186,18 +186,41 @@ public final class Tuple implements HeadTail<Object>, Comparable<Tuple> {
   }
 
   /**
+   * Helper for destructuring.
    *
+   * @return the tuple itself
    */
   public Tuple destruct() { return this; }
 
+  /**
+   * Extract a sub-tuple.
+   *
+   * @param start the index of the first element.
+   * @return a new tuple containing the elements from {@code start} to the end.
+   */
   public Tuple subTuple(int start) {
     return this.subTuple(start, data.length);
   }
 
+  /**
+   * Extract a sub-tuple.
+   *
+   * @param start the index of the first element (inclusive).
+   * @param end the index of the last element (exclusive).
+   * @return a new tuple containing the elements between indices {@start} inclusive and {@code end}
+   * exclusive.
+   */
   public Tuple subTuple(int start, int end) {
     if (this.isEmpty()) {
       return this;
     }
     return fromArray(Arrays.copyOfRange(data, start, end));
+  }
+
+  /**
+   * Returns a array of this tuple data.
+   */
+  public Object[] toArray() {
+    return Arrays.copyOf(data, data.length);
   }
 }

--- a/src/main/java/gololang/Tuple.java
+++ b/src/main/java/gololang/Tuple.java
@@ -182,10 +182,22 @@ public final class Tuple implements HeadTail<Object>, Comparable<Tuple> {
    */
   @Override
   public Tuple tail() {
+    return this.subTuple(1);
+  }
+
+  /**
+   *
+   */
+  public Tuple destruct() { return this; }
+
+  public Tuple subTuple(int start) {
+    return this.subTuple(start, data.length);
+  }
+
+  public Tuple subTuple(int start, int end) {
     if (this.isEmpty()) {
-      // we can return this since a Tuple is immutable.
       return this;
     }
-    return fromArray(Arrays.copyOfRange(data, 1, data.length));
+    return fromArray(Arrays.copyOfRange(data, start, end));
   }
 }

--- a/src/main/jjtree/Golo.jjt
+++ b/src/main/jjtree/Golo.jjt
@@ -924,13 +924,13 @@ void Statement() #void:{}
   |
   LOOKAHEAD(2) Assignment()
   |
-  ExpressionStatement()
-  |
-  Return()
-  |
   LOOKAHEAD(3) DestructuringAssignment()
   |
   LOOKAHEAD(3) LetOrVar()
+  |
+  ExpressionStatement()
+  |
+  Return()
   |
   ConditionalBranching()
   |
@@ -1364,6 +1364,14 @@ ASTDestructuringAssignment DestructuringAssignment():
   <VAR> names=DestructuredNames() (varargsToken="...")? "=" (BlankLine())? ExpressionStatement()
   {
     jjtThis.setType(ASTLetOrVar.Type.VAR);
+    jjtThis.setNames(names);
+    jjtThis.setVarargs(varargsToken != null);
+    return jjtThis;
+  }
+  |
+  names=DestructuredNames() (varargsToken="...")? "=" (BlankLine())? ExpressionStatement()
+  {
+    jjtThis.setType(null);
     jjtThis.setNames(names);
     jjtThis.setVarargs(varargsToken != null);
     return jjtThis;

--- a/src/main/jjtree/Golo.jjt
+++ b/src/main/jjtree/Golo.jjt
@@ -928,7 +928,9 @@ void Statement() #void:{}
   |
   Return()
   |
-  LetOrVar()
+  LOOKAHEAD(3) DestructuringAssignment()
+  |
+  LOOKAHEAD(3) LetOrVar()
   |
   ConditionalBranching()
   |
@@ -1328,6 +1330,51 @@ void Reference():{}
   <IDENTIFIER>
   {
     jjtThis.setName(jjtThis.jjtGetFirstToken().image);
+  }
+}
+
+ASTDestructuringAssignment DestructuringAssignment():
+{
+  List<String> names;
+  Token varargsToken = null;
+}
+{
+  <LET> names=DestructuredNames() (varargsToken="...")? "=" (BlankLine())? ExpressionStatement()
+  {
+    jjtThis.setType(ASTLetOrVar.Type.LET);
+    jjtThis.setNames(names);
+    jjtThis.setVarargs(varargsToken != null);
+    return jjtThis;
+  }
+  |
+  <VAR> names=DestructuredNames() (varargsToken="...")? "=" (BlankLine())? ExpressionStatement()
+  {
+    jjtThis.setType(ASTLetOrVar.Type.VAR);
+    jjtThis.setNames(names);
+    jjtThis.setVarargs(varargsToken != null);
+    return jjtThis;
+  }
+}
+
+List<String> DestructuredNames() #void:
+{
+  List<String> names = new LinkedList<String>();
+  Token rootToken;
+  Token nextToken;
+}
+{
+  rootToken=<IDENTIFIER>
+  {
+    names.add(rootToken.image);
+  }
+  (
+    "," (BlankLine())? nextToken=<IDENTIFIER>
+    {
+      names.add(nextToken.image);
+    }
+  )+
+  {
+    return names;
   }
 }
 

--- a/src/main/jjtree/Golo.jjt
+++ b/src/main/jjtree/Golo.jjt
@@ -982,18 +982,32 @@ void ForLoop(): {}
 void ForEachLoop():
 {
   Token elementId;
+  List<String> names;
+  Token varargsToken = null;
 }
 {
   <FOREACH>
   (
-    (elementId=<IDENTIFIER> <IN> ExpressionStatement() (<WHEN> ExpressionStatement())?)
+    LOOKAHEAD(2)(
+      (elementId=<IDENTIFIER> <IN> ExpressionStatement() (<WHEN> ExpressionStatement())?)
+      |
+      ("(" elementId=<IDENTIFIER> <IN> ExpressionStatement() (<WHEN> ExpressionStatement())? ")")
+    )
+    {
+      jjtThis.setElementIdentifier(elementId.image);
+    }
     |
-    ("(" elementId=<IDENTIFIER> <IN> ExpressionStatement() (<WHEN> ExpressionStatement())? ")")
+    LOOKAHEAD(2)(
+      (names=DestructuredNames()(varargsToken="...")? <IN> ExpressionStatement() (<WHEN> ExpressionStatement())?)
+      |
+      ("(" names=DestructuredNames()(varargsToken="...")? <IN> ExpressionStatement() (<WHEN> ExpressionStatement())? ")")
+    )
+    {
+      jjtThis.setNames(names);
+      jjtThis.setVarargs(varargsToken != null);
+    }
   )
   Block()
-  {
-    jjtThis.setElementIdentifier(elementId.image);
-  }
 }
 
 void TryCatchFinally():

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Callable;
 import static fr.insalyon.citi.golo.compiler.GoloCompilationException.Problem;
 import static fr.insalyon.citi.golo.compiler.GoloCompilationException.Problem.Type.*;
 import static fr.insalyon.citi.golo.internal.testing.TestUtils.compileAndLoadGoloModule;
+import static fr.insalyon.citi.golo.internal.testing.TestUtils.getTestMethods;
 import static java.lang.invoke.MethodType.genericMethodType;
 import static java.lang.reflect.Modifier.*;
 import static java.util.Arrays.asList;
@@ -1234,7 +1235,6 @@ public class CompileAndRunTest {
         fail("method test_" + methodName + " in " + SRC + "unions.golo failed");
       }
     }
-
   }
 
   @Test
@@ -1846,4 +1846,18 @@ public class CompileAndRunTest {
     result = (String) golo_augmentation_varargs.invoke(null);
     assertThat(result, is("abc"));
   }
+
+  @Test
+  public void destructuring() throws Throwable {
+    Class<?> moduleClass = compileAndLoadGoloModule(SRC, "destruct.golo");
+    for (Method testMethod : getTestMethods(moduleClass)) {
+      try {
+        testMethod.invoke(null);
+      } catch (InvocationTargetException e) {
+        fail("method " + testMethod.getName() + " in " + SRC + "destruct.golo failed: " + 
+              e.getCause().getMessage());
+      }
+    }
+  }
+
 }

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -1849,13 +1849,16 @@ public class CompileAndRunTest {
 
   @Test
   public void destructuring() throws Throwable {
+    if (bootstraping()) {
+      return;
+    }
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "destruct.golo");
     for (Method testMethod : getTestMethods(moduleClass)) {
       try {
         testMethod.invoke(null);
       } catch (InvocationTargetException e) {
         fail("method " + testMethod.getName() + " in " + SRC + "destruct.golo failed: " + 
-              e.getCause().getMessage());
+              e.getCause());
       }
     }
   }

--- a/src/test/java/fr/insalyon/citi/golo/internal/testing/TestUtils.java
+++ b/src/test/java/fr/insalyon/citi/golo/internal/testing/TestUtils.java
@@ -21,6 +21,10 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.lang.reflect.Method;
+
+import static java.lang.reflect.Modifier.isStatic;
+import static java.lang.reflect.Modifier.isPublic;
 
 public class TestUtils {
 
@@ -55,5 +59,24 @@ public class TestUtils {
 
   private static boolean shouldTestNgReportToConsole() {
     return Boolean.valueOf(System.getProperty("testng-report-to-console", "false"));
+  }
+
+  public static boolean isTestMethod(Method m) {
+    return (
+      isPublic(m.getModifiers()) &&
+      isStatic(m.getModifiers()) &&
+      m.getName().startsWith("test_") &&
+      m.getParameterCount() == 0
+    );
+  }
+
+  public static Iterable<Method> getTestMethods(Class<?> module) {
+    List<Method> methods = new LinkedList<>();
+    for (Method m : module.getDeclaredMethods()) {
+      if (isTestMethod(m)) {
+        methods.add(m);
+      }
+    }
+    return methods;
   }
 }

--- a/src/test/resources/for-execution/destruct.golo
+++ b/src/test/resources/for-execution/destruct.golo
@@ -1,0 +1,121 @@
+
+module golotest.execution.Destructuring
+
+struct Point = { x, y }
+
+function test_tuple_samesize = {
+  let a, b, c = [1, 2, 3]
+  require(a == 1, "err")
+  require(b == 2, "err")
+  require(c == 3, "err")
+}
+
+function test_tuple_var = {
+  var a, b, c = [1, 2, 3]
+  require(a == 1, "err")
+  require(b == 2, "err")
+  require(c == 3, "err")
+  a = 4
+  b = 5
+  c = 6
+  require(a == 4, "err")
+  require(b == 5, "err")
+  require(c == 6, "err")
+}
+
+function test_tuple_rest = {
+  let fst, scd, rest... = [1, 2, 3, 4, 5]
+  require(fst == 1, "err")
+  require(scd == 2, "err")
+  require(rest == [3, 4, 5], "err")
+}
+
+function test_tuple_less = {
+  let fst, scd = [1, 2, 3, 4]
+  require(fst == 1, "err")
+  require(scd == 2, "err")
+}
+
+function test_struct = {
+  let p = Point(3, 4)
+  let x, y = p
+  require(x == 3, "err")
+  require(y == 4, "err")
+}
+
+function test_list = {
+  let l = list[1, 2, 3, 4, 5]
+
+  let fst, scd, rest... = l
+  require(fst == 1, "err")
+  require(scd == 2, "err")
+  require(rest == [3, 4, 5], "err")
+
+}
+
+function test_range = {
+  let fst, scd, rest... = [1..6]
+  require(fst == 1, "err")
+  require(scd == 2, "err")
+  require(rest == [3, 4, 5], "err")
+
+  let a, b = [1..4]
+  require(a == 1, "err")
+  require(b == 2, "err")
+}
+
+function test_foreach = {
+  let l = [ [1, 2, 3], [3, 4, 5] ]
+  var i = 0
+  foreach a, b in l {
+    require(a == l: get(i): get(0), "err")
+    require(b == l: get(i): get(1), "err")
+    i = i + 1
+  }
+
+  i = 0
+  foreach a, b... in l {
+    require(a == l: get(i): head(), "err")
+    require(b == l: get(i): tail(), "err")
+    i = i + 1
+  }
+}
+
+function test_map = {
+  let m = map[ ["k", 1] ]
+  foreach k, v in m: entrySet() {
+    require(k == "k", "err")
+    require(v == 1, "err")
+  }
+}
+
+union MyUnion = {
+  Foo = { x, y }
+  Bar = { a, b, c }
+}
+
+function test_union = {
+  let foo = MyUnion.Foo(1, 2)
+  let x, y = foo
+  require(x == 1, "err")
+  require(y == 2, "err")
+  
+  let bar = MyUnion.Bar("a", "b", "c")
+  let a, b, c = bar
+  require(a == "a", "err")
+  require(b == "b", "err")
+  require(c == "c", "err")
+}
+
+function main = |args| {
+  test_tuple_samesize()
+  test_tuple_rest()
+  test_tuple_less()
+  test_tuple_var()
+  test_struct()
+  test_list()
+  test_range()
+  test_foreach()
+  test_map()
+  println("ok")
+}

--- a/src/test/resources/for-execution/destruct.golo
+++ b/src/test/resources/for-execution/destruct.golo
@@ -107,6 +107,22 @@ function test_union = {
   require(c == "c", "err")
 }
 
+function test_swap = {
+  var a, b = [1, 2]
+  require(a == 1, "err")
+  require(b == 2, "err")
+
+  a, b = [b, a]
+  require(a == 2, "err")
+  require(b == 1, "err")
+
+  var c = 0
+  a, b, c = [c, a, b]
+  require(a == 0, "err")
+  require(b == 2, "err")
+  require(c == 1, "err")
+}
+
 function main = |args| {
   test_tuple_samesize()
   test_tuple_rest()
@@ -117,5 +133,6 @@ function main = |args| {
   test_range()
   test_foreach()
   test_map()
+  test_swap()
   println("ok")
 }

--- a/src/test/resources/for-execution/unions.golo
+++ b/src/test/resources/for-execution/unions.golo
@@ -80,6 +80,10 @@ function test_hashcode = {
   let t1 = Tree.Node(Tree.Node(Tree.Leaf(1), Tree.Empty()), Tree.Leaf(0))
   let t2 = Tree.Node(Tree.Node(Tree.Leaf(1), Tree.Empty()), Tree.Leaf(0))
   require(t1: hashCode() == t2: hashCode(), "hashcode")
+
+  let t3 = Tree.Node(Tree.Node(Tree.Leaf(3), Tree.Empty()), Tree.Leaf(0))
+  let t4 = Tree.Node(Tree.Node(Tree.Leaf(4), Tree.Empty()), Tree.Leaf(0))
+  require(t3: hashCode() != t4: hashCode(), "hashcode")
 }
 
 # ............................................................................................... #


### PR DESCRIPTION
Allows to destructure an object to assign to several values at the same
time. E.g.:

```golo
let a, b = [1, 2]
require(a == 1 and b == 2, "failed")
```

Any object with a `destruct` method returning a tuple can be used.
Vararg can be used as the last value, e.g.

```golo
let a, b... = [1, 2, 3, 4]
require(a == 1 and b == [2, 3, 4], "failed")
```

Also allows constructs like
```golo
foreach key, value in map: entrySet() {
  println(key)
  println(value)
}
```
on any iterable, as long as values are destructurable.