### PR TITLE
Adds a ref predefined function creating reference

### DIFF
--- a/doc/predefined-functions.asciidoc
+++ b/doc/predefined-functions.asciidoc
@@ -299,7 +299,7 @@ println(e: getKey() + " => " + e: getValue())
 ----
 
 `box` gives instances of `java.util.concurrent.atomic.AtomicReference`, and can
-be used to create a muttable reference where not possible othewise, e.g. in
+be used to create a mutable reference where not possible otherwise, e.g. in
 closures, as in:
 
 [source,golo]

--- a/doc/predefined-functions.asciidoc
+++ b/doc/predefined-functions.asciidoc
@@ -297,3 +297,20 @@ let e = mapEntry("foo", "bar")
 # prints "foo => bar"
 println(e: getKey() + " => " + e: getValue())
 ----
+
+`box` gives instances of `java.util.concurrent.atomic.AtomicReference`, and can
+be used to create a muttable reference where not possible othewise, e.g. in
+closures, as in:
+
+[source,golo]
+----
+function counter = |init, stepFun| {
+  let current = box(init)
+  return -> current: getAndUpdate(stepFun)
+}
+#...
+let c2 = counter(3, |x| -> x * 2)
+c() # -> 3
+c() # -> 6
+c() # -> 12
+----

--- a/src/main/java/gololang/Predefined.java
+++ b/src/main/java/gololang/Predefined.java
@@ -749,13 +749,13 @@ public final class Predefined {
   }
 
   /**
-   * Returns a reference to the given object.
+   * Returns a box containing the given object.
    * <p>
    * Useful whenever an explicit reference is needed, for instance to create a closure with internal
    * mutable state:
    * <pre>
    *    function counter = |init| {
-   *      let current = ref(init)
+   *      let current = box(init)
    *      return -> current: getAndSet(current: get() + 1)
    *    }
    *
@@ -766,9 +766,9 @@ public final class Predefined {
    * </pre>
    *
    * @param obj the object to reference.
-   * @return a {@java.util.concurrent.atomic.AtomicReference} reference to the object
+   * @return a {@java.util.concurrent.atomic.AtomicReference} instance wrapping the object
    */
-  public static Object ref(Object obj) {
+  public static Object box(Object obj) {
     return new java.util.concurrent.atomic.AtomicReference<Object>(obj);
   }
 

--- a/src/main/java/gololang/Predefined.java
+++ b/src/main/java/gololang/Predefined.java
@@ -748,6 +748,29 @@ public final class Predefined {
     return lst.remove(idx.intValue());
   }
 
+  /**
+   * Returns a reference to the given object.
+   * <p>
+   * Useful whenever an explicit reference is needed, for instance to create a closure with internal
+   * mutable state:
+   * <pre>
+   *    function counter = |init| {
+   *      let current = ref(init)
+   *      return -> current: getAndSet(current: get() + 1)
+   *    }
+   *
+   *    let c = counter(3)
+   *    c() # 3
+   *    c() # 4
+   *    c() # 5
+   * </pre>
+   *
+   * @param obj the object to reference.
+   * @return a {@java.util.concurrent.atomic.AtomicReference} reference to the object
+   */
+  public static Object ref(Object obj) {
+    return new java.util.concurrent.atomic.AtomicReference<Object>(obj);
+  }
 
   // ...................................................................................................................
 }


### PR DESCRIPTION
The new predefined `ref` function returns an `AtomicReference` on the
given object. This is just a helper function around
`java.util.concurrent.atomic.AtomicReference`.

Useful whenever an explicit reference is needed, for instance to create
a closure with internal mutable state:

```golo
    function counter = |init| {
      let current = ref(init)
      return -> current: getAndSet(current: get() + 1)
    }

    function counter = |init, stepFun| {
      let current = ref(init)
      return -> current: getAndUpdate(stepFun)
    }

    let c = counter(3)
    c() # -> 3
    c() # -> 4
    c() # -> 5

    let c2 = counter(3, |x| -> x * 2)
    c() # -> 3
    c() # -> 6
    c() # -> 12
```