### PR TITLE
Fix: issues when mixing module state and closures

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/ClosureCaptureGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ClosureCaptureGoloIrVisitor.java
@@ -13,8 +13,6 @@ import org.eclipse.golo.compiler.ir.*;
 
 import java.util.*;
 
-// TODO: don't capture module state variables
-
 class ClosureCaptureGoloIrVisitor extends AbstractGoloIrVisitor {
 
   private static final class Context {

--- a/src/main/java/org/eclipse/golo/compiler/ClosureCaptureGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ClosureCaptureGoloIrVisitor.java
@@ -139,7 +139,7 @@ class ClosureCaptureGoloIrVisitor extends AbstractGoloIrVisitor {
   public void visitBlock(Block block) {
     pushBlockTable(block);
     definedInBlock(block.getReferenceTable().ownedSymbols(), block);
-    super.visitBlock(block);
+    block.walk(this);
     dropBlockTable();
   }
 
@@ -206,7 +206,7 @@ class ClosureCaptureGoloIrVisitor extends AbstractGoloIrVisitor {
 
   @Override
   public void visitClosureReference(ClosureReference closureReference) {
-    closureReference.getTarget().accept(this);
+    closureReference.walk(this);
     if (closureReference.getTarget().isSynthetic()) {
       Context context = context();
       if (context != null) {

--- a/src/main/java/org/eclipse/golo/compiler/ClosureCaptureGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ClosureCaptureGoloIrVisitor.java
@@ -13,6 +13,8 @@ import org.eclipse.golo.compiler.ir.*;
 
 import java.util.*;
 
+// TODO: don't capture module state variables
+
 class ClosureCaptureGoloIrVisitor extends AbstractGoloIrVisitor {
 
   private static final class Context {
@@ -23,11 +25,11 @@ class ClosureCaptureGoloIrVisitor extends AbstractGoloIrVisitor {
     final Map<String, Block> definingBlock = new HashMap<>();
     final Deque<ReferenceTable> referenceTableStack = new LinkedList<>();
 
-    Set<String> shouldBeArguments() {
+    Set<String> shouldBeParameters() {
       Set<String> result = new HashSet<>();
-      for (String ref : accessedReferences) {
-        if (!localReferences.contains(ref)) {
-          result.add(ref);
+      for (String refName : accessedReferences) {
+        if (!localReferences.contains(refName)) {
+          result.add(refName);
         }
       }
       return result;
@@ -109,12 +111,13 @@ class ClosureCaptureGoloIrVisitor extends AbstractGoloIrVisitor {
       declaredParameters(function.getParameterNames());
       function.getBlock().internReferenceTable();
       function.walk(this);
-      makeArguments(function, context().shouldBeArguments());
+      function.addSyntheticParameters(context().shouldBeParameters());
       dropUnused(context().shouldBeRemoved());
       dropContext();
     } else {
       function.walk(this);
     }
+    function.captureClosedReference();
   }
 
   private void dropUnused(Set<String> refs) {
@@ -122,15 +125,6 @@ class ClosureCaptureGoloIrVisitor extends AbstractGoloIrVisitor {
     for (String ref : refs) {
       if (!context.parameterReferences.contains(ref)) {
         context.definingBlock.get(ref).getReferenceTable().remove(ref);
-      }
-    }
-  }
-
-  private void makeArguments(GoloFunction function, Set<String> refs) {
-    Set<String> existing = new HashSet<>(function.getParameterNames());
-    for (String ref : refs) {
-      if (!existing.contains(ref) && !ref.equals(function.getSyntheticSelfName())) {
-        function.addSyntheticParameter(ref);
       }
     }
   }
@@ -173,11 +167,7 @@ class ClosureCaptureGoloIrVisitor extends AbstractGoloIrVisitor {
     assignmentStatement.getExpressionStatement().accept(this);
     if (assignmentStatement.getExpressionStatement() instanceof ClosureReference) {
       ClosureReference closure = (ClosureReference) assignmentStatement.getExpressionStatement();
-      GoloFunction target = closure.getTarget();
-      if (target.getSyntheticParameterNames().contains(referenceName)) {
-        target.removeSyntheticParameter(referenceName);
-        target.setSyntheticSelfName(referenceName);
-      }
+      closure.getTarget().setSyntheticSelfName(referenceName);
     }
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
@@ -86,20 +86,7 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
       }
     }
     function.walk(this);
-    captureClosedReference(function);
     functionStack.pop();
-  }
-
-  private void captureClosedReference(GoloFunction function) {
-    String selfName = function.getSyntheticSelfName();
-    if (function.isSynthetic() && selfName != null) {
-      LocalReference self = function.getBlock().getReferenceTable().get(selfName);
-      ClosureReference closureReference = function.asClosureReference();
-      for (String syntheticRef : function.getSyntheticParameterNames()) {
-        closureReference.addCapturedReferenceName(syntheticRef);
-      }
-      function.getBlock().prependStatement(Builders.assign(closureReference).to(self));
-    }
   }
 
   @Override
@@ -236,10 +223,7 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
 
   @Override
   public void visitClosureReference(ClosureReference closureReference) {
-    GoloFunction target = closureReference.getTarget();
-    for (String name : target.getSyntheticParameterNames()) {
-      closureReference.addCapturedReferenceName(name);
-    }
+    closureReference.updateCapturedReferenceNames();
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -320,6 +320,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
       context.push(function.asClosureReference());
     } else {
       context.addFunction(function);
+      context.pop();
     }
     return data;
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
@@ -31,14 +31,17 @@ public class ClosureReference extends ExpressionStatement {
     this.target = target;
     makeParentOf(target);
     this.setASTNode(target.getASTNode());
+    updateCapturedReferenceNames();
   }
 
   public Set<String> getCapturedReferenceNames() {
     return Collections.unmodifiableSet(capturedReferenceNames);
   }
 
-  public boolean addCapturedReferenceName(String referenceName) {
-    return capturedReferenceNames.add(referenceName);
+  public void updateCapturedReferenceNames() {
+    for (String name : target.getSyntheticParameterNames()) {
+      capturedReferenceNames.add(name);
+    }
   }
 
   public ClosureReference block(Object... statements) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
@@ -227,7 +227,10 @@ public final class GoloFunction extends ExpressionStatement implements Scope {
     Set<String> existing = new HashSet<>(getParameterNames());
     for (String name : names) {
       if (!existing.contains(name) && !name.equals(syntheticSelfName)) {
-        this.syntheticParameterNames.add(name);
+        LocalReference ref = block.getReferenceTable().get(name);
+        if (ref == null || !ref.isModuleState()) {
+          this.syntheticParameterNames.add(name);
+        }
       }
     }
   }

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -1678,6 +1678,14 @@ public class CompileAndRunTest {
   }
 
   @Test
+  public void module_state_closures() throws Throwable {
+    Class<?> moduleClass = compileAndLoadGoloModule(SRC, "module-state-closures.golo");
+    Method test = moduleClass.getMethod("test");
+    Object result = test.invoke(null);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
   public void decorators() throws Throwable {
 
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "decorators.golo");

--- a/src/test/resources/for-execution/module-state-closures.golo
+++ b/src/test/resources/for-execution/module-state-closures.golo
@@ -28,21 +28,21 @@ let CALL_FUNREF = identity(^foo)
 # Module state can be closure on other module state
 let CLOSED_FUNREF = addCurry(CONSTANT_VALUE)
 
-# FIXME: Module state can be a lambda
-# let CONSTANT_CONSTANT_LAMBDA = -> 42
-# let CALL_CONSTANT_LAMBDA = identity(-> 42)
-# let CONSTANT_LAMBDA = |x| -> 2 * x
-# let CALL_LAMBDA = identity(|x| -> 2 * x)
+# Module state can be a lambda
+let CONSTANT_CONSTANT_LAMBDA = -> 42
+let CALL_CONSTANT_LAMBDA = identity(-> 42)
+let CONSTANT_LAMBDA = |x| -> 2 * x
+let CALL_LAMBDA = identity(|x| -> 2 * x)
 
-# FIXME: Module state can be curryfied function
-# let CONSTANT_CURRY = |x| -> |y| -> x + y
-# let CALL_CURRY = identity(|x| -> |y| -> x + y)
+# Module state can be curryfied function
+let CONSTANT_CURRY = |x| -> |y| -> x + y
+let CALL_CURRY = identity(|x| -> |y| -> x + y)
 
-# FIXME: Module state can be a closure
-# let CONSTANT_CONSTANT_CLOSURE = -> CONSTANT_VALUE
-# let CALL_CONSTANT_CLOSURE = identity(-> CONSTANT_VALUE)
-# let CONSTANT_CLOSURE = |x| -> x + CONSTANT_VALUE
-# let CALL_CLOSURE = identity(|x| -> x + CONSTANT_VALUE)
+# Module state can be a closure
+let CONSTANT_CONSTANT_CLOSURE = -> CONSTANT_VALUE
+let CALL_CONSTANT_CLOSURE = identity(-> CONSTANT_VALUE)
+let CONSTANT_CLOSURE = |x| -> x + CONSTANT_VALUE
+let CALL_CLOSURE = identity(|x| -> x + CONSTANT_VALUE)
 
 function test = {
   # just check utility functions
@@ -78,21 +78,21 @@ function test = {
   require(CALL_FUNREF(1) == 43, "err")
   require(CLOSED_FUNREF(1) == 43, "err")
   
-  # FIXME: A module state containing a lambda can be called
-  # require(CONSTANT_CONSTANT_LAMBDA() == 42, "err")
-  # require(CALL_CONSTANT_LAMBDA() == 42, "err")
-  # require(CONSTANT_LAMBDA(21) == 42, "err")
-  # require(CALL_LAMBDA(21) == 42, "err")
+  # A module state containing a lambda can be called
+  require(CONSTANT_CONSTANT_LAMBDA() == 42, "err")
+  require(CALL_CONSTANT_LAMBDA() == 42, "err")
+  require(CONSTANT_LAMBDA(21) == 42, "err")
+  require(CALL_LAMBDA(21) == 42, "err")
 
-  # FIXME: A module state containing a curryfied function can be called
-  # require(CONSTANT_CURRY(21)(21) == 42, "err")
-  # require(CALL_CURRY(21)(21) == 42, "err")
+  # A module state containing a curryfied function can be called
+  require(CONSTANT_CURRY(21)(21) == 42, "err")
+  require(CALL_CURRY(21)(21) == 42, "err")
   
-  # FIXME: A module state containing a closure can be called
-  # require(CONSTANT_CONSTANT_CLOSURE() == 42, "err")
-  # require(CALL_CONSTANT_CLOSURE() == 42, "err")
-  # require(CONSTANT_CLOSURE(1) == 43, "err")
-  # require(CALL_CLOSURE(1) == 43, "err")
+  # A module state containing a closure can be called
+  require(CONSTANT_CONSTANT_CLOSURE() == 42, "err")
+  require(CALL_CONSTANT_CLOSURE() == 42, "err")
+  require(CONSTANT_CLOSURE(1) == 43, "err")
+  require(CALL_CLOSURE(1) == 43, "err")
 }
 
 

--- a/src/test/resources/for-execution/module-state-closures.golo
+++ b/src/test/resources/for-execution/module-state-closures.golo
@@ -1,0 +1,102 @@
+
+module golotest.execution.ModuleStateClosures
+
+# Utility functions
+local function identity = |x| -> x
+local function addCurry = |x| -> |y| -> x + y
+
+# One can define a constant value as a module state
+let CONSTANT_VALUE = 42
+
+# One can assign an expression to a module state
+let CONSTANT_EXPR = 21 + 21
+
+# One can set a module state from a function result
+let CONSTANT_CALL_CONSTANT = identity(42)
+
+# Module state can be used in a regular function
+local function foo = |x| -> x + CONSTANT_VALUE
+
+# Module state can  be used in a closure (curry)
+local function bar = |x| -> |y| -> x + y + CONSTANT_VALUE
+
+# Module state can be a function ref
+let CONSTANT_FUNREF = ^foo
+let CONSTANT_REF_CURRY = ^addCurry
+let CALL_FUNREF = identity(^foo)
+
+# Module state can be closure on other module state
+let CLOSED_FUNREF = addCurry(CONSTANT_VALUE)
+
+# FIXME: Module state can be a lambda
+# let CONSTANT_CONSTANT_LAMBDA = -> 42
+# let CALL_CONSTANT_LAMBDA = identity(-> 42)
+# let CONSTANT_LAMBDA = |x| -> 2 * x
+# let CALL_LAMBDA = identity(|x| -> 2 * x)
+
+# FIXME: Module state can be curryfied function
+# let CONSTANT_CURRY = |x| -> |y| -> x + y
+# let CALL_CURRY = identity(|x| -> |y| -> x + y)
+
+# FIXME: Module state can be a closure
+# let CONSTANT_CONSTANT_CLOSURE = -> CONSTANT_VALUE
+# let CALL_CONSTANT_CLOSURE = identity(-> CONSTANT_VALUE)
+# let CONSTANT_CLOSURE = |x| -> x + CONSTANT_VALUE
+# let CALL_CLOSURE = identity(|x| -> x + CONSTANT_VALUE)
+
+function test = {
+  # just check utility functions
+  require(identity(42) == 42, "err")
+  require(addCurry(21)(21) == 42, "err")
+  let plus21 = addCurry(21)
+  require(plus21(21) == 42, "err")
+
+  # A constant module state can be accessed
+  require(CONSTANT_VALUE == 42, "err")
+  require(CONSTANT_EXPR == 42, "err")
+  require(CONSTANT_CALL_CONSTANT == 42, "err")
+
+  # A constant module state can be used in functions
+  require(foo(1) == 43, "err")
+
+  # A constant module state can be used as closed variable locally
+  require(addCurry(CONSTANT_VALUE)(1) == 43, "err")
+  require(addCurry(1)(CONSTANT_VALUE) == 43, "err")
+
+  # A constant module state can be used in static closures
+  let f = |x| -> x + CONSTANT_VALUE
+  require(f(1) == 43, "err")
+
+  # A constant module state can be used in generated closures (curry)
+  let g = bar(1)
+  require(g(-1) == 42, "err")
+  require(bar(2)(-2) == 42, "err")
+
+  # A module state containing a function ref can be called
+  require(CONSTANT_FUNREF(1) == 43, "err")
+  require(CONSTANT_REF_CURRY(21)(21) == 42, "err")
+  require(CALL_FUNREF(1) == 43, "err")
+  require(CLOSED_FUNREF(1) == 43, "err")
+  
+  # FIXME: A module state containing a lambda can be called
+  # require(CONSTANT_CONSTANT_LAMBDA() == 42, "err")
+  # require(CALL_CONSTANT_LAMBDA() == 42, "err")
+  # require(CONSTANT_LAMBDA(21) == 42, "err")
+  # require(CALL_LAMBDA(21) == 42, "err")
+
+  # FIXME: A module state containing a curryfied function can be called
+  # require(CONSTANT_CURRY(21)(21) == 42, "err")
+  # require(CALL_CURRY(21)(21) == 42, "err")
+  
+  # FIXME: A module state containing a closure can be called
+  # require(CONSTANT_CONSTANT_CLOSURE() == 42, "err")
+  # require(CALL_CONSTANT_CLOSURE() == 42, "err")
+  # require(CONSTANT_CLOSURE(1) == 43, "err")
+  # require(CALL_CLOSURE(1) == 43, "err")
+}
+
+
+function main = |args| {
+  test()
+  println("ok")
+}


### PR DESCRIPTION
Their was some issues when mixing module state and closure:
- when a local closure used a module state value, it was captured, causing runtime errors
- when a module state containing a closure was defined after a regular functions, the reference tables was merged, causing compilation errors

This PR fixes both issues.