### PR TITLE
Fix: the same parsing error appears multiple times

### DIFF
--- a/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
+++ b/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
@@ -40,11 +40,16 @@ public class GoloParser {
 
   public GoloCompilationException.Builder exceptionBuilder;
 
+  private boolean errorAlreadyReported = false;
+
   void skipto(int kind, ParseException e, GoloASTNode node) throws ParseException {
     if (exceptionBuilder == null) {
       throw e;
     }
-    exceptionBuilder.report(e, node);
+    if (!errorAlreadyReported) {
+      exceptionBuilder.report(e, node);
+      errorAlreadyReported = true;
+    }
     if ("<EOF>".equals(e.tokenImage[0])) {
       return;
     }


### PR DESCRIPTION
The same parsing error appears multiple times.

as example:

```golo
module test

function main = |args| {
  # missing double quote
  let a = "aBc
}
```

prints 3 times the same error:

```
[error] In Golo module: test.golo
[error] Encountered unexpected  <INVALID> `\"`  at line 5, column 11
[error] Encountered unexpected  <INVALID> `\"`  at line 5, column 11
[error] Encountered unexpected  <INVALID> `\"`  at line 5, column 11
```