### PR TITLE
FIX #320: Lookup augmentations in call stack

### DIFF
--- a/doc/augmentations.asciidoc
+++ b/doc/augmentations.asciidoc
@@ -131,6 +131,19 @@ TIP: As a matter of style, we suggest that your module names end with `Augmentat
 module imports **all** of its augmentation definitions, we suggest that you modularize them with *fine
 taste* (for what it means).
 
+To allow building libraries of functions leveraging augmentations, the callstack is also looked up in order to find if a complying augmentation was applied to the function arguments. It is thus possible to create a function like:
+
+[source,golo]
+----
+module MyLib
+
+function sayPlop = |o| {
+  println(o: plop())
+}
+----
+
+that can be applied on any object having a `plop` method, provided this is a native method or it is defined in an augmentation imported in the calling module.
+
 
 === Named augmentations
 

--- a/src/main/java/org/eclipse/golo/cli/command/GoloGoloCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/GoloGoloCommand.java
@@ -38,8 +38,8 @@ public class GoloGoloCommand implements CliCommand {
 
   public void execute() throws Throwable {
     URLClassLoader primaryClassLoader = primaryClassLoader(this.classpath);
-    Thread.currentThread().setContextClassLoader(primaryClassLoader);
     GoloClassLoader loader = new GoloClassLoader(primaryClassLoader);
+     Thread.currentThread().setContextClassLoader(loader);
     Class<?> lastClass = null;
     for (String goloFile : this.files) {
       lastClass = loadGoloFile(goloFile, this.module, loader);

--- a/src/test/java/org/eclipse/golo/internal/testing/TestUtils.java
+++ b/src/test/java/org/eclipse/golo/internal/testing/TestUtils.java
@@ -82,8 +82,8 @@ public class TestUtils {
     return methods;
   }
 
-  public static GoloClassLoader classLoader(Class<?> testClass) {
-    return new GoloClassLoader(testClass.getClassLoader());
+  public static GoloClassLoader classLoader(Object o) {
+    return new GoloClassLoader(o.getClass().getClassLoader());
   }
 
   public static void runTests(String sourceFolder, String goloModuleName, GoloClassLoader classLoader) throws Throwable {

--- a/src/test/java/org/eclipse/golo/internal/testing/TestUtils.java
+++ b/src/test/java/org/eclipse/golo/internal/testing/TestUtils.java
@@ -22,9 +22,11 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
 
 import static java.lang.reflect.Modifier.isStatic;
 import static java.lang.reflect.Modifier.isPublic;
+import static org.testng.Assert.fail;
 
 public class TestUtils {
 
@@ -79,4 +81,22 @@ public class TestUtils {
     }
     return methods;
   }
+
+  public static GoloClassLoader classLoader(Class<?> testClass) {
+    return new GoloClassLoader(testClass.getClassLoader());
+  }
+
+  public static void runTests(String sourceFolder, String goloModuleName, GoloClassLoader classLoader) throws Throwable {
+    Class<?> testModule = compileAndLoadGoloModule(sourceFolder, goloModuleName, classLoader);
+    for (Method testMethod : getTestMethods(testModule)) {
+      try {
+        testMethod.invoke(null);
+      } catch (InvocationTargetException e) {
+        fail("method " + testMethod.getName()
+            + " in " + sourceFolder + goloModuleName + " failed: "
+            + e.getCause());
+      }
+    }
+  }
+
 }

--- a/src/test/java/org/eclipse/golo/runtime/AugmentationResolutionTest.java
+++ b/src/test/java/org/eclipse/golo/runtime/AugmentationResolutionTest.java
@@ -23,7 +23,7 @@ public class AugmentationResolutionTest {
 
   @BeforeMethod
   public void setUp() {
-    loader = classLoader(this.getClass());
+    loader = classLoader(this);
   }
 
   @Test

--- a/src/test/java/org/eclipse/golo/runtime/AugmentationResolutionTest.java
+++ b/src/test/java/org/eclipse/golo/runtime/AugmentationResolutionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012-2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.golo.runtime;
+
+import org.testng.annotations.Test;
+import org.testng.annotations.BeforeMethod;
+import org.eclipse.golo.compiler.GoloClassLoader;
+
+import static org.eclipse.golo.internal.testing.TestUtils.runTests;
+import static org.eclipse.golo.internal.testing.TestUtils.classLoader;
+import static org.eclipse.golo.internal.testing.TestUtils.compileAndLoadGoloModule;
+
+public class AugmentationResolutionTest {
+  private static final String SRC = "src/test/resources/for-execution/call-resolution/";
+  private GoloClassLoader loader;
+
+  @BeforeMethod
+  public void setUp() {
+    loader = classLoader(this.getClass());
+  }
+
+  @Test
+  public void callStackLookup() throws Throwable {
+    compileAndLoadGoloModule(SRC, "data.golo", loader);
+    compileAndLoadGoloModule(SRC, "lib.golo", loader);
+    runTests(SRC, "call-stack-lookup.golo", loader);
+  }
+}

--- a/src/test/resources/for-execution/call-resolution/call-stack-lookup.golo
+++ b/src/test/resources/for-execution/call-resolution/call-stack-lookup.golo
@@ -1,0 +1,28 @@
+module golotest.augmentationScope.CallStackLookup
+
+import golotest.augmentationScope.MyData
+import golotest.augmentationScope.MyLib
+
+augment java.lang.String {
+  function size = |this| -> this: length()
+}
+
+function test_on_string = {
+  require(getSize("hello") == 5, "err on string")
+}
+
+function test_on_struct = {
+  require(getSize(MyStruct(42)) == 42, "err on struct")
+}
+
+function test_named_augmentation = {
+  require(not MyStruct(42): isEmpty(), "err")
+  require(MyStruct(0): isEmpty(), "err")
+}
+
+function main = |args| {
+  test_on_string()
+  test_on_struct()
+  test_named_augmentation()
+  println("ok")
+}

--- a/src/test/resources/for-execution/call-resolution/data.golo
+++ b/src/test/resources/for-execution/call-resolution/data.golo
@@ -1,0 +1,9 @@
+
+module golotest.augmentationScope.MyData
+
+struct MyStruct = { val }
+augment MyStruct {
+  function size = |this| -> this: val()
+}
+augment MyStruct with golotest.augmentationScope.MyLib.Sizable
+

--- a/src/test/resources/for-execution/call-resolution/lib.golo
+++ b/src/test/resources/for-execution/call-resolution/lib.golo
@@ -1,0 +1,8 @@
+
+module golotest.augmentationScope.MyLib
+
+function getSize = |o| -> o: size()
+
+augmentation Sizable = {
+  function isEmpty = |this| -> this: size() == 0
+}


### PR DESCRIPTION
When an augmentation is defined, it is only visible if the module using
it has imported the module defining it. This limits the ability to
create generic functions using any augmented object.

The solution is to look up in the call stack if a complying augmentation
had been imported in the calling module.