### PR TITLE
Adds special methods to unions.

### DIFF
--- a/doc/unions.asciidoc
+++ b/doc/unions.asciidoc
@@ -88,8 +88,8 @@ union Tree = {
 === JVM existence
 
 A `union` type is compiled to an abstract JVM class. Each alternative value
-type is itself compiled to a final immutable JVM class extending the `union` abstract class.
-The value classes are member classes of the `union` one.
+type is itself compiled to a final immutable JVM class extending the abstract class.
+The value classes are member classes of the abstract one.
 
 Given:
 [source,golo]
@@ -121,6 +121,66 @@ are immutable, have getters for fields and are compared by values. However,
 these types does not feature the same helper methods, and can't have private
 members.
 
+=== Special testing methods
+
+Unions feature special methods to test for the exact type of a value, as well
+as members values if applicable. This allows to write readable tests, more
+specially using the `match` clause, to look like destructuring match in
+langages like OCaml, Haskell or Scala.
+
+For instance, given a union defining a binary tree:
+[source,golo]
+----
+union Tree = {
+  Node = {left, right}
+  Leaf = {value}
+  Empty
+}
+----
+
+one can match a `elt` value using:
+[source,golo]
+----
+match {
+  when elt: isEmpty() then // we have an empty value
+  when elt: isLeaf(0) then // we have a leaf containing 0
+  when elt: isLeaf()  then // we have a leaf (whatever the value)
+  when elt: isNode(Empty(), Empty()) then // we have a node with empty children
+  when elt: isNode(Leaf(42), Leaf(42)) then // we have a node whose  both children contain 42
+  when elt: isNode() then // we have a node, whatever the values
+  otherwise // default case...
+}
+----
+
+More precisely, each possible union value provides parameterless methods
+testing its exact type, named `is<TypeName>`. In the tree example, three
+methods are defined: `isEmpty()`, `isLeaf()` and `isNode()`.
+In addition to these methods, a method with parameters is defined for every
+alternative with members, here `isLeaf(x)` and `isNode(x, y)`. The arguments
+are compared (in order) for equality to the members of the union value. 
+For instance:
+[source,golo]
+----
+Leaf(0): isLeaf(0) # true
+Leaf(42): isLeaf(0) # false
+----
+allowing readable test and match clauses.
+
+A special singleton value is available to make these clauses even more
+readable: the `Unknown` value. This special singleton is considered equal to
+any other object (except `null`), and thus can be used is the parametrized test 
+methods to ignore some members. For instance, to match a `Node` with only one
+child, one can use:
+[source,golo]
+----
+let _ = Unknown.get()
+
+function dealWithTree = |elt| -> match {
+  when elt: isNode(Empty(), _) or elt: isNode(_, Empty()) then ...
+    // one of the children is Empty, whatever the other one
+  otherwise ...
+}
+----
 
 === Augmenting unions
 
@@ -130,8 +190,8 @@ concrete class extending it, it is possible to augment the whole `union`, as in:
 [source,golo]
 ----
 augment Option {
-  function fmap = |this, func| -> match {
-    when this is Option.None() then this
+  function map = |this, func| -> match {
+    when this: isNone() then this
     otherwise Option.Some(func(this: value()))
   }
 }
@@ -142,13 +202,13 @@ or just a value, as in:
 [source,golo]
 ----
 augment ConsList$Empty {
-  function isEmpty = |this| -> true
+  function size = |this| -> 0
   function head = |this| -> null
   function tail = |this| -> this
 }
 
 augment ConsList$List {
-  function isEmpty = |this| -> false
+  function size = |this| -> 1 + this: tail(): size()
 }
 ----
 

--- a/samples/union.golo
+++ b/samples/union.golo
@@ -35,24 +35,32 @@ union Tree = {
   Empty
 }
 
-augment Tree$Node {
-  function isEmpty = |this| -> false
-}
-
-augment Tree$Empty {
-  function isEmpty = |this| -> true
-}
-
-augment Tree$Leaf {
-  function isEmpty = |this| -> false
-}
-
 augment Tree {
   function whoAreYou = |this| -> match {
     when this oftype samples.Unions.types.Tree$Node.class then "I'm a node"
     when this oftype samples.Unions.types.Tree$Leaf.class then "I'm a leaf"
     otherwise "I'm empty"
   }
+}
+
+let _ = Unknown.get()
+
+function in_a_match = |tree| -> match {
+  when tree: isEmpty() then "empty tree"
+  when tree: isLeaf(0) then "a leaf with 0"
+  when tree: isLeaf() then "a leaf"
+  when tree: isNode(Tree.Empty(), _) or tree: isNode(_, Tree.Empty()) then "node with 1 child"
+  when tree: isNode() then "a node"
+  otherwise "wtf"
+}
+
+function test_match = {
+  require(in_a_match(Tree.Empty()) == "empty tree", "err")
+  require(in_a_match(Tree.Leaf(0)) == "a leaf with 0", "err")
+  require(in_a_match(Tree.Leaf(42)) == "a leaf", "err")
+  require(in_a_match(Tree.Node(0, 0)) == "a node", "err")
+  require(in_a_match(Tree.Node(Tree.Empty(), 0)) == "node with 1 child", "err")
+  require(in_a_match(Tree.Node(0, Tree.Empty())) == "node with 1 child", "err")
 }
 
 function test_option = {
@@ -97,6 +105,7 @@ function test_tree = {
 function main = |args| {
   test_option()
   test_tree()
+  test_match()
 
   println("OK")
 }

--- a/src/main/java/gololang/Unknown.java
+++ b/src/main/java/gololang/Unknown.java
@@ -5,8 +5,10 @@ package gololang;
  * A singleton class that is equals to any object.
  * <p>
  * Used in unions matching special methods to ignore a value.
+ * Note that this break the commutativity property of {@code equals}, and thus this object must be
+ * used with caution.
  */
-public class Unknown {
+public final class Unknown {
   private static final Unknown instance = new Unknown();
   private Unknown() {}
   public static Unknown get() { 

--- a/src/main/java/gololang/Unknown.java
+++ b/src/main/java/gololang/Unknown.java
@@ -1,0 +1,25 @@
+
+package gololang;
+
+/**
+ * A singleton class that is equals to any object.
+ * <p>
+ * Used in unions matching special methods to ignore a value.
+ */
+public class Unknown {
+  private static final Unknown instance = new Unknown();
+  private Unknown() {}
+  public static Unknown get() { 
+    return instance;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o == null ? false : true;
+  }
+
+  @Override
+  public int hashCode() { 
+    return 0; 
+  }
+}

--- a/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/fr/insalyon/citi/golo/compiler/CompileAndRunTest.java
@@ -1227,7 +1227,7 @@ public class CompileAndRunTest {
     Method testMethod;
 
     for (String methodName : asList("toString", "equality", "hashcode", "augmentations",
-                                    "immutable", "singleton", "not_instantiable")) {
+                                    "immutable", "singleton", "not_instantiable", "match_methods")) {
       testMethod = moduleClass.getMethod("test_" + methodName);
       try {
         testMethod.invoke(null);

--- a/src/test/resources/for-execution/unions.golo
+++ b/src/test/resources/for-execution/unions.golo
@@ -21,7 +21,7 @@ augment Option {
   }
 }
 
-function monadicAdd = |mx, my| -> 
+function monadicAdd = |mx, my| ->
   mx: bind(|x| ->
     my: bind(|y| ->
       Option.Some(x + y)))
@@ -34,15 +34,15 @@ union Tree = {
 }
 
 augment Tree$Node {
-  function isEmpty = |this| -> false
+  function isEmptyNode = |this| -> false
 }
 
 augment Tree$Empty {
-  function isEmpty = |this| -> true
+  function isEmptyNode = |this| -> true
 }
 
 augment Tree$Leaf {
-  function isEmpty = |this| -> false
+  function isEmptyNode = |this| -> false
 }
 
 augment Tree {
@@ -136,9 +136,9 @@ function test_augmentations = {
   require(n: fmap(double) == n, "err")
   require(s: fmap(double) == Option.Some(10), "err")
 
-  require(not Tree.Leaf(0): isEmpty(), "err on Tree.Leaf:isEmpty")
-  require(not Tree.Node(0, 0): isEmpty(), "err on Tree.Node:isEmpty")
-  require(Tree.Empty(): isEmpty(), "err on Tree.Empty:isEmpty")
+  require(not Tree.Leaf(0): isEmptyNode(), "err on Tree.Leaf:isEmpty")
+  require(not Tree.Node(0, 0): isEmptyNode(), "err on Tree.Node:isEmpty")
+  require(Tree.Empty(): isEmptyNode(), "err on Tree.Empty:isEmpty")
 
   require(Tree.Leaf(0): whoAreYou() == "I'm a leaf",
     "err on Tree.Leaf:whoAreYou")
@@ -178,6 +178,37 @@ function test_singleton = {
   }
 }
 
+function test_match_methods = {
+  let n = Tree.Node(0, 0)
+  let l = Tree.Leaf(0)
+  let e = Tree.Empty()
+  
+  require(not n: isEmpty(), "err")
+  require(not l: isEmpty(), "err")
+  require(e: isEmpty(), "err")
+
+  require(n: isNode(), "err")
+  require(not l: isNode(), "err")
+  require(not e: isNode(), "err")
+
+  require(not n: isLeaf(), "err")
+  require(l: isLeaf(), "err")
+  require(not e: isLeaf(), "err")
+
+  require(l: isLeaf(0), "err")
+  require(not l: isLeaf(42), "err")
+
+  require(n: isNode(0, 0), "err")
+  require(not n: isNode(42, 0), "err")
+  require(not n: isNode(0, 42), "err")
+  require(not n: isNode(42, 42), "err")
+
+  let _ = gololang.Unknown.get()
+  require(n: isNode(0, _), "err")
+  require(n: isNode(_,0), "err")
+  require(n: isNode(_,_), "err")
+}
+
 # ............................................................................................... #
 function main = |args| {
   test_toString()
@@ -187,6 +218,7 @@ function main = |args| {
   test_immutable()
   test_singleton()
   test_not_instantiable()
+  test_match_methods()
 
   println("OK")
 }


### PR DESCRIPTION
A union has now special methods to test its kind (type) as well as the
values of its members if applicable. This make the use of unions in
`match` constructs easier and more readable.

For instance, given the union:
```golo
union Tree = {
  Empty
  Leaf = { value }
  Node = { left, right }
}
```

one can now write a match like:
```golo
function foo = |elt| -> match {
  when elt: isEmpty() then "empty"
  when elt: isLeaf() then "leaf"
  when elt: isNode(Empty(), Empty()) then "node with empty children"
  when elt: isNode() then "a node"
}
```

In the same way, a union:
```golo
union Option = {
  Some = {value}
  None
}
```

can be tested with:
```golo
if v: isNone() {
  // ...
}
if v: isSome(null) {
  // a some, but containing null (not a good idea)
}
if v: isSome(42) {
  // a some containing 42
}
if v: isSome() {
  // a some, whatever le value
}
```

A special singleton class `Unknown` is added. The instance is equal to
any object (except null). It can be used to ignore members is the tests:
```golo
let _ = Unknown.get()
function getTreeValue = |elt| -> match {
  when elt: isEmpty() then null
  when elt: isLeaf() then elt: value()
  when elt: isNode(_, Empty()) then elt: left()
  when elt: isNode(Empty(), _) then elt: right()
  when elt: isNode() then [elt: left(), elt: right()]
  otherwise null
}
```