### PR TITLE
Make structures comparable

### DIFF
--- a/doc/structs.asciidoc
+++ b/doc/structs.asciidoc
@@ -167,6 +167,44 @@ p3 == p4 true
 TIP: It is recommended that you use `Immutable<name of struct>(...)` or `frozenCopy()` when you can,
 especially when storing values into collections.
 
+=== Comparison semantics
+
+Golo structures are comparable with structures of the same type, provided that their members are comparable pairwise. Two structure are compared by comparing their members lexicographically, that is pairwise in the order they are defined.
+
+For instance, the following listing:
+
+[source,golo]
+----
+module test
+
+struct Triplet = {x, y, z}
+
+struct Other = {x, y, z}
+
+function main = |args| {
+
+  let t1 = Triplet(1, 2, 3)
+  let t2 = Triplet(1, 3, 2)
+  let o = Other(1, 2, 4)
+
+  println(t1 < t2)
+  println(t1: values() < o: values())
+  println(t1 < o)
+}
+----
+
+will output:
+
+[source]
+----
+true
+true
+Exception in thread "main" java.lang.ClassCastException: struct Triplet{x=1, y=2, z=3} and struct Other{x=1, y=2, z=4} can't be compared
+----
+
+even if `Triplet` and `Other` have the same members.
+
+
 === Helper methods
 
 A number of helper methods are being generated:

--- a/src/main/java/gololang/GoloStruct.java
+++ b/src/main/java/gololang/GoloStruct.java
@@ -16,7 +16,7 @@ import java.util.Iterator;
  * <p>
  * This class defines common behavior. Golo structure classes are final subclasses of this one.
  */
-public abstract class GoloStruct implements Iterable<Tuple> {
+public abstract class GoloStruct implements Iterable<Tuple>, Comparable<GoloStruct>  {
 
   /**
    * The array of member names, initialized in Golo structure classes constructors.
@@ -60,6 +60,43 @@ public abstract class GoloStruct implements Iterable<Tuple> {
    */
   public Tuple destruct() {
     return values();
+  }
+
+  /**
+   * Compares this structure with the specified structure for order.
+   * <p>Returns a negative integer, zero, or a positive integer as this structure is less than,
+   * equal to, or greater than the specified structure.
+   * <p>Two structures are compared by comparing their {@link #values()}, thus the
+   * limitations of {@link gololang.Tuple#compareTo} also apply.
+   * <p>Moreover, two structures are only comparable if they have the same type. For instance,
+   * given
+   * <code><pre>
+   * struct StructA = {x, y}
+   * struct StructB = {a, b}
+   *
+   * let aStructA = StructA(1, 2)
+   * let aStructB = StructB(1, 3)
+   * </pre></code>
+   * while {@code aStructA: values() < aStructB: values()} is valid and true since we compare two
+   * 2-tuples, comparing directly the structures {@code aStructA < aStructB} throws a
+   * {@link java.lang.ClassCastException}.
+   *
+   * @param other the structure to be compared
+   * @return a negative integer, zero, or a positive integer as this structure is less than, equal to, or greater than the specified structure
+   * @throws NullPointerException if the specified structure is null
+   * @throws ClassCastException  if the structure are of different type, of if the type of the members prevent them from being compared pairwise
+   * @since Golo3.1
+   */
+  @Override
+  public int compareTo(GoloStruct other) {
+    if (this.equals(other)) {
+      return 0;
+    }
+    if (getClass() != other.getClass()) {
+      throw new ClassCastException(String.format(
+            "%s and %s can't be compared; try to compare their values", this, other));
+    }
+    return this.values().compareTo(other.values());
   }
 
   /**

--- a/src/main/java/gololang/Tuple.java
+++ b/src/main/java/gololang/Tuple.java
@@ -133,7 +133,7 @@ public final class Tuple implements HeadTail<Object>, Comparable<Tuple> {
    *
    * @param other the tuple to be compared.
    * @return a negative integer, zero, or a positive integer as this tuple is less than, equal to, or greater than the specified tuple.
-   * @throws NullPointerException if the specified tuple is null
+   * @throws NullPointerException if the specified tuple is null.
    * @throws ClassCastException  if the type of the elements in the specified tuple prevent them from being compared to this tuple elements.
    * @throws IllegalArgumentException if the specified tuple has a different size than this tuple.
    */

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -1427,6 +1427,36 @@ public class CompileAndRunTest {
   }
 
   @Test
+  public void structs_comparison() throws Throwable {
+    Class<?> moduleClass = compileAndLoadGoloModule(SRC, "structs.golo");
+    Method test_method;
+    Object result;
+
+    test_method = moduleClass.getMethod("check_compare");
+    result = test_method.invoke(null);
+    assertThat(result, notNullValue());
+    assertThat((Boolean) result, is(true));
+
+    test_method = moduleClass.getMethod("check_equals");
+    result = test_method.invoke(null);
+    assertThat(result, notNullValue());
+    assertThat((Boolean) result, is(true));
+  }
+
+  @Test
+  public void structs_not_comparable() throws Throwable {
+    Class<?> moduleClass = compileAndLoadGoloModule(SRC, "structs.golo");
+    Method test_method = moduleClass.getMethod("check_not_comparable");
+    try {
+      Object result = test_method.invoke(null);
+    } catch (InvocationTargetException e) {
+      assertThat(e.getCause(), instanceOf(ClassCastException.class));
+      assertThat(e.getCause().getMessage(),
+          containsString("struct Couple{x=1, y=2} and struct Point{x=1, y=3} can't be compared"));
+    }
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   public void adapters() throws Throwable {
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "adapters.golo");

--- a/src/test/resources/for-execution/structs.golo
+++ b/src/test/resources/for-execution/structs.golo
@@ -66,3 +66,17 @@ augment Point {
 }
 
 function check_concision = -> Point(1, 2): str()
+
+# ............................................................................................... #
+
+struct Couple = { x, y }
+
+function check_compare = -> 
+  Couple(1, 2) < Couple(1, 3)
+  and Couple(1, 10) < Couple(2, 1)
+
+function check_equals = -> 
+  Couple(1, 2) != Couple(1, 2) 
+  and ImmutableCouple(1, 2) == ImmutableCouple(1, 2)
+
+function check_not_comparable = -> Couple(1, 2) < Point(1, 3)


### PR DESCRIPTION
`GoloStruct` now implement `Comparable`, by comparing their members
pairwise in lexicographical order. `Tuple::compareTo` is used, doing
`this.values.compareTo(other.values())`

This allow to directly compare structures, using classical operators:

```golo
    struct Couple = { x, y }

    ...

    require(Couple(1, 2) < Couple(2, 4), "err")
```

An exception is raised if the structure are different, such that two
different structures with the same members are not comparable, for instance:

```golo
Couple(1, 2) < Point(2, 4)
```

will fail.