### PR TITLE
Make the range classes use a static inner class

### DIFF
--- a/src/main/java/gololang/AbstractRange.java
+++ b/src/main/java/gololang/AbstractRange.java
@@ -19,7 +19,10 @@ abstract class AbstractRange<T extends Comparable<T>> extends AbstractCollection
   private int increment = 1;
   private int cmp = 1;
 
-  abstract class RangeIterator implements Iterator<T> {
+  abstract static class RangeIterator<T extends Comparable<T>> implements Iterator<T> {
+
+    public RangeIterator() {
+    }
 
     @Override
     public void remove() {

--- a/src/main/java/gololang/CharRange.java
+++ b/src/main/java/gololang/CharRange.java
@@ -37,10 +37,10 @@ final class CharRange extends AbstractRange<Character> {
 
   @Override
   public int size() {
-    if (to() == from()) {
+    if (to().equals(from())) {
       return 0;
     }
-    final int s = ((int) to().charValue() - (int) from().charValue()) / increment();
+    final int s = ((int) to() - (int) from()) / increment();
     if (s < 0) {
       return 0;
     }
@@ -57,7 +57,7 @@ final class CharRange extends AbstractRange<Character> {
     }
     final Character obj = (Character) o;
     return encloses(obj)
-           && ((int) obj.charValue() - (int) from().charValue()) % increment() == 0;
+           && ((int) obj - (int) from()) % increment() == 0;
   }
 
   @Override
@@ -73,8 +73,8 @@ final class CharRange extends AbstractRange<Character> {
     return new AbstractRange.RangeIterator<Character>() {
 
       private boolean started = false;
-      private char current = from().charValue();
-      private char to = to().charValue();
+      private char current = from();
+      private char to = to();
 
       @Override
       public boolean hasNext() {
@@ -83,7 +83,7 @@ final class CharRange extends AbstractRange<Character> {
 
       @Override
       public Character next() {
-        final Character value = Character.valueOf(current);
+        final Character value = current;
         if (started && !hasNext()) {
           throw new NoSuchElementException("iteration has finished");
         } else {

--- a/src/main/java/gololang/CharRange.java
+++ b/src/main/java/gololang/CharRange.java
@@ -70,7 +70,7 @@ final class CharRange extends AbstractRange<Character> {
 
   @Override
   public Iterator<Character> iterator() {
-    return new AbstractRange<Character>.RangeIterator() {
+    return new AbstractRange.RangeIterator<Character>() {
 
       private boolean started = false;
       private char current = from().charValue();

--- a/src/main/java/gololang/IntRange.java
+++ b/src/main/java/gololang/IntRange.java
@@ -66,7 +66,7 @@ final class IntRange extends AbstractRange<Integer> {
 
   @Override
   public Iterator<Integer> iterator() {
-    return new AbstractRange<Integer>.RangeIterator() {
+    return new AbstractRange.RangeIterator<Integer>() {
 
       private boolean started = false;
       private int current = from();

--- a/src/main/java/gololang/IntRange.java
+++ b/src/main/java/gololang/IntRange.java
@@ -11,6 +11,7 @@ package gololang;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 final class IntRange extends AbstractRange<Integer> {
 
@@ -34,7 +35,7 @@ final class IntRange extends AbstractRange<Integer> {
 
   @Override
   public int size() {
-    if (to() == from()) {
+    if (Objects.equals(to(), from())) {
       return 0;
     }
     final int theSize = (to() - from()) / increment();

--- a/src/main/java/gololang/LongRange.java
+++ b/src/main/java/gololang/LongRange.java
@@ -11,6 +11,7 @@ package gololang;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 final class LongRange extends AbstractRange<Long> {
 
@@ -34,7 +35,7 @@ final class LongRange extends AbstractRange<Long> {
 
   @Override
   public int size() {
-    if (to() == from()) {
+    if (Objects.equals(to(), from())) {
       return 0;
     }
     final int theSize = (int) ((to() - from()) / increment());

--- a/src/main/java/gololang/LongRange.java
+++ b/src/main/java/gololang/LongRange.java
@@ -66,7 +66,7 @@ final class LongRange extends AbstractRange<Long> {
 
   @Override
   public Iterator<Long> iterator() {
-    return new AbstractRange<Long>.RangeIterator() {
+    return new AbstractRange.RangeIterator<Long>() {
 
       private boolean started = false;
       private long current = from();


### PR DESCRIPTION
This is generally better to use static vs instance-attached inner classes (performance, GC, etc).

Another point is that this makes the Eclipse compiler happy due to a bug it has.