### PR TITLE
Change implicit import order

### DIFF
--- a/doc/augmentations.asciidoc
+++ b/doc/augmentations.asciidoc
@@ -251,7 +251,7 @@ The augmentations resolution order is as follows:
    using the same order than locally applied ones, in the importation order.
 
 The first matching method found is used. It is thus possible to “override” an
-augmentation with a more higher priority one (in the sens of the previous order). xref:implicit_imports[Implicit modules] are imported after explicit ones to allow to redefined standard augmentations.
+augmentation with a more higher priority one (in the sens of the previous order). xref:implicit_imports[Implicit modules] are imported after explicit ones to allow to redefine standard augmentations.
 
 TIP: Since importing a module imports all the applied augmentations, and given
 the somewhat complex resolution order when involving simple and named

--- a/doc/augmentations.asciidoc
+++ b/doc/augmentations.asciidoc
@@ -230,7 +230,6 @@ with the previous `FooBar` augmentation will raise
 `java.lang.NoSuchMethodError: class java.lang.Integer::length`
 at *runtime* when trying to call `1:bar(1)`. Calling `1:foo()` will be OK however.
 
-
 === Augmentations Resolution Order
 
 The augmentations resolution order is as follows:
@@ -252,7 +251,7 @@ The augmentations resolution order is as follows:
    using the same order than locally applied ones, in the importation order.
 
 The first matching method found is used. It is thus possible to “override” an
-augmentation with a more higher priority one (in the sens of the previous order).
+augmentation with a more higher priority one (in the sens of the previous order). xref:implicit_imports[Implicit modules] are imported after explicit ones to allow to redefined standard augmentations.
 
 TIP: Since importing a module imports all the applied augmentations, and given
 the somewhat complex resolution order when involving simple and named

--- a/doc/functions.asciidoc
+++ b/doc/functions.asciidoc
@@ -144,7 +144,7 @@ post(
 
 NOTE: Once you are using named parameters in your function call, the order doesn't matter anymore.
 
-Note: To name varargs argument, you have be box the values into an `array[]` (just has it's done with the `tags` argument in the above snippet)
+NOTE: To name varargs argument, you have be box the values into an `array[]` (just has it's done with the `tags` argument in the above snippet)
 
 CAUTION: You must name either or none of the arguments. A compilation error will be raised, if you mix named an unamed arguments in a function invocation.
 
@@ -207,12 +207,15 @@ function plop = {
 }
 ----
 
+[[implicit_imports]]
 Golo modules have a set of implicit imports:
 
 * `gololang.Predefined`,
 * `gololang.StandardAugmentations`,
 * `gololang`,
 * `java.lang`.
+
+These modules are imported *after* the module explicitly imported in the module, so that elements defined in these modules (e.g. predefined functions or xref:_augmentations_resolution_order[augmentations]) can be redefined.
 
 === Local functions
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
@@ -48,7 +48,6 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
     super();
     this.packageAndClass = name;
     this.globalReferences = references;
-    imports.addAll(DEFAULT_IMPORTS);
   }
 
   @Override
@@ -62,7 +61,9 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
   }
 
   public Set<ModuleImport> getImports() {
-    return unmodifiableSet(imports);
+    Set<ModuleImport> imp = new LinkedHashSet<>(imports);
+    imp.addAll(DEFAULT_IMPORTS);
+    return imp;
   }
 
   public Collection<Augmentation> getAugmentations() {


### PR DESCRIPTION
Import explicit modules *before* implicit ones (e.g.
`gololang.StandardAugmentations`) such that we can for instance redefine
standard augmentations.

When a type is augmented several times with the same method, the first one is used, that is the one defined in the first imported module.
This is ok, since you can “override” an augmentation by changing the import order. However, since some modules are implicitly imported first (e.g. `StandardAugmentations`), it is not possible to redefine augmentations specified in these modules, i.e. one can’t redefine standard augmentations. 

This limit the usefulness of augmentations. For instance, suppose one want to define a `reduce` method on a specific `struct`. Since a `struct` is a subclass of `GoloStruct`, that implements `Iterable`, and since `Iterable` already has a `reduce` augmentation in `StandardAugmentations`, one can’t define this specific method on the `struc`. This solution simply import implicit modules after the explicit ones. 
Thus, the “user defined” augmentations defined in explicitly imported modules are used, the standard augmentations beeing used as a “fallback” if no other augmentation is defined in the current (or imported) module.