### PR TITLE
Make the orIfNull operator lazy

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
@@ -712,14 +712,19 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
 
   @Override
   public void visitBinaryOperation(BinaryOperation binaryOperation) {
-    OperatorType operatorType = binaryOperation.getType();
-    if (AND.equals(operatorType)) {
-      andOperator(binaryOperation);
-    } else if (OR.equals(operatorType)) {
-      orOperator(binaryOperation);
-    } else {
-      binaryOperation.walk(this);
-      genericBinaryOperator(binaryOperation);
+    switch (binaryOperation.getType()) {
+      case AND:
+        andOperator(binaryOperation);
+        break;
+      case OR:
+        orOperator(binaryOperation);
+        break;
+      case ORIFNULL:
+        orIfNullOperator(binaryOperation);
+        break;
+      default:
+        binaryOperation.walk(this);
+        genericBinaryOperator(binaryOperation);
     }
   }
 
@@ -728,6 +733,22 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
       String name = binaryOperation.getType().name().toLowerCase();
       methodVisitor.visitInvokeDynamicInsn(name, goloFunctionSignature(2), OPERATOR_HANDLE, (Integer) 2);
     }
+  }
+
+  private void orIfNullOperator(BinaryOperation binaryOperation) {
+    int idx = context.referenceTableStack.peek().size();
+    Label nullLabel = new Label();
+    Label exitLabel = new Label();
+    binaryOperation.getLeftExpression().accept(this);
+    methodVisitor.visitVarInsn(ASTORE, idx);
+    methodVisitor.visitVarInsn(ALOAD, idx);
+    methodVisitor.visitJumpInsn(IFNULL, nullLabel);
+    methodVisitor.visitJumpInsn(GOTO, exitLabel);
+    methodVisitor.visitLabel(nullLabel);
+    binaryOperation.getRightExpression().accept(this);
+    methodVisitor.visitVarInsn(ASTORE, idx);
+    methodVisitor.visitLabel(exitLabel);
+    methodVisitor.visitVarInsn(ALOAD, idx);
   }
 
   private void orOperator(BinaryOperation binaryOperation) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/ReferenceTable.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ReferenceTable.java
@@ -33,6 +33,10 @@ public final class ReferenceTable implements Scope {
     return this;
   }
 
+  public int size() {
+    return table.size() + (parent != null ? parent.size() : 0);
+  }
+
   public boolean hasReferenceFor(String name) {
     return table.containsKey(name) || parent != null && parent.hasReferenceFor(name);
   }

--- a/src/main/java/org/eclipse/golo/runtime/OperatorSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/OperatorSupport.java
@@ -46,8 +46,6 @@ public final class OperatorSupport {
       add("is");
       add("isnt");
       add("oftype");
-
-      add("orifnull");
     }
   };
 
@@ -1356,10 +1354,6 @@ public final class OperatorSupport {
 
   public static Object isnt_noguard(Object a, Object b) {
     return a != b;
-  }
-
-  public static Object orifnull_noguard(Object a, Object b) {
-    return (a != null) ? a : b;
   }
 
   // helpers ..........................................................................................................

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -399,6 +399,9 @@ public class CompileAndRunTest {
     Method null_guarded = moduleClass.getMethod("null_guarded");
     assertThat((String) null_guarded.invoke(null), is("n/a"));
 
+    Method lazy_ifnull = moduleClass.getMethod("lazy_ifnull");
+    assertThat((Boolean) lazy_ifnull.invoke(null), is(true));
+
     Method polymorphic_number_comparison = moduleClass.getMethod("polymorphic_number_comparison");
     assertThat((Boolean) polymorphic_number_comparison.invoke(null), is(true));
   }

--- a/src/test/java/org/eclipse/golo/runtime/OperatorSupportTest.java
+++ b/src/test/java/org/eclipse/golo/runtime/OperatorSupportTest.java
@@ -274,11 +274,4 @@ public class OperatorSupportTest {
     assertThat((Integer) modulo.invokeWithArguments(four, two), is(0));
     assertThat((Long) modulo.invokeWithArguments(three_l, two), is(1L));
   }
-
-  @Test
-  public void check_orIfNull() throws Throwable {
-    MethodHandle orIfNull = OperatorSupport.bootstrap(lookup(), "orifnull", BINOP_TYPE, 2).dynamicInvoker();
-    assertThat((String) orIfNull.invoke("a", "b"), is("a"));
-    assertThat((String) orIfNull.invoke(null, "n/a"), is("n/a"));
-  }
 }

--- a/src/test/resources/for-execution/operators.golo
+++ b/src/test/resources/for-execution/operators.golo
@@ -78,6 +78,19 @@ function null_guarded = {
   return map: get("bogus") orIfNull "n/a"
 }
 
+local function sideeffect = |l, v| {
+  l: add(v)
+  return v
+}
+
+function lazy_ifnull = {
+  let l = list[]
+  var a = "plop" orIfNull sideeffect(l, 42)
+  a = "foo" orIfNull sideeffect(l, "foo")
+  a = null orIfNull sideeffect(l, 42)
+  return [a, l] == [42, list[42]]
+}
+
 function polymorphic_number_comparison = {
   let left = list[1, 1_L, 1.0, 1.0_F]
   let right = list[2, 2_L, 1.1, 1.1_F]


### PR DESCRIPTION
FIX #342

Replace the call to an invoke dynamic method by a generated bytecode
whose evaluation is lazy. For instance, in:
```golo
"plop" orIfNull getPlop()
```
the `getPlop` function is not called anymore.