### PR TITLE
New syntax to specify arity in function literals

### DIFF
--- a/doc/closures.asciidoc
+++ b/doc/closures.asciidoc
@@ -283,6 +283,17 @@ function call_foo = {
 }
 ----
 
+In this case, one can even specify if a varargs function is needed or not (since arity alone can be ambiguous) using final `...`:
+
+[source,golo]
+----
+local function foo = |a| -> "unary"
+local function foo = |a...| -> "variable"
+
+^foo\1(null) # unary
+^foo\1...()  # variable
+----
+
 Note that you can in the same way get a reference to a Java static method. For
 instance:
 

--- a/doc/closures.asciidoc
+++ b/doc/closures.asciidoc
@@ -269,6 +269,20 @@ function call_local_fun = {
 }
 ----
 
+If the function is overridden, that is several functions exist with the same name but different arities, 
+you *must* specify the arity with the notation `^moduleName::functionName\arity`. For instance:
+
+[source,golo]
+----
+local function foo = |a, b| -> a * b
+
+local function foo = |x| -> x + 1
+
+function call_foo = {
+  return ^foo\2(^foo\1(20), 2)
+}
+----
+
 Note that you can in the same way get a reference to a Java static method. For
 instance:
 

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -165,7 +165,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
             classRef(ref.module == null
               ? this.module.getPackageAndClass()
               : ref.module),
-            constant(-1));
+            constant(ref.arity));
       constantStatement.replaceInParentBy(fun);
       fun.accept(this);
       return;

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -165,7 +165,8 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
             classRef(ref.module == null
               ? this.module.getPackageAndClass()
               : ref.module),
-            constant(ref.arity));
+            constant(ref.arity),
+            constant(ref.varargs));
       constantStatement.replaceInParentBy(fun);
       fun.accept(this);
       return;

--- a/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
@@ -180,7 +180,15 @@ public final class Builders {
   }
 
   public static ConstantStatement functionRef(Object moduleName, Object funcName, Object arity) {
-    return constant(new GoloParser.FunctionRef((String) moduleName, (String) funcName, (Integer) arity));
+    return functionRef(moduleName, funcName, -1, false);
+  }
+
+  public static ConstantStatement functionRef(Object moduleName, Object funcName, Object arity, Object varargs) {
+    return constant(new GoloParser.FunctionRef(
+          (String) moduleName,
+          (String) funcName,
+          (Integer) arity,
+          (Boolean) varargs));
   }
 
   public static ReturnStatement returns(Object expr) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
@@ -172,11 +172,15 @@ public final class Builders {
   }
 
   public static ConstantStatement functionRef(Object funcName) {
-    return functionRef(null, funcName);
+    return functionRef(null, funcName, -1);
   }
 
   public static ConstantStatement functionRef(Object moduleName, Object funcName) {
-    return constant(new GoloParser.FunctionRef((String) moduleName, (String) funcName));
+    return functionRef(moduleName, funcName, -1);
+  }
+
+  public static ConstantStatement functionRef(Object moduleName, Object funcName, Object arity) {
+    return constant(new GoloParser.FunctionRef((String) moduleName, (String) funcName, (Integer) arity));
   }
 
   public static ReturnStatement returns(Object expr) {

--- a/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
+++ b/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
@@ -78,18 +78,22 @@ public class GoloParser {
     public String module;
     public String name;
     public int arity;
+    public boolean varargs;
 
-    public FunctionRef(String module, String name, int arity) {
+    public FunctionRef(String module, String name, int arity, boolean varargs) {
       this.module = module;
       this.name = name;
       this.arity = arity;
+      this.varargs = varargs;
     }
 
     @Override
     public String toString() {
       return "FunctionRef{module=" + module
                           + ",name=" + name
-                          + ",arity=" + arity + "}";
+                          + ",arity=" + arity 
+                          + (varargs ? ",varargs" : "")
+                          + "}";
     }
   }
 }
@@ -245,7 +249,7 @@ TOKEN :
   |
   < CLASSREF: <IDENTIFIER> ("." <IDENTIFIER>)* (".class" | ".module") >
   |
-  < FUNREF: "^" (<IDENTIFIER> ("." <IDENTIFIER>)* "::")? <IDENTIFIER> ("\\" <NUMBER>)?>
+  < FUNREF: "^" (<IDENTIFIER> ("." <IDENTIFIER>)* "::")? <IDENTIFIER> ("\\" <NUMBER>("...")?)?>
   |
   < COLL_START: ("array" | "list" | "set" | "map" | "vector" | "tuple" )? "[" >
 }
@@ -627,6 +631,7 @@ GoloParser.FunctionRef FunctionRef() #void:
     String module = null;
     String name;
     int arity = -1;
+    boolean varargs = false;
     String[] parts = literal.image.substring(1).split("::");
     if (parts.length > 1) {
       module = parts[0];
@@ -637,9 +642,14 @@ GoloParser.FunctionRef FunctionRef() #void:
     parts = name.split("\\\\");
     if (parts.length > 1) {
       name = parts[0];
-      arity = Integer.valueOf(parts[1]);
+      if (parts[1].endsWith("...")) {
+        arity = Integer.valueOf(parts[1].substring(0, parts[1].length() - 3));
+        varargs = true;
+      } else {
+        arity = Integer.valueOf(parts[1]);
+      }
     }
-    return new GoloParser.FunctionRef(module, name, arity);
+    return new GoloParser.FunctionRef(module, name, arity, varargs);
   }
 }
 

