### PR TITLE
FIX #323: Check for duplicated types compile time

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -105,6 +105,17 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
       container.addFunction(function);
     }
 
+    public boolean checkExistingSubtype(GoloASTNode node, String name) {
+      GoloElement existing = module.getSubtypeByName(name);
+      if (existing != null) {
+        errorMessage(AMBIGUOUS_DECLARATION, node,
+            String.format("Declaring a type `%s` twice (declared first here: %s)",
+                name, existing.getASTNode().getPositionInSourceCode()));
+        return true;
+      }
+      return false;
+    }
+
     public GoloFunction getOrCreateFunction() {
       if (!(objectStack.peek() instanceof GoloFunction)) {
         objectStack.push(functionDeclaration().synthetic().local().asClosure());
@@ -210,25 +221,32 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   @Override
   public Object visit(ASTStructDeclaration node, Object data) {
     Context context = (Context) data;
-    context.module.addStruct(structure(node.getName())
-      .ofAST(node)
-      .members(node.getMembers()));
+    if (!context.checkExistingSubtype(node, node.getName())) {
+      context.module.addStruct(structure(node.getName())
+        .ofAST(node)
+        .members(node.getMembers()));
+    }
     return node.childrenAccept(this, data);
   }
 
   @Override
   public Object visit(ASTUnionDeclaration node, Object data) {
     Context context = (Context) data;
-    context.push(union(node.getName()));
-    node.childrenAccept(this, data);
-    context.module.addUnion((Union) context.pop());
+    if (!context.checkExistingSubtype(node, node.getName())) {
+      context.push(union(node.getName()).ofAST(node));
+      node.childrenAccept(this, data);
+      context.module.addUnion((Union) context.pop());
+    }
     return data;
   }
 
   @Override
   public Object visit(ASTUnionValue node, Object data) {
     Context context = (Context) data;
-    ((Union) context.peek()).addValue(node.getName(), node.getMembers());
+    if (!((Union) context.peek()).addValue(node.getName(), node.getMembers())) {
+      context.errorMessage(AMBIGUOUS_DECLARATION, node,
+          String.format("Declaring the union value `%s` twice", node.getName()));
+    }
     return node.childrenAccept(this, data);
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
@@ -135,6 +135,20 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
     struct.setModuleName(getPackageAndClass());
   }
 
+  public GoloElement getSubtypeByName(String name) {
+    for (Struct s : structs) {
+      if (s.getName().equals(name)) {
+        return s;
+      }
+    }
+    for (Union u : unions) {
+      if (u.getName().equals(name)) {
+        return u;
+      }
+    }
+    return null;
+  }
+
   public void addUnion(Union union) {
     unions.add(union);
     makeParentOf(union);

--- a/src/main/java/org/eclipse/golo/compiler/ir/Struct.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Struct.java
@@ -40,6 +40,10 @@ public final class Struct extends GoloElement {
     this.name = name;
   }
 
+  public String getName() {
+    return name;
+  }
+
   public Struct members(String... members) {
     return this.members(asList(members));
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/Union.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Union.java
@@ -29,6 +29,10 @@ public final class Union extends GoloElement {
     this.name = name;
   }
 
+  public String getName() {
+    return name;
+  }
+
   public PackageAndClass getPackageAndClass() {
     return new PackageAndClass(moduleName.toString() + ".types", name);
   }
@@ -37,16 +41,22 @@ public final class Union extends GoloElement {
     this.moduleName = module;
   }
 
-  public void addValue(String name, Collection<String> members) {
+  public boolean addValue(String name, Collection<String> members) {
+    for (UnionValue v : values) {
+      if (v.getName().equals(name)) {
+        return false;
+      }
+    }
     UnionValue value = new UnionValue(this, name);
     value.addMembers(members);
     values.add(value);
     makeParentOf(value);
+    return true;
   }
 
-  public void addValue(UnionValue value) {
-    values.add(value);
+  public boolean addValue(UnionValue value) {
     makeParentOf(value);
+    return values.add(value);
   }
 
   public Collection<UnionValue> getValues() {

--- a/src/test/resources/for-test/duplicated-struct.golo
+++ b/src/test/resources/for-test/duplicated-struct.golo
@@ -1,0 +1,13 @@
+
+module DuplicatedStruct
+
+
+
+
+struct Foo = { a }
+
+struct Foo = { x, y }
+
+function main = |args| {
+
+}

--- a/src/test/resources/for-test/duplicated-type.golo
+++ b/src/test/resources/for-test/duplicated-type.golo
@@ -1,0 +1,13 @@
+
+module DuplicatedType
+
+union Foo = {
+  Bar = { x }
+  Baz = { x, y }
+}
+
+struct Foo = { a }
+
+function main = |args| {
+
+}

--- a/src/test/resources/for-test/duplicated-union-value.golo
+++ b/src/test/resources/for-test/duplicated-union-value.golo
@@ -1,0 +1,14 @@
+
+module DuplicatedUnionVal
+
+
+
+
+union Foo = {
+  Bar = { x }
+  Bar = { x, y }
+}
+
+function main = |args| {
+
+}

--- a/src/test/resources/for-test/duplicated-union.golo
+++ b/src/test/resources/for-test/duplicated-union.golo
@@ -1,0 +1,16 @@
+
+module DuplicatedUnion
+
+union Foo = {
+  Bar = { x }
+  Baz = { x, y }
+}
+
+union Foo = {
+  Plop = { x }
+  Daplop
+}
+
+function main = |args| {
+
+}


### PR DESCRIPTION
When two types (`struct` or `union`) with the same name were declared in
the same module, the code compiled without error, but an obscure
exception was raised at runtime

The case is now checked when building the IR, so that we have a clear
compiling error.

This fix the #323 issue.