### PR TITLE
Operator call sites with catchException instead of a guardWithTest

### DIFF
--- a/doc/structs.asciidoc
+++ b/doc/structs.asciidoc
@@ -199,7 +199,7 @@ will output:
 ----
 true
 true
-Exception in thread "main" java.lang.ClassCastException: struct Triplet{x=1, y=2, z=3} and struct Other{x=1, y=2, z=4} can't be compared
+Exception in thread "main" java.lang.IllegalArgumentException: struct Triplet{x=1, y=2, z=3} and struct Other{x=1, y=2, z=4} can't be compared
 ----
 
 even if `Triplet` and `Other` have the same members.

--- a/src/main/java/gololang/GoloStruct.java
+++ b/src/main/java/gololang/GoloStruct.java
@@ -84,7 +84,7 @@ public abstract class GoloStruct implements Iterable<Tuple>, Comparable<GoloStru
    * @param other the structure to be compared
    * @return a negative integer, zero, or a positive integer as this structure is less than, equal to, or greater than the specified structure
    * @throws NullPointerException if the specified structure is null
-   * @throws ClassCastException  if the structure are of different type, of if the type of the members prevent them from being compared pairwise
+   * @throws IllegalArgumentException  if the structure are of different type, of if the type of the members prevent them from being compared pairwise
    * @since Golo3.1
    */
   @Override
@@ -93,7 +93,7 @@ public abstract class GoloStruct implements Iterable<Tuple>, Comparable<GoloStru
       return 0;
     }
     if (getClass() != other.getClass()) {
-      throw new ClassCastException(String.format(
+      throw new IllegalArgumentException(String.format(
             "%s and %s can't be compared; try to compare their values", this, other));
     }
     return this.values().compareTo(other.values());

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -1450,7 +1450,7 @@ public class CompileAndRunTest {
     try {
       Object result = test_method.invoke(null);
     } catch (InvocationTargetException e) {
-      assertThat(e.getCause(), instanceOf(ClassCastException.class));
+      assertThat(e.getCause(), instanceOf(IllegalArgumentException.class));
       assertThat(e.getCause().getMessage(),
           containsString("struct Couple{x=1, y=2} and struct Point{x=1, y=3} can't be compared"));
     }


### PR DESCRIPTION
This proposed change invalidates operator call sites on `ClassCastException` rather than through a
branching `guardWithTest` method handle combinator. This removes 2 `instanceof` checks on each
call.