--- a/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
+++ b/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
@@ -77,15 +77,19 @@ public class GoloParser {
 
     public String module;
     public String name;
+    public int arity;
 
-    public FunctionRef(String module, String name) {
+    public FunctionRef(String module, String name, int arity) {
       this.module = module;
       this.name = name;
+      this.arity = arity;
     }
 
     @Override
     public String toString() {
-      return "FunctionRef{module=" + module + ",name=" + name + "}";
+      return "FunctionRef{module=" + module
+                          + ",name=" + name
+                          + ",arity=" + arity + "}";
     }
   }
 }
@@ -241,7 +245,7 @@ TOKEN :
   |
   < CLASSREF: <IDENTIFIER> ("." <IDENTIFIER>)* (".class" | ".module") >
   |
-  < FUNREF: "^" (<IDENTIFIER> ("." <IDENTIFIER>)* "::")? <IDENTIFIER> >
+  < FUNREF: "^" (<IDENTIFIER> ("." <IDENTIFIER>)* "::")? <IDENTIFIER> ("\\" <NUMBER>)?>
   |
   < COLL_START: ("array" | "list" | "set" | "map" | "vector" | "tuple" )? "[" >
 }
@@ -620,13 +624,22 @@ GoloParser.FunctionRef FunctionRef() #void:
 {
   literal=<FUNREF>
   {
-    String image = literal.image.substring(1);
-    String[] parts = image.split("::");
+    String module = null;
+    String name;
+    int arity = -1;
+    String[] parts = literal.image.substring(1).split("::");
     if (parts.length > 1) {
-      return new GoloParser.FunctionRef(parts[0], parts[1]);
+      module = parts[0];
+      name = parts[1];
     } else {
-      return new GoloParser.FunctionRef(null, parts[0]);
+      name = parts[0];
     }
+    parts = name.split("\\\\");
+    if (parts.length > 1) {
+      name = parts[0];
+      arity = Integer.valueOf(parts[1]);
+    }
+    return new GoloParser.FunctionRef(module, name, arity);
   }
 }
 

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -911,6 +911,9 @@ public class CompileAndRunTest {
     Method call_varargs_overloaded_fun = moduleClass.getMethod("call_varargs_overloaded_fun");
     assertThat((Tuple) call_varargs_overloaded_fun.invoke(null), is(equalTo(new Tuple("p", "pv"))));
 
+    Method call_varargs_overloaded_fun_literal = moduleClass.getMethod("call_varargs_overloaded_fun_literal");
+    assertThat((Tuple) call_varargs_overloaded_fun_literal.invoke(null), is(equalTo(new Tuple("p", "pv"))));
+
     Method call_java_method_literal = moduleClass.getMethod("call_java_method_literal");
     assertThat((List) call_java_method_literal.invoke(null), is(equalTo(asList(5, 7, 3, 3))));
 

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -866,6 +866,12 @@ public class CompileAndRunTest {
     Method call_local_overloaded_fun_with_arity2 = moduleClass.getMethod("call_local_overloaded_fun_with_arity2");
     assertThat((Integer) call_local_overloaded_fun_with_arity2.invoke(null), is(3));
 
+    Method call_local_overloaded_fun_literal_with_arity1 = moduleClass.getMethod("call_local_overloaded_fun_literal_with_arity1");
+    assertThat((Integer) call_local_overloaded_fun_literal_with_arity1.invoke(null), is(3));
+
+    Method call_local_overloaded_fun_literal_with_arity2 = moduleClass.getMethod("call_local_overloaded_fun_literal_with_arity2");
+    assertThat((Integer) call_local_overloaded_fun_literal_with_arity2.invoke(null), is(3));
+
     Method call_local_overloaded_fun_without_arity = moduleClass.getMethod("call_local_overloaded_fun_without_arity");
     try {
       call_local_overloaded_fun_without_arity.invoke(null);

--- a/src/test/resources/for-execution/closures.golo
+++ b/src/test/resources/for-execution/closures.golo
@@ -147,6 +147,13 @@ function call_varargs_overloaded_fun = {
   return [f(1), fv(1)]
 }
 
+function call_varargs_overloaded_fun_literal = {
+  let f = ^plop\1
+  let fv = ^plop\1...
+  return [f(1), fv(1)]
+}
+
+
 function call_local_overloaded_fun_literal_with_arity1 = {
   let f = ^golotest.execution.Closures::local_overloaded_fun\1
   return f(2)

--- a/src/test/resources/for-execution/closures.golo
+++ b/src/test/resources/for-execution/closures.golo
@@ -147,6 +147,16 @@ function call_varargs_overloaded_fun = {
   return [f(1), fv(1)]
 }
 
+function call_local_overloaded_fun_literal_with_arity1 = {
+  let f = ^golotest.execution.Closures::local_overloaded_fun\1
+  return f(2)
+}
+
+function call_local_overloaded_fun_literal_with_arity2 = {
+  let f = ^golotest.execution.Closures::local_overloaded_fun\2
+  return f(1, 2)
+}
+
 function nested_closures = {
   let s = "plop"
   let f1 = |x| -> x

--- a/src/test/resources/for-parsing-and-compilation/closures.golo
+++ b/src/test/resources/for-parsing-and-compilation/closures.golo
@@ -60,6 +60,9 @@ function k = {
 function l = {
   let f1 = ^k
   let f2 = ^foo.bar::baz
+  let f3 = ^plop\3
+  let f4 = ^my.module::plop\2
+  let f5 = ^plop\1...
 }
 
 function m = {


### PR DESCRIPTION
Introduces a extended notation for function reference literals that
allows to specify the arity of the function.

The general syntax is `^package.module.::function\arity`

Example:

```golo
function foo = |a, b| -> a * b

function foo = |x| -> x + 1

function call_foo = {
  return ^foo\2(^foo\1(20), 2)
}
```