### PR TITLE
Fix special characters escaping in String and char

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/compiler/utils/StringUnescaping.java
+++ b/src/main/java/fr/insalyon/citi/golo/compiler/utils/StringUnescaping.java
@@ -11,34 +11,42 @@ package fr.insalyon.citi.golo.compiler.utils;
 
 public class StringUnescaping {
 
-  private static final String[] ESCAPE_STRINGS = {
-      String.valueOf('\n'),
-      String.valueOf('\t'),
-      String.valueOf('\b'),
-      String.valueOf('\r'),
-      String.valueOf('\f'),
-      String.valueOf('\''),
-      String.valueOf('"'),
-      String.valueOf('\\')
-  };
-
-  private static final String[] SEQS = {
-      "\\n",
-      "\\t",
-      "\\b",
-      "\\r",
-      "\\f",
-      "\\'",
-      "\\\"",
-      "\\\\"
-  };
-
   public static String unescape(String str) {
-    String result = str;
-    for (int i = 0; i < ESCAPE_STRINGS.length; i++) {
-      result = result.replace(SEQS[i], ESCAPE_STRINGS[i]);
+    StringBuilder sb = new StringBuilder(str.length());
+    for (int i = 0; i < str.length(); i++) {
+      char ch = str.charAt(i);
+      if (ch == '\\') {
+        char nextChar = (i == str.length() - 1) ? '\\' : str.charAt(i + 1);
+        switch (nextChar) {
+          case '\\':
+            ch = '\\';
+            break;
+          case 'b':
+            ch = '\b';
+            break;
+          case 'f':
+            ch = '\f';
+            break;
+          case 'n':
+            ch = '\n';
+            break;
+          case 'r':
+            ch = '\r';
+            break;
+          case 't':
+            ch = '\t';
+            break;
+          case '\"':
+            ch = '\"';
+            break;
+          case '\'':
+            ch = '\'';
+            break;
+        }
+        i++;
+      }
+      sb.append(ch);
     }
-    return result;
-    // TODO: this is a rather inefficient algorithm...
+    return sb.toString();
   }
 }

--- a/src/main/jjtree/Golo.jjt
+++ b/src/main/jjtree/Golo.jjt
@@ -222,7 +222,11 @@ TOKEN :
     ("\\" (["n", "t", "b", "r", "f", "\\", "'", "\""]) )
   )* "\"" >
   |
-  < CHAR: "'" (~["\n", "\r", "\""]) "'" >
+  < CHAR: "'" (
+    (~["\n", "\r", "\""])
+    |
+    ("\\" (["n", "t", "b", "r", "f", "\\", "'"]) )
+  ) "'" >
   |
   < NULL: "null" >
   |
@@ -541,7 +545,7 @@ Character CharLiteral() #void:
 {
   literal=<CHAR>
   {
-    return Character.valueOf(literal.image.charAt(1));
+    return Character.valueOf(StringUnescaping.unescape(literal.image.substring(1, literal.image.length() - 1)).charAt(0));
   }
 }
 

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -90,11 +90,16 @@ public class CompileAndRunTest {
     Method no = moduleClass.getMethod("no");
     assertThat((Boolean) no.invoke(null), is(Boolean.FALSE));
 
-    Method escaped = moduleClass.getMethod("escaped");
-    String str = (String) escaped.invoke(null);
-    String expected = "\nFoo\r\n";
-    assertThat(str.length(), is(expected.length()));
-    assertThat(str, is(expected));
+    Method escaped_string = moduleClass.getMethod("escaped_string");
+    String str = (String) escaped_string.invoke(null);
+    String expected_string = "\nFoo\r\n\\n";
+    assertThat(str.length(), is(expected_string.length()));
+    assertThat(str, is(expected_string));
+
+    Method escaped_char = moduleClass.getMethod("escaped_char");
+    char character = (char) escaped_char.invoke(null);
+    char expected_char = '\n';
+    assertThat(character, is(expected_char));
 
     Method multiline = moduleClass.getMethod("multiline");
     assertThat((String) multiline.invoke(null), is("This is\n*awesome*"));

--- a/src/test/resources/for-execution/returns.golo
+++ b/src/test/resources/for-execution/returns.golo
@@ -14,8 +14,12 @@ function yes = { return ((true)) }
 
 function no = { return (false) }
 
-function escaped = {
-  return "\nFoo\r\n"
+function escaped_string = {
+  return "\nFoo\r\n\\n"
+}
+
+function escaped_char = {
+  return '\n'
 }
 
 function multiline = {


### PR DESCRIPTION
- fixes this:
   ```golo
   print("<\\t>")
   ```
   will print:
   ```
   <\    >
   ```
   but the expected value is
   ```
   <\t>
   ```

- add the ability to the parser to deal with special characters using single quote notation