### PR TITLE
Fix cursor movement

### DIFF
--- a/src/main/golo/ansicodes.golo
+++ b/src/main/golo/ansicodes.golo
@@ -54,10 +54,10 @@ function cursor_position  = |line, column| -> print("\u001B[" + line + ";" + col
 function cursor_save_position     = -> print("\u001B[s")
 function cursor_restore_position  = -> print("\u001B[u")
 
-function cursor_up        = |lines| -> println("\u001B[" + lines + "A")
-function cursor_down      = |lines| -> println("\u001B[" + lines + "B")
-function cursor_forward   = |columns| -> println("\u001B[" + columns + "C")
-function cursor_backward  = |columns| -> println("\u001B[" + columns + "D")
+function cursor_up        = |lines| -> print("\u001B[" + lines + "A")
+function cursor_down      = |lines| -> print("\u001B[" + lines + "B")
+function cursor_forward   = |columns| -> print("\u001B[" + columns + "C")
+function cursor_backward  = |columns| -> print("\u001B[" + columns + "D")
 
 function erase_display  = -> print("\u001B[2J")
 function erase_line     = -> print("\u001B[K")

--- a/src/test/java/gololang/AnsiCodesTest.java
+++ b/src/test/java/gololang/AnsiCodesTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2012-2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package gololang;
+
+import org.hamcrest.Matchers;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+
+import static org.eclipse.golo.internal.testing.TestUtils.compileAndLoadGoloModule;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class AnsiCodesTest {
+
+  private static final String SRC = "src/test/resources/for-test/";
+  private Class<?> moduleClass;
+
+  private StringOutputStream out;
+
+  public static class StringOutputStream extends OutputStream {
+
+    private StringBuilder buffer = new StringBuilder();
+
+    @Override
+    public void write(int b) throws IOException {
+      buffer.append((char)b);
+    }
+
+    public String getString() {
+      return buffer.toString();
+    }
+  }
+
+  @BeforeMethod
+  public void load_module() throws Throwable {
+    if (System.getenv("golo.bootstrapped") == null) {
+      throw new SkipException("Golo is in a bootstrap build execution");
+    }
+    moduleClass = compileAndLoadGoloModule(SRC, "ansicodes.golo");
+    out = new StringOutputStream();
+    System.setOut(new PrintStream(out));
+  }
+
+  @Test
+  public void cursor_movement() throws Throwable {
+    Method cursor_movement = moduleClass.getMethod("cursor_movement");
+    cursor_movement.invoke(null);
+    assertThat(out.getString(), is("\u001B[2C\u001B[10A\u001B[5D\u001B[3B"));
+  }
+}

--- a/src/test/resources/for-test/ansicodes.golo
+++ b/src/test/resources/for-test/ansicodes.golo
@@ -1,0 +1,14 @@
+# ............................................................................................... #
+
+module golo.test.bootstrapped.JSON
+
+import gololang.AnsiCodes
+
+# ............................................................................................... #
+
+function cursor_movement = {
+  cursor_forward(2)
+  cursor_up(10)
+  cursor_backward(5)
+  cursor_down(3)
+}


### PR DESCRIPTION
Replace `println` by `print` to not jump to the new line when the cursor is moved.