### PR TITLE
Fix: inconsistent naming for reversed_range

### DIFF
--- a/doc/predefined-functions.asciidoc
+++ b/doc/predefined-functions.asciidoc
@@ -154,13 +154,13 @@ foreach i in range(0, -6):decrementBy(2) {
 }
 ----
 
-The `reversed_range` function is an alias for `range` with an increment of -1,
-such that `reversed_range(5, 1)` is the same as `range(5, 1): decrementBy(1)`.
+The `reversedRange` function is an alias for `range` with an increment of -1,
+such that `reversedRange(5, 1)` is the same as `range(5, 1): decrementBy(1)`.
 
 When `range` is called with only one value, it is used as the upper bound, the
 lower one being a default value (0 for numbers, 'A' for chars). For example,
 `range(5) == range(0, 5)` and `range('Z') == range('A', 'Z')`. In the same way,
-`reversed_range(5) == reversed_range(5, 0)`.
+`reversedRange(5) == reversedRange(5, 0)`.
 
 Two ranges are equals if they have the same bounds and increment.
 

--- a/src/main/java/gololang/Predefined.java
+++ b/src/main/java/gololang/Predefined.java
@@ -276,7 +276,7 @@ public final class Predefined {
    * @return a range object.
    * @see gololang.Predefined.range
    */
-  public static Object reversed_range(Object from, Object to) {
+  public static Object reversedRange(Object from, Object to) {
     return ((Range<?>) range(from, to)).incrementBy(-1);
   }
 
@@ -288,11 +288,27 @@ public final class Predefined {
    * @param from the upper-bound (inclusive) as an <code>Integer</code>, <code>Long</code> or
    *             <code>Character</code>.
    * @return a range object.
-   * @see gololang.Predefined.reversed_range
+   * @see gololang.Predefined.reversedRange
    * @see gololang.Predefined.range
    */
-  public static Object reversed_range(Object from) {
+  public static Object reversedRange(Object from) {
     return ((Range<?>) range(from)).reversed();
+  }
+
+  /**
+   * @deprecated renamed to {@code reversedRange} for consistency.
+   */
+  @Deprecated
+  public static Object reversed_range(Object from) {
+    return reversedRange(from);
+  }
+
+  /**
+   * @deprecated renamed to {@code reversedRange} for consistency.
+   */
+  @Deprecated
+  public static Object reversed_range(Object from, Object to) {
+    return reversedRange(from, to);
   }
 
   // ...................................................................................................................

--- a/src/test/java/gololang/PredefinedTest.java
+++ b/src/test/java/gololang/PredefinedTest.java
@@ -93,21 +93,21 @@ public class PredefinedTest {
   }
 
   @Test
-  public void test_reversed_range() {
-    assertThat(Predefined.reversed_range(10, 1), instanceOf(IntRange.class));
-    assertThat(Predefined.reversed_range(10, 1L), instanceOf(LongRange.class));
-    assertThat(Predefined.reversed_range(10L, 1), instanceOf(LongRange.class));
-    assertThat(Predefined.reversed_range(10L, 1L), instanceOf(LongRange.class));
-    assertThat(Predefined.reversed_range(10), instanceOf(IntRange.class));
-    assertThat(Predefined.reversed_range(10L), instanceOf(LongRange.class));
-    assertThat(Predefined.reversed_range(10), is(Predefined.reversed_range(10, 0)));
-    assertThat(Predefined.reversed_range(10L), is(Predefined.reversed_range(10L, 0L)));
-    assertThat((IntRange)Predefined.reversed_range(5, 1), is(((IntRange)Predefined.range(5, 1)).incrementBy(-1)));
-    assertThat((LongRange)Predefined.reversed_range(5L, 1L), is(((LongRange)Predefined.range(5L, 1L)).incrementBy(-1)));
-    assertThat(Predefined.reversed_range('d', 'a'), instanceOf(CharRange.class));
-    assertThat(Predefined.reversed_range('D'), instanceOf(CharRange.class));
-    assertThat(Predefined.reversed_range('D'), is(Predefined.reversed_range('D', 'A')));
-    assertThat((CharRange)Predefined.reversed_range('D', 'A'), is(((CharRange)Predefined.range('D', 'A')).incrementBy(-1)));
+  public void test_reversedRange() {
+    assertThat(Predefined.reversedRange(10, 1), instanceOf(IntRange.class));
+    assertThat(Predefined.reversedRange(10, 1L), instanceOf(LongRange.class));
+    assertThat(Predefined.reversedRange(10L, 1), instanceOf(LongRange.class));
+    assertThat(Predefined.reversedRange(10L, 1L), instanceOf(LongRange.class));
+    assertThat(Predefined.reversedRange(10), instanceOf(IntRange.class));
+    assertThat(Predefined.reversedRange(10L), instanceOf(LongRange.class));
+    assertThat(Predefined.reversedRange(10), is(Predefined.reversedRange(10, 0)));
+    assertThat(Predefined.reversedRange(10L), is(Predefined.reversedRange(10L, 0L)));
+    assertThat((IntRange)Predefined.reversedRange(5, 1), is(((IntRange)Predefined.range(5, 1)).incrementBy(-1)));
+    assertThat((LongRange)Predefined.reversedRange(5L, 1L), is(((LongRange)Predefined.range(5L, 1L)).incrementBy(-1)));
+    assertThat(Predefined.reversedRange('d', 'a'), instanceOf(CharRange.class));
+    assertThat(Predefined.reversedRange('D'), instanceOf(CharRange.class));
+    assertThat(Predefined.reversedRange('D'), is(Predefined.reversedRange('D', 'A')));
+    assertThat((CharRange)Predefined.reversedRange('D', 'A'), is(((CharRange)Predefined.range('D', 'A')).incrementBy(-1)));
   }
 
   static class MyCallable {


### PR DESCRIPTION
rename `reversed_range` to `reversedRange`, and create a new
*deprecated* `reversed_range` delegating on it.