### PR TITLE
Fix a bug in Result::either

### DIFF
--- a/src/main/java/gololang/error/Result.java
+++ b/src/main/java/gololang/error/Result.java
@@ -473,7 +473,7 @@ public final class Result<T, E extends Throwable> implements Iterable<T> {
     if (isError()) {
       return recover.invoke(error);
     }
-    return recover.invoke(value);
+    return mapping.invoke(value);
   }
 
     /**

--- a/src/test/resources/for-test/result.golo
+++ b/src/test/resources/for-test/result.golo
@@ -126,11 +126,11 @@ function test_andThen = {
 
 function test_either = {
   let twice = |x| -> 2 * x
-  let recover = |err| -> 42
-  let answer = -> 42
+  let recover = |err| -> "err"
+  let answer = -> "default"
   assertEquals(Ok(21): either(twice, recover), 42)
-  assertEquals(Error("err"): either(twice, recover), 42)
-  assertEquals(Ok(null): either(twice, recover, answer), 42)
+  assertEquals(Error("err"): either(twice, recover), "err")
+  assertEquals(Ok(null): either(twice, recover, answer), "default")
 }
 
 function test_orElseGet = {


### PR DESCRIPTION
The mapping function was not used, the recover one was used in both cases
(note to future me: don't use 42 in every test case)