### PR TITLE
Fix WrongMethodTypeException when calling either method

### DIFF
--- a/src/main/java/gololang/error/Result.java
+++ b/src/main/java/gololang/error/Result.java
@@ -473,7 +473,7 @@ public final class Result<T, E extends Throwable> implements Iterable<T> {
     if (isError()) {
       return recover.invoke(error);
     }
-    return recover.invoke(value);
+    return mapping.invoke(value);
   }
 
     /**


### PR DESCRIPTION
When I use this:

    Option(42): either(|v|->println("YES"),-> println("NO"))
    Option(null): either(|v|->println("YES"),-> println("NO"))
    None(): either(|v|->println("YES"),-> println("NO"))

But not when I use this: (I get an exception: `java.lang.invoke.WrongMethodTypeException`)

    Result(5): either(|v|->println("YES"), |error| -> println("YES"))
    Error("Huston!?"): either(|v|->println("YES"),|error| -> println("YES"))


