### PR TITLE
Property-style method support

### DIFF
--- a/doc/java-interop.asciidoc
+++ b/doc/java-interop.asciidoc
@@ -271,6 +271,73 @@ println(foo: bar())
 ----
 ====
 
+=== Properties support
+
+Golo support property-style method calls.
+
+Given a property `name()`, Golo will translate the method call to a `{get|is or set}Name` method call. Obviously, if a field
+is not accessible (ie. `private`) and doesn't have a getter or setter, the resolution will fail.
+Finally, _write-only_ properties can be chained (ie: return the current `this` instance), unless a return value is defined in the according setter method.
+
+NOTE: The property resolution does not check if an according field exists. Basically all the `get|set|is|` methods are candidates to
+a property-style method invocation.
+
+[source,java]
+----
+public class Person {
+
+  private String name;
+  private boolean goloComitter;
+  private String email;
+  private int score;
+
+  public String getName() {
+  ...
+  }
+
+  public boolean isGoloComitter() {
+  ...
+  }
+
+  public void setName(String name) {
+    ...
+  }
+
+  public void setGoloCommitter(boolean goloCommitter) {
+  ...
+  }
+
+  public int setScore(int score) {
+    this.score = score;
+    return score;
+  }
+
+  public boolean isRockStar() {
+    return goloCommitter;
+  }
+}
+----
+====
+
+
+[source,golo]
+----
+let duke = Person()
+
+try {
+  duke: email("duke@golo-lang.org")
+} catch (e) {
+  require(e oftype java.lang.NoSuchMethodError.class, "the email field is private and no setter is defined")
+}
+
+require(duke: name("Duke"): goloCommiter(true) oftype Person.class, "the set mutators should be chained with fluent calls")
+require(duke: name() is "Duke", "should find the getName() accessor.")
+require(duke: goloCommitter() is true, "should invoke the isGoloCommitter accessor since the field it's a boolean")
+require(print(duke: rockStar() is true, "even if the field rockstar doesn't exists, it should invoke the isRockStar accessor")
+require(ducke: score(100) is 100, "setScore returns a value, the method isn't fluent")
+----
+====
+
 === Inner classes and enumerations
 
 We will illustrate both how to deal with public static inner classes and enumerations at once.

--- a/src/main/java/org/eclipse/golo/runtime/MethodInvocationSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/MethodInvocationSupport.java
@@ -316,7 +316,10 @@ public final class MethodInvocationSupport {
   private static MethodHandle findTarget(MethodInvocation invocation, Lookup lookup, InlineCache inlineCache) {
     MethodHandle target;
 
-    // NOTE: magic for accessors and mutators would go here...
+    target = new PropertyMethodFinder(invocation, lookup).find();
+    if (target != null) {
+      return target;
+    }
 
     RegularMethodFinder regularMethodFinder = new RegularMethodFinder(invocation, lookup);
     target = regularMethodFinder.find();

--- a/src/main/java/org/eclipse/golo/runtime/PropertyMethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/PropertyMethodFinder.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012-2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.golo.runtime;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.lang.invoke.MethodHandles.*;
+import static java.lang.invoke.MethodType.methodType;
+import static java.util.Arrays.copyOfRange;
+
+public class PropertyMethodFinder extends MethodFinder {
+
+  private static final MethodHandle FLUENT_SETTER;
+
+  static {
+    try {
+      FLUENT_SETTER = lookup().findStatic(
+          PropertyMethodFinder.class,
+          "fluentSetter",
+          methodType(Object.class, Object.class, Object.class));
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new Error("Could not bootstrap the required fluent method handles", e);
+    }
+  }
+
+  private static Object fluentSetter(Object o, Object notUsedSetterReturnValue) {
+    return o;
+  }
+
+  private String propertyName;
+
+  public PropertyMethodFinder(MethodInvocation invocation, Lookup lookup) {
+    super(invocation, lookup);
+    this.propertyName = capitalize(invocation.name());
+  }
+
+  private static MethodInvocation propertyInvocation(String propertyInvocationName, MethodInvocation parentInvocation) {
+    return new MethodInvocation(
+        propertyInvocationName,
+        parentInvocation.type(),
+        parentInvocation.arguments(),
+        copyOfRange(parentInvocation.argumentNames(), 0, parentInvocation.argumentNames().length - 1));
+  }
+
+  private MethodHandle findMethodForGetter() {
+    MethodHandle target = new RegularMethodFinder(
+        propertyInvocation("get" + propertyName, invocation),
+        lookup
+    ).find();
+
+    if (target != null) {
+      return target;
+    }
+    return new RegularMethodFinder(
+        propertyInvocation("is" + propertyName, invocation),
+        lookup
+    ).find();
+  }
+
+  private MethodHandle fluentMethodHandle(Method candidate) {
+    Objects.requireNonNull(candidate);
+    MethodHandle target = toMethodHandle(candidate).orElse(null);
+    if (target != null) {
+      if (!TypeMatching.returnsValue(candidate)) {
+        Object receiver = invocation.arguments()[0];
+        MethodHandle fluent = FLUENT_SETTER.bindTo(receiver);
+        target = filterReturnValue(target, fluent);
+      }
+    }
+    return target;
+  }
+
+  private MethodHandle findMethodForSetter() {
+    return new RegularMethodFinder(
+        propertyInvocation("set" + propertyName, invocation),
+        lookup)
+        .findInMethods()
+        .map(this::fluentMethodHandle)
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
+  public MethodHandle find() {
+    if (invocation.arity() == 1) {
+      return findMethodForGetter();
+    }
+    return findMethodForSetter();
+  }
+
+  private static String capitalize(String word) {
+    return Character.toUpperCase(word.charAt(0)) + word.substring(1);
+  }
+}

--- a/src/main/java/org/eclipse/golo/runtime/RegularMethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/RegularMethodFinder.java
@@ -105,7 +105,7 @@ class RegularMethodFinder extends MethodFinder {
   }
 
 
-  private Stream<Method> findInMethods() {
+  protected Stream<Method> findInMethods() {
     return Extractors.getMethods(invocation.receiverClass())
         .filter(m -> invocation.match(m) || isValidPrivateStructAccess(m));
   }

--- a/src/main/java/org/eclipse/golo/runtime/TypeMatching.java
+++ b/src/main/java/org/eclipse/golo/runtime/TypeMatching.java
@@ -122,4 +122,8 @@ public final class TypeMatching {
       argumentsNumberMatches(constructor.getParameterTypes().length, arguments.length, constructor.isVarArgs())
       && canAssign(constructor.getParameterTypes(), arguments, constructor.isVarArgs());
   }
+
+  public static boolean returnsValue(Method m) {
+    return !(m.getReturnType().equals(void.class) || m.getReturnType().equals(Void.class));
+  }
 }


### PR DESCRIPTION
# Description
This PR adds a property support to Golo. If `the RegularMethodFinder` can't do
the resolution, then the `PropertyMethodFinder` will seek for an accessor or
mutator after ensuring the method name matches to a field name.
Related issue: #198 

# Todo
- [x] Manage booleans
- [x] Dynamic fluent API
- [x] Do not mask user-defined setter return value
- [x] Support computed fields.

# Question
* Is the fluent aspect a good thing? Is it to the language or to the dev to make the getter/setter fluent?