### PR TITLE
The function name parameter isn't necessarily called "name"

### DIFF
--- a/doc/augmentations.asciidoc
+++ b/doc/augmentations.asciidoc
@@ -277,8 +277,6 @@ println("golo": notExistingMethod(1,2))
 # Prints "Dispatch failed for method: notExistingMethod on instance golo, with args: [1, 2]"
 ----
 
-Note: The `fallback` method must respect the signature and parameter names `fallback = |this, name, args...|`
-
 === Standard augmentations
 
 Golo comes with a set of pre-defined augmentations over collections, strings, closures and more.

--- a/src/main/java/fr/insalyon/citi/golo/runtime/MethodInvocationSupport.java
+++ b/src/main/java/fr/insalyon/citi/golo/runtime/MethodInvocationSupport.java
@@ -10,10 +10,11 @@
 package fr.insalyon.citi.golo.runtime;
 
 import gololang.DynamicObject;
-import gololang.FunctionReference;
 
 import java.lang.invoke.*;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.WeakHashMap;
 
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.invoke.MethodType.methodType;
@@ -158,8 +159,7 @@ public class MethodInvocationSupport {
           inlineCache.callerLookup,
           "fallback",
           methodType(Object.class, Object.class, Object.class, Object[].class),
-          false,
-          "name", "args");
+          false);
       Object[] fallbackArgs = new Object[] {
           args[0],
           inlineCache.name,

--- a/src/test/resources/for-execution/augmentations-with-fallback.golo
+++ b/src/test/resources/for-execution/augmentations-with-fallback.golo
@@ -3,14 +3,14 @@ module golotest.execution.AugmentationsWithFallback
 import java.util.stream.Collectors
 
 augment java.lang.String {
-  function fallback = |this, name, args...| -> "Fallback for this " + this + " named " + name + " with args" + args: asList()
+  function fallback = |this, functionName, args...| -> "Fallback for this " + this + " named " + functionName + " with args" + args: asList()
 }
 
 augmentation Fluent = {
-  function fallback = |this, name, args...| {
+  function fallback = |this, functionName, args...| {
     return match {
-      when args: length() is 1 then this: bindAt(name, args: get(0))
-      otherwise this: bindAt(name, args)
+      when args: length() is 1 then this: bindAt(functionName, args: get(0))
+      otherwise this: bindAt(functionName, args)
     }
   }
 }


### PR DESCRIPTION
Before, the parameter "name" (name of the function) was "fixed" (you can only call it "name")

    augment java.lang.String {
      function fallback = |this, name, args...| -> "Fallback for this " + this + " named " + name + " with args" + args: asList()
    }

Now, you can name it as you want:

    augment java.lang.String {
      function fallback = |this, functionName, args...| -> "Fallback for this " + this + " functionName " + name + " with args" + args: asList()
    }