### PR TITLE
FIX #335: Named arguments and anonymous calls

### DIFF
--- a/src/main/golo/async.golo
+++ b/src/main/golo/async.golo
@@ -37,7 +37,7 @@ Future objects have the following methods.
 * `onFail(|e| {...})`: registers a callback when the corresponding promise fails with an exception.
 * `isResolved()`, `isFailed()` `get()` and `blockingGet()` delegate to the promise implementation.
 ----
-function promise = -> 
+function promise = ->
   gololang.concurrent.async.Promise()
 
 ----
@@ -83,7 +83,7 @@ augment gololang.concurrent.async.Promise {
 ----
 Returns a future set to `value`.
 ----
-function setFuture = |value| -> 
+function setFuture = |value| ->
   gololang.concurrent.async.AssignedFuture.setFuture(value)
 
 ----
@@ -99,8 +99,8 @@ class.
 augment gololang.concurrent.async.Future {
 
   ----
-  Returns a future whose value is mapped through the `fun` function. 
-  
+  Returns a future whose value is mapped through the `fun` function.
+
   If this future is set to `v`, then the returned future is set to `fun(v)`. If it fails, the
   returned future is also failed with the same exception.
   ----
@@ -265,25 +265,25 @@ The provided functions all forward to Golo futures, while `cancel` forwards to a
 ----
 augment gololang.Async.types.FutureBridge {
 
-  function onSet = |this, listener| -> 
+  function onSet = |this, listener| ->
     this: _goloFuture(): onSet(listener)
 
-  function onFail = |this, listener| -> 
+  function onFail = |this, listener| ->
     this: _goloFuture(): onFail(listener)
 
-  function map = |this, fun| -> 
+  function map = |this, fun| ->
     this: _goloFuture(): map(fun)
 
   function flatMap = |this, fun| ->
     this: _goloFuture(): flatMap(fun)
 
-  function filter = |this, pred| -> 
+  function filter = |this, pred| ->
     this: _goloFuture(): filter(pred)
 
-  function fallbackTo = |this, future| -> 
+  function fallbackTo = |this, future| ->
     this: _goloFuture(): fallbackTo(future)
 
-  function cancel = |this, mayInterruptIfRunning| -> 
+  function cancel = |this, mayInterruptIfRunning| ->
     this: _javaFuture(): cancel(mayInterruptIfRunning)
 }
 
@@ -309,7 +309,7 @@ augment java.util.concurrent.ExecutorService {
       })
 
       # Watch what could happen
-      f: onSet(|v| -> println(v)): 
+      f: onSet(|v| -> println(v)):
          onFail(|e| -> println(e: getMessage()))
 
       # ...but make it fail unless the CPU was too slow

--- a/src/main/golo/json.golo
+++ b/src/main/golo/json.golo
@@ -13,7 +13,7 @@
 A set of useful APIs for dealing with JSON documents from Golo.
 
 The implementation is backed by [json-simple](https://code.google.com/p/json-simple/). While
-`json-simple` only supports encoding from lists and maps, this API brings support for sets, arrays, 
+`json-simple` only supports encoding from lists and maps, this API brings support for sets, arrays,
 Golo tuples, dynamic objects and structs.
 ----
 module gololang.JSON
@@ -144,7 +144,7 @@ augment gololang.GoloStruct {
 
   ----
   Populates the elements of a struct based on the values found in a JSON string.
-  
+
       let str = JSON.stringify(map[
         ["name", "Foo"],
         ["email", "foo@gmail.com"],

--- a/src/main/golo/lazylists.golo
+++ b/src/main/golo/lazylists.golo
@@ -233,7 +233,7 @@ augment gololang.LazyList {
 
 
   ----
-  Takes the `nb` first elements of the lazy list, as a lazy list. 
+  Takes the `nb` first elements of the lazy list, as a lazy list.
   This is a wrapper, the underlying list is resolved on demand, such that
   everything remains lazy. `take` can thus be used on infinite lists.
   ----
@@ -254,7 +254,7 @@ augment gololang.LazyList {
     when this: isEmpty() or not pred(this: head()) then emptyList()
     otherwise gololang.LazyList.cons(this: head(), -> this: tail() :takeWhile(pred))
   }
-  
+
   ----
   Remove `nb` elements from the list and return the rest as a lazy list.
   ----
@@ -327,7 +327,7 @@ Produces a infinite list of values. If the argument is a closure, it must have
 no parameters, and it's used to produce the values (called for each `tail`
 access).
 
-For instance, `repeat(5)` will return an infinite lazy list of `5`s, and 
+For instance, `repeat(5)` will return an infinite lazy list of `5`s, and
 `repeat(^f)` will return a infinite lazy list of calls to `f`
 ([f(), f(), f(), ...])
 
@@ -339,12 +339,12 @@ function repeat = |value| -> match {
 }
 
 ----
-Returns an infinite lazy list produced by iterative application of a function 
+Returns an infinite lazy list produced by iterative application of a function
 to an initial element.
 `iterate(z, f)` thus yields `z, f(z), f(f(z)), ...`
 
 For instance, one can create a infinite list of integers using:
-    
+
     iterate(0, |x| -> x + 1)
 
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/IrTreeDumper.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/IrTreeDumper.java
@@ -193,7 +193,8 @@ public class IrTreeDumper implements GoloIrVisitor {
     System.out.println("Function call: " + functionInvocation.getName()
         + ", on reference? -> " + functionInvocation.isOnReference()
         + ", on module state? -> " + functionInvocation.isOnModuleState()
-        + ", anonymous? -> " + functionInvocation.isAnonymous());
+        + ", anonymous? -> " + functionInvocation.isAnonymous()
+        + ", named arguments? -> " + functionInvocation.usesNamedArguments());
 
     functionInvocation.walk(this);
     decr();

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -1836,6 +1836,11 @@ public class CompileAndRunTest {
   }
 
   @Test
+  public void test_named_on_anon_call() throws Throwable {
+    runTests(SRC, "namedarguments-anoncall.golo", classLoader(this));
+  }
+
+  @Test
   public void test_named_parameters() throws Throwable {
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "namedparameters-function-calls.golo");
 

--- a/src/test/resources/for-execution/call-resolution/mixin-test.golo
+++ b/src/test/resources/for-execution/call-resolution/mixin-test.golo
@@ -32,7 +32,7 @@ function test_dispatch = {
 
   assertEquals(sayPlop(42), "no plop:42")
 
-  assertEquals(sayPlop(MyStruct(42)), 
+  assertEquals(sayPlop(MyStruct(42)),
     "say:plop:golotest.augmentations.MyData.types.MyStruct:42")
 
   assertEquals(sayPlop(MyUnion.Not()),

--- a/src/test/resources/for-execution/comprehension.golo
+++ b/src/test/resources/for-execution/comprehension.golo
@@ -92,7 +92,7 @@ function test_two_mixed_loops = {
 }
 
 function test_more_loops = {
-  let l = list[ [x,y,z] foreach x in [0,1,2] when (x % 2) == 1 
+  let l = list[ [x,y,z] foreach x in [0,1,2] when (x % 2) == 1
                         foreach y in [1,2,3] when y < 2
                         foreach z in [1] ]
   require(l == list[[1,1,1]], "more_loops failed")
@@ -120,11 +120,11 @@ function test_filtered_destruct_two = {
     foreach k, v in aMap:entrySet() when k: startsWith("f") or v >= 42
   ]
 
-  let result = list[ 
-    "foo: 5", "bar: 45", 
+  let result = list[
+    "foo: 5", "bar: 45",
     "foo: 15", "bar: 135",
     "foo: 25", "bar: 225",
-    "foo: 35", "bar: 315", 
+    "foo: 35", "bar: 315",
     "foo: 45", "bar: 405"
   ]
   require(l == result, "filtered destruct failed")
@@ -180,6 +180,6 @@ function main = |args| {
     ^test_more_loops,
     ^test_destruct,
     ^test_map_destruct,
-    ^test_filtered_destruct_two 
+    ^test_filtered_destruct_two
   )
 }

--- a/src/test/resources/for-execution/destruct.golo
+++ b/src/test/resources/for-execution/destruct.golo
@@ -99,7 +99,7 @@ function test_union = {
   let x, y = foo
   require(x == 1, "err")
   require(y == 2, "err")
-  
+
   let bar = MyUnion.Bar("a", "b", "c")
   let a, b, c = bar
   require(a == "a", "err")

--- a/src/test/resources/for-execution/direct-anon-call.golo
+++ b/src/test/resources/for-execution/direct-anon-call.golo
@@ -10,7 +10,7 @@ function with_invoke = {
 }
 
 function direct_call = {
-  return (|x| -> x + 1)(1)  
+  return (|x| -> x + 1)(1)
 }
 
 function ident = {
@@ -19,11 +19,11 @@ function ident = {
 }
 
 function anon_ident = {
-  return (|x| -> x)(|x| -> x + 1)(1)  
+  return (|x| -> x)(|x| -> x + 1)(1)
 }
 
 function currified = {
-  return (|x| -> |y| -> x + y)(1)(1)  
+  return (|x| -> |y| -> x + y)(1)(1)
 }
 
 function struct_field = {
@@ -42,9 +42,9 @@ function dynamic = {
 }
 
 function main = |args| {
-  require(with_invoke() == 2, "err") 
-  require(direct_call() == 2, "err") 
-  require(ident() == 2, "err") 
+  require(with_invoke() == 2, "err")
+  require(direct_call() == 2, "err")
+  require(ident() == 2, "err")
   require(anon_ident() == 2, "err")
   require(currified() == 2, "err")
   require(struct_field() == 2, "err")

--- a/src/test/resources/for-execution/module-state-closures.golo
+++ b/src/test/resources/for-execution/module-state-closures.golo
@@ -77,7 +77,7 @@ function test = {
   require(CONSTANT_REF_CURRY(21)(21) == 42, "err")
   require(CALL_FUNREF(1) == 43, "err")
   require(CLOSED_FUNREF(1) == 43, "err")
-  
+
   # A module state containing a lambda can be called
   require(CONSTANT_CONSTANT_LAMBDA() == 42, "err")
   require(CALL_CONSTANT_LAMBDA() == 42, "err")
@@ -87,7 +87,7 @@ function test = {
   # A module state containing a curryfied function can be called
   require(CONSTANT_CURRY(21)(21) == 42, "err")
   require(CALL_CURRY(21)(21) == 42, "err")
-  
+
   # A module state containing a closure can be called
   require(CONSTANT_CONSTANT_CLOSURE() == 42, "err")
   require(CALL_CONSTANT_CLOSURE() == 42, "err")

--- a/src/test/resources/for-execution/namedarguments-anoncall.golo
+++ b/src/test/resources/for-execution/namedarguments-anoncall.golo
@@ -1,0 +1,69 @@
+
+module Test
+
+local function assertEquals = |got, expected| {
+  require(expected == got, "expected %s, got %s": format(expected, got))
+}
+
+function yo = |message| -> |before, after| -> before + ":" + message + ":" + after
+
+function say = |message, before, after| -> before + ":" + message + ":" + after
+
+function add = |left, right| -> left + right
+
+function test_indirect = {
+  let expected =  "Hello:sam:!"
+
+  let y = yo("sam")
+  assertEquals(y(before="Hello", after="!"), expected)
+  
+  let s = ^say: bindAt("message", "sam")
+  assertEquals(s(before="Hello", after="!"), expected)
+
+  let a = ^add
+  assertEquals(a(left="a", right="b"), "ab")
+
+  let l = |left, right| -> left + right
+  assertEquals(l(left="a", right="b"), "ab")
+
+  assertEquals(yo("sam"): invoke(before="Hello", after="!"), expected)
+  assertEquals(
+    ^say: bindAt("message", "sam"): invoke(before="Hello", after="!"),
+    expected)
+
+  assertEquals(^add: invoke(left="a", right="b"), "ab")
+  assertEquals((|left, right| -> left + right): invoke(left="a", right="b"), "ab")
+}
+
+
+function test_no_names = {
+  let expected =  "Hello:sam:!"
+
+  assertEquals(yo("sam")("Hello", "!"), expected)
+  assertEquals(^say: bindAt("message", "sam")("Hello", "!"), expected)
+  assertEquals(add("a", "b"), "ab")
+  assertEquals(^add("a", "b"), "ab")
+  assertEquals((|left, right| -> left + right)("a", "b"), "ab")
+}
+
+function test_anon_names = {
+  let expected =  "Hello:sam:!"
+  assertEquals(yo("sam")(before="Hello", after="!"), expected)
+  assertEquals(^say: bindAt("message", "sam")(before="Hello", after="!"), expected)
+}
+
+function test_ref_names = {
+  assertEquals(^add(left="a", right="b"), "ab")
+  assertEquals((|left, right| -> left + right)(left="a", right="b"), "ab")
+}
+
+
+function main = |args| {
+  assertEquals(add(left="a", right="b"), "ab")
+  test_indirect()
+  test_no_names()
+  test_anon_names()
+  test_ref_names()
+
+  println("ok")
+}

--- a/src/test/resources/for-execution/operators.golo
+++ b/src/test/resources/for-execution/operators.golo
@@ -101,7 +101,7 @@ function polymorphic_number_comparison = {
       require((not (b == a)), "equals failed")
       require((b != a), "not equals failed")
       require((a != b), "not equals failed")
-      
+
       require((a <= b), "less or equals failed")
       require((not (a >= b)), "more or equals failed")
       require((b >= a), "more or equals failed")
@@ -120,7 +120,7 @@ function polymorphic_number_comparison = {
       require((b == a), "equals failed")
       require((not (a != b)), "not equals failed")
       require((not (b != a)), "not equals failed")
-      
+
       require((a <= b), "less or equals failed")
       require((a >= b), "more or equals failed")
       require((b >= a), "more or equals failed")

--- a/src/test/resources/for-execution/structs.golo
+++ b/src/test/resources/for-execution/structs.golo
@@ -73,12 +73,12 @@ function check_concision = -> Point(1, 2): str()
 
 struct Couple = { x, y }
 
-function check_compare = -> 
+function check_compare = ->
   Couple(1, 2) < Couple(1, 3)
   and Couple(1, 10) < Couple(2, 1)
 
-function check_equals = -> 
-  Couple(1, 2) != Couple(1, 2) 
+function check_equals = ->
+  Couple(1, 2) != Couple(1, 2)
   and ImmutableCouple(1, 2) == ImmutableCouple(1, 2)
 
 function check_not_comparable = -> Couple(1, 2) < Point(1, 3)

--- a/src/test/resources/for-execution/unions.golo
+++ b/src/test/resources/for-execution/unions.golo
@@ -70,7 +70,7 @@ function test_toString = {
 
 # ............................................................................................... #
 function test_hashcode = {
-  require(Option.None(): hashCode() == Option.None(): hashCode(), 
+  require(Option.None(): hashCode() == Option.None(): hashCode(),
     "singleton hashcode")
   require(Option.Some("bar"): hashCode() == Option.Some("bar"): hashCode(),
     "hashcode")
@@ -93,7 +93,7 @@ function test_equality = {
 
   require(n == Option.None(), "singleton equality")
   require(n is Option.None(), "singleton identity")
-  
+
   require(s == Option.Some(5), "value equality")
   require(s isnt Option.Some(5), "value identity")
 
@@ -144,7 +144,7 @@ function test_augmentations = {
     "err on Tree.Leaf:whoAreYou")
   require(Tree.Node(0, 0): whoAreYou() == "I'm a node",
     "err on Tree.Node:whoAreYou")
-  require(Tree.Empty(): whoAreYou() == "I'm empty", 
+  require(Tree.Empty(): whoAreYou() == "I'm empty",
     "err on Tree.Empty:whoAreYou")
 
 }
@@ -182,7 +182,7 @@ function test_match_methods = {
   let n = Tree.Node(0, 0)
   let l = Tree.Leaf(0)
   let e = Tree.Empty()
-  
+
   require(not n: isEmpty(), "err")
   require(not l: isEmpty(), "err")
   require(e: isEmpty(), "err")

--- a/src/test/resources/for-parsing-and-compilation/decorators.golo
+++ b/src/test/resources/for-parsing-and-compilation/decorators.golo
@@ -19,7 +19,7 @@ function decorator3 = |func| {
 }
 
 function decorator4 = |closure| {
-        return  |func| {                        
+        return  |func| {
                 println("decorator4")
                 closure()
                return func
@@ -65,7 +65,7 @@ Golodoc
 @decorator1 #comment
 @decorator2(4,2) #comment
 @decorator3 #comment
-@decorator4( 
+@decorator4(
     -> {
         println("closure!")
     }
@@ -76,7 +76,7 @@ function adder4 = |a,b| {
 
 augment java.lang.String {
 
-  @decorator1  
+  @decorator1
   function append = |this, tail| -> this + tail
 
   @decorator2(4,2)

--- a/src/test/resources/for-parsing-and-compilation/doc.golo
+++ b/src/test/resources/for-parsing-and-compilation/doc.golo
@@ -1,4 +1,4 @@
-  ----               
+  ----
   Waoo, this is a documented module!
 
   This is super *cool*.
@@ -9,7 +9,7 @@
       let bang = "----"
       let bangbang = "------"
 
-      ----     
+      ----
 module Documented
 
 import java.util.Map

--- a/src/test/resources/for-parsing-and-compilation/unions.golo
+++ b/src/test/resources/for-parsing-and-compilation/unions.golo
@@ -7,13 +7,13 @@ union Option = {
 
 union Color = { RED GREEN BLUE }
 union Tree = {
-  
+
 Empty
 
 
   Node = {
-    
-    left, 
+
+    left,
 
 right
   }


### PR DESCRIPTION
There is a issue when doing anonymous calls, i.e. calls directly applied
on references, on lambda, on partialized functions, or on functions
returned by other functions, when using named arguments.

The issue is due to an incorrect flagging in the AST to IR conversion:
the anonymous function invocations were not flagged as using named
arguments. Therefore, the magic behind did not happened, which caused
the arguments not being stacked, and thus a weired runtime error.

(Also some space cleaning)