### PR TITLE
Functions and operators utilities

### DIFF
--- a/doc/basics.asciidoc
+++ b/doc/basics.asciidoc
@@ -614,7 +614,7 @@ let a, b, c... = [1, 2, 3, 4, 5]   # a = 1, b = 2, c = [3, 4, 5]
 
 Any object having a `destruct()` method returning a tuple can be used in
 destructuring assignments. Golo specific data structures and some Java native
-ones can be destructured. Augmentations can be used to make an existing class
+ones (arrays, maps, collections) can be destructured. Augmentations can be used to make an existing class
 destructurable.
 
 For instance, xref:_structs[golo structures] are destructurable:

--- a/src/main/golo/functions.golo
+++ b/src/main/golo/functions.golo
@@ -1,0 +1,1012 @@
+----
+This module contains several functions and higher order functions or
+decorators, mostly useful with HOF like `map`, `reduce` or in generators.
+
+Indeed, using HOF often require some classical functions like constants one,
+identity, or classical operators.
+
+Most of the times, these functions needs to be unary ones, i.e.
+have only one parameter. This module contains, among others, functions helping in the arity
+conversion of such functions:
+
+* [`curry`](#curry_f) that makes a function automatically partializable,
+* [`uncurry`](#uncurry_f) that is the reverse of `curry`,
+* [`unary`](#unary_f) and [`spreader`](#spreader_f) that convert a polyadic function into a unary
+  function taking an array or a tuple of values instead of several
+  values,
+* [`varargs`](#varargs_f) which is the reverse of `unary`
+
+Most of the binary operator functions defined here are curried. To ease
+partialization, the non commutative operators have a reversed version, with
+arguments swapped.
+For example, using the reverse division operator [`rdiv`](#rdiv_x_y) with
+[`map`](StandardAugmentations.html#java.util.List.map_this_func)
+
+    [2, 4, 8]: map(rdiv(2)) == [1, 2, 4]
+
+The identity function [`id`](#id_x), the constant function
+[`const`](#const_val), together with composition (`FunctionReference::andThen`,
+[`pipe`](#pipe_funcs), [`compose`](#compose_funcs)) and [`io`](#io_block) can be
+used to create monad-like processing chains.
+----
+module gololang.Functions
+
+import java.lang.invoke
+import java.util
+
+### Operators ##########################################################
+
+#== Arithmetic =========================================================
+----
+Polymorphic addition and concatenation.
+
+Adds `value` to `element`.
+The behavior depends on the type of `element`:
+
+- if a number or a string, equivalent to using `+`;
+- if a collection, equivalent to invoking `add` and returning the collection;
+- if an `Appendable` or a `StringBuilder`, equivalent to invoking `append` and
+  returning the collection.
+
+This function is *swapped* and curried. For instance:
+
+    add("b", "a") == "ab"
+
+    list[1, 2, 3]: map(add(3)) == list[4, 5, 6]
+
+    add("a", StringBuilder()): toString() == "a"
+
+    let f = add(42): andThen(add(1337)): andThen(add(69))
+    f(list[]) == list[42, 1337, 69]
+    f(0) == 1448
+    f(StringBuilder()): toString() == "42133769"
+
+
+- *param* `value`: the value to add
+- *param* `element`: the element to add the value to
+
+See also [`addTo`](#addTo_element_value)
+----
+@!curry
+function add = |value, element| {
+  case {
+    when _addWithPlus(element) {
+      return element + value
+    }
+    when _addWithAdd(element)  {
+      element: add(value)
+      return element
+    }
+    when _addWithAppend(element) {
+      element: append(value)
+      return element
+    }
+    otherwise {
+      throw IllegalArgumentException("Don't know how to add to a %s"
+            : format(element: getClass(): getName()))
+    }
+  }
+}
+
+local function _addWithPlus = |elt| -> elt oftype java.lang.Number.class
+                                    or elt oftype java.lang.String.class
+
+local function _addWithAdd = |elt| -> elt oftype java.util.Collection.class
+                                   or elt oftype java.util.stream.Stream$Builder.class
+                                   or elt oftype java.util.StringJoiner.class
+
+local function _addWithAppend = |elt| -> elt oftype java.lang.Appendable.class
+                                      or elt oftype java.lang.StringBuffer.class
+                                      or elt oftype java.lang.StringBuilder.class
+
+----
+Not swapped version of [`add`](#add_value_element)
+----
+@!curry
+function addTo = |element, value| -> add(value, element)
+
+----
+Number successor (side-effect free increment).
+
+    succ(x) == x + 1
+
+Equivalent to `add(1)`
+
+See also [`pred`](#pred_x)
+----
+function succ = |x| -> x + 1
+
+----
+Number predecessor (side-effect free decrement).
+
+    pred(x) == x - 1
+
+See also [`succ`](#succ_x)
+----
+function pred = |x| -> x - 1
+
+----
+Curried multiplication.
+
+    mul(x, y) == x * y
+
+See also [`div`](#div_x_y)
+----
+@!curry
+function mul = |x, y| -> x * y
+
+
+----
+Opposite (negative value).
+
+    neg(x) == -x
+
+Same as `mul(-1)`
+----
+function neg = |x| -> -1 * x
+
+----
+Curried subtract.
+
+    sub(x, y) == x - y
+
+See also [`add`](#add_value_element), [`rsub`](#rsub_x_y)
+----
+@!curry
+function sub = |x, y| -> x - y
+
+----
+Reversed curried subtract.
+
+    rsub(x, y) == y - x
+
+See also [`sub`](#sub_x_y)
+----
+@!curry
+function rsub = |x, y| -> y - x
+
+----
+Curried division.
+
+    div(x, y) == x / y
+
+See also [`mul`](#mul_x_y), [`rdiv`](#rdiv_x_y)
+----
+@!curry
+function div = |x, y| -> x / y
+
+----
+Reverse curried division.
+
+    rdiv(y, x) == x / y
+
+See also  [`mul`](#mul_x_y),  [`div`](#div_x_y)
+----
+@!curry
+function rdiv = |x, y| -> y / x
+
+----
+Curried modulo.
+
+    mod(a, b) == a % b
+
+See also [`rmod`](#rmod_a_b)
+----
+@!curry
+function mod = |a, b| -> (a % b)
+
+----
+Reverse curried modulo.
+
+    rmod(a, b) == b % a
+
+See also [`mod`](#mod_a_b)
+----
+@!curry
+function rmod = |a, b| -> (b % a)
+
+----
+Curried power.
+
+    pow(a, 2) == a*a
+
+Does an implicit conversion to double.
+
+See also [`rpow`](#rpow_a_b)
+----
+@!curry
+function pow = |a, b| -> Math.pow(doubleValue(a), doubleValue(b))
+
+----
+Reversed curried power.
+
+    rpow(2, a) == a*a
+
+Does an implicit conversion to double.
+
+See also [`pow`](#pow_a_b)
+----
+@!curry
+function rpow = |a, b| -> Math.pow(doubleValue(b), doubleValue(a))
+
+
+----
+Converts its argument to a `String`.
+----
+function str = |o| -> o: toString()
+
+
+#== Boolean operators ==================================================
+
+----
+Curried swapped *less than*.
+
+    lt(a, b) == b < a
+
+    lt(42) == |x| -> x < 42
+
+Note: this function is swapped to make curried version more readable: `lt(42)`
+is a predicate testing if its argument is "less than 42".
+
+See also [`le`](#le_a), [`gt`](#gt_a), [`ge`](#ge_a)
+----
+@!curry
+function lt = |a, b| -> b < a
+
+----
+Curried swapped *greater than*.
+
+    gt(a, b) == b > a
+
+Note: this function is swapped to make curried version more readable.
+
+See also [`lt`](#lt_a), [`le`](#le_a), [`ge`](#ge_a)
+----
+@!curry
+function gt = |a, b| -> b > a
+
+----
+Curried *equal*.
+
+    eq(a, b) == (a == b)
+
+See also [`ne`](#ne_a_b)
+----
+@!curry
+function eq = |a, b| -> a == b
+
+----
+Curried *not equal*.
+
+    ne(a, b) == (a != b)
+
+See also [`eq`](#eq_a_b)
+----
+@!curry
+function ne = |a, b| -> a != b
+
+----
+Curried swapped *greater than or equal*.
+
+    ge(a, b) == (b >= a)
+
+Note: this function is swapped to make curried version more readable.
+
+See also [`lt`](#lt_a), [`le`](#le_a), [`gt`](#gt_a)
+----
+@!curry
+function ge = |a, b| -> b >= a
+
+----
+Curried swapped *less than or equal*.
+
+    le(a, b) == (a <= b)
+
+Note: this function is swapped to make curried version more readable.
+
+See also [`lt`](#lt_a), [`ge`](#ge_a), [`gt`](#gt_a)
+----
+@!curry
+function le = |a, b| -> b <= a
+
+----
+Curried boolean *and*.
+
+This implementation is lazy.
+
+The arguments can be boolean expressions or predicate functions. If called with
+predicate functions, returns a new predicate function.
+
+    `and(a, b) == (a and b)
+    `and(gt(10), ^even) == |x| -> a > 10 and x % 2 == 0
+
+See also [`or`](#or_a), [`not`](#not_a), [`xor`](#xor_a_b)
+----
+@!uncurry
+function `and = |a| -> match {
+  when isClosure(a) then curry(|b, x| -> a(x) and b(x))
+  when a then ^id
+  otherwise ^False
+}
+
+----
+Curried boolean *or*.
+
+    `or(a, b) == (a or b)
+
+This implementation is lazy.
+
+The arguments can be boolean expressions or predicate functions. If called with
+predicate functions, returns a new predicate function.
+
+See also [`and`](#and_a), [`not`](#not_a), [`xor`](#xor_a_b)
+----
+@!uncurry
+function `or = |a| -> match {
+  when isClosure(a) then curry(|b, x| -> a(x) or b(x))
+  when a then ^True
+  otherwise ^id
+}
+
+----
+Polymorphic negation function.
+
+* when given a boolean-like value, returns its negation.
+* when given a predicate function, returns a new function returning the
+  negated result.
+
+E.g.
+
+    list[true, false, false]: map(^not) == list[false, true, true]
+
+    let even = |a| -> (a % 2) == 0
+    let odd = `not(even)
+
+See also [`and`](#and_a), [`or`](#or_a)
+----
+function `not = |a| -> match {
+  when isClosure(a) then a: andThen(|v| -> not v)
+  otherwise not a
+}
+
+----
+Curried boolean *xor*.
+
+    xor(a, b) == (a or b) and not (a and b)
+
+The arguments can be boolean expressions or predicate functions. If called with
+predicate functions, returns a new predicate function.
+
+See also [`and`](#and_a), [`or`](#or_a)
+----
+@!curry
+function xor = |a, b| -> match {
+  when isClosure(a) then curry(|b, x| -> _xor(a(x), b(x)))
+  otherwise _xor(a, b)
+}
+
+local function _xor = |a, b| -> (a or b) and not (a and b)
+
+----
+Checks if the value is even.
+
+See also [`odd`](#odd_a)
+----
+function even = |a| -> (a % 2) == 0
+
+----
+Checks if the value is odd.
+
+See also [`even`](#even_a)
+----
+function odd = |a| -> (a % 2) == 1
+
+----
+Swapped curried containment test.
+
+Checks if `collection` contains `value`.
+The collection object can be anything with a `contains` method.
+
+For instance:
+
+    let predicate = contains(42)
+    if (predicate(collection)) {
+      ...
+    }
+
+- *param* `value`: the value to test for containment
+- *param* `collection`: any object having a `contains` method
+----
+@!curry
+function contains = |value, collection| -> collection:contains(value)
+
+----
+Emptiness test.
+
+Checks if the collection-like argument is empty.
+----
+function isEmpty = |o| -> o: isEmpty()
+
+----
+Curried identity comparison
+
+    `is(ref, obj) == obj is ref
+
+Parameters are swapped to ease partialization, as in:
+
+    lst: filter(is(ref))
+----
+@!curry
+function `is = |ref, obj| -> obj is ref
+
+----
+Curried difference comparison
+
+    `isnt(ref, obj) = obj isnt ref
+
+Like `is`, this is more useful partialized. For instance:
+
+    lst: filter(`isnt(null))
+----
+@!curry
+function `isnt = |ref, obj| -> obj isnt ref
+
+----
+Curried type checking
+
+    `oftype(type, obj) = obj oftype type
+
+Partialized version can be used as a predicate, for instance in `filter`:
+
+    alist: filter(`oftype(String.class))
+
+----
+@!curry
+function `oftype = |type, object| -> object oftype type
+
+----
+Null value substitution
+
+    `orIfNull(0, 3) == 3
+    `orIfNull(0, null) == 0
+
+This function can be useful, for example, to replace `null` values in a list with
+a map:
+
+    list[1, 2, null, 3]:map(`orIfNull(0)) == list[1, 2, 0, 3]
+----
+@!curry
+function `orIfNull = |fallback, value| -> value orIfNull fallback
+
+
+#=== Destructuring =====================================================
+
+----
+First element of a list, tuple, vector, array.
+
+    fst([a, b]) == a
+
+- *param* `t`: any object with a `get` method and at least one element.
+- *throws* an `IndexOutOfBoundsException` if the object is empty.
+----
+function fst = |t| -> t: get(0)
+
+----
+Second element of a list, tuple, vector, array.
+
+    snd([a, b]) == b
+
+- *param* `t`: any object with a `get` method and at least two elements.
+- *throws* an `IndexOutOfBoundsException` if the object has less than 2 elements.
+----
+function snd = |t| -> t: get(1)
+
+----
+Curried indexing.
+
+    getitem(obj, i) == obj: get(i)
+
+Throws an `IndexOutOfBoundsException` (for a collection-like object) or returns
+`null` (for a map-like object) if the index is not present.
+
+- *param* `obj`: any object having a `get` method
+- *param* `i`: the index to get
+
+See also [`setitem`](#setitem_obj_i), [`getter`](#getter_i)
+----
+@!curry
+function getitem = |obj, i| -> obj: get(i)
+
+----
+Curried indexed assignment
+
+    setitem(obj, i, v) == obj: set(i, v)
+
+- *param* `obj`: any object having a `set` method
+- *param* `i`: the index to set
+- *param* `v`: the value to set
+
+See also [`getitem`](#getitem_obj_i), [`getter`](#getter_i)
+----
+@!curry
+function setitem = |obj, i, v| {
+  obj: set(i, v)
+  return obj
+}
+
+----
+Indexer factory (curried indexing).
+
+    let third = getter(2)
+    third([1, 2, 3, 4]) -> 3
+
+See also [`getitem`](#getitem_obj_i)
+----
+function getter = |i| -> |col| -> col: get(i)
+
+
+####################################################################
+----
+The identity function.
+
+Returns it's argument unchanged. This can be useful with
+*higher order functions* (*I* combinator).
+----
+function id = |x| -> x
+
+----
+The constant function.
+
+Returns a new variadic functions that always returns `val`, ignoring its
+arguments. For example:
+
+    let theAnswerTo = const(42)
+
+    theAnswerTo() == 42
+    theAnswerTo(1, 2, 3) == 42
+    theAnswerTo("Life, the Universe and Everything") == 42
+
+One interesting use case is to write "pipe" like composition, with the argument
+on the left:
+
+    const(42): andThen(f): andThen(g): andThen(h)() == h(g(f(42)))
+
+This is also the *K* combinator.
+----
+function const = |val| -> |_...| -> val
+
+----
+`false` constant function.
+----
+function False = |_...| -> false
+
+----
+`true` constant function.
+----
+function True = |_...| -> true
+
+----
+`null` constant function.
+----
+function Null = |_...| -> null
+
+
+#== Changing a function arity =============================================
+----
+Function to curryfy a function, i.e. transforms a polyadic function into a
+sequence of variadic functions. This allows for automatic partial application.
+
+This is equivalent to applying `invokeOrBind` on each call.
+
+E.g.
+
+    function f = |a, b, c| -> a + b + c
+
+    let g = curry(^f)
+
+    g(29)(10)(3) == f(29, 10, 3)
+    g(29, 10)(3) == 42
+    g(29)(10, 3) == 42
+
+    let g1 = g(29)
+    let g2 = g1(10)
+    let g3 = g(29, 10)
+
+    g(29, 10, 3) == 42
+    g1(10, 3) == 42
+    g1(10)(3) == 42
+    g2(3) == 42
+    g3(3) == 42
+
+This is particularly useful to allow composing polyadic functions. For
+instance, with the previous `g`:
+
+    let h = g(2, 20): andThen(g("The answer", " is "))
+    h(20) == "The answer is 42"
+
+If the function is variadic, only the fixed parameters can be partialized.
+For instance, given:
+
+    @!curry
+    function f = |a, b, c...| -> ...
+    ...
+    let g = f(1, 2)
+
+then `g` is a variadic function that can't be called partially. All the
+following calls are valids:
+
+    g()
+    g(1)
+    g(1, 2, 3)
+
+but
+
+    g(1)(2)
+
+is not.
+
+This function can also be used as a decorator.
+
+- *param* `f` the function to curry
+- *return* a variadic function dispatching on `f` that can be partialized
+
+See also [`uncurry`](#uncurry_f)
+----
+function curry = |f| -> match {
+  when f: arity() < 2 then f
+  otherwise |args...| {
+    let result = f: invokeOrBind(args)
+    return match {
+      when isClosure(result) then curry(result)
+      otherwise result
+    }
+  }
+}
+
+----
+Reverse of [`curry`](#curry_f).
+
+Take a curried function (e.g. `|a| -> |b| -> a + b`) and return a polyadic
+function (e.g. `|a, b| -> a + b`).
+It is actually a variadic function calling the curried one in sequence.
+
+The two functions defined by
+
+    let f = curry(|a, b, c| -> a + b + c)
+    let g = uncurry(|a| -> |b| -> |c| -> a + b + c)
+
+have the same behavior.
+
+This function can also be used as a decorator.
+
+- *param* `f` the function to uncurry
+- *return* a variadic function dispatching on `f`
+
+See also [`curry`](#curry_f)
+----
+function uncurry = |f| -> match {
+  when f: isVarargsCollector() then f
+  otherwise |args...| {
+    var uc = f
+    var i = 0
+    var argslength = args: length()
+    while i < argslength and not uc: isVarargsCollector() {
+      uc = uc(args: get(i))
+      i = i + 1
+    }
+    return match {
+      when i < argslength then uc: invoke(Arrays.copyOfRange(args, i, argslength))
+      when isClosure(uc) then uncurry(uc)
+      otherwise uc
+    }
+  }
+}
+
+----
+Convers a polyadic function into an unary function.
+E.g.
+
+    let f = |a, b, c| -> a + b + c
+    let g = unary(f)
+
+    g([1, 2, 3]) == 6
+
+If the function already takes zero or one argument, it is returned
+unchanged.
+
+This can be useful in HOF, for example to `map` a binary function on a list of
+couple:
+
+    let f = |a, b| -> ...
+    list[["a", 1], ["b", 2], ["c", 3]]: map(unary(f))
+
+results in `list[f("a", 1), f("b", 2), f("c", 3)]`
+
+The resulting unary function will accept any object having a `toArray` method
+(array, tuple, collection, map entry, struct...)
+
+Thus, `unary(func)(arg)` is equivalent to `func: invoke(arg: toArray())`
+
+This function can also be used as a decorator.
+
+See also [`spreader`](#spreader_f) and [`varargs`](#varargs_f)
+----
+function unary = |f| -> |args| -> f: invoke(args: toArray())
+
+----
+Convers a polyadic function into an unary function.
+
+Similar to [`unary`](#unary_f) but using `spread` instead of `invoke`.
+
+This function can also be used as a decorator.
+
+See also [`varargs`](#varargs_f)
+----
+function spreader = |f| -> |args| -> f: spread(args: toArray())
+
+----
+Convert an unary function taking an array into a variadic function.
+
+This is the contrary of [`unary`](#unary_f).
+E.g.
+
+    let f = |t| -> t:get(0) + t:get(1) + t:get(2)
+    let g = varargs(f)
+
+    f([1, 2, 3]) == g(1, 2, 3)
+
+This function can also be used as a decorator.
+
+See also [`spreader`](#spreader_f) and [`unary`](#unary_f)
+----
+function varargs = |f| -> f: asVarargsCollector(objectArrayType())
+
+#=== Other signature changing HOF =============================================
+
+----
+Change the signature of the given binary function by swapping its arguments,
+such that:
+
+    swapArgs(f)(b, a) == f(a, b)
+
+*Warning*: when using this function with one previously wrapped in
+[`curry`](#curry_f) or [`uncurry`](#uncurry_f), the resulting function can't be
+automatically partialized any more.
+----
+function swapArgs = |func| {
+  return match {
+    when func: arity() == 2 and func: isVarargsCollector() then
+      |a, b| -> func: asFixedArity()(b, a)
+    when func: arity() == 1 and func: isVarargsCollector() then
+      |args...| -> func: invoke(swapCouple(args))
+    when func: arity() == 2 then |a, b| -> func: invoke(b, a)
+    otherwise raise("Can only swap binary functions")
+  }
+}
+
+----
+Change the signature of the given curried binary function by swapping its
+arguments, such that:
+
+    swapCurry(f)(a)(b) = f(b)(a)
+----
+function swapCurry = |func| -> |a| -> |b| -> func(b)(a)
+
+
+local function isCollection = |v| -> (
+  v oftype java.util.List.class
+  or v oftype gololang.Tuple.class
+  or v oftype java.util.RandomAccess.class
+  or isArray(v)
+)
+
+----
+Swap the values of a couple.
+
+The couple can be a tuple, a vector, a list or an array as long as its size is 2.
+The return value as the same type.
+
+For example:
+
+    swap([a, b]) == [b, a]
+----
+function swapCouple = |couple| {
+  require(couple: size() == 2, "Can only swap a couple")
+  let a = couple: get(1)
+  let b = couple: get(0)
+  return match {
+    when couple oftype java.util.List.class then list[a, b]
+    when couple oftype gololang.Tuple.class then tuple[a, b]
+    when couple oftype java.util.RandomAccess.class then vector[a, b]
+    when isArray(couple) then array[a, b]
+    otherwise
+      raise("Can't swap a " + couple:getClass():getName())
+  }
+}
+
+----
+Polymorphic swapping.
+
+This function dispatches on [`swapArgs`](#swapArgs_func),
+[`swapCurry`](#swapCurry_func) or [`swapCouple`](#swapCouple_couple) according
+to its parameter.
+
+Note that we have the property that given a binary function `f` and a
+couple `c`
+
+    unary(f)(swap(c)) == unary(swap(f))(c)
+
+When applied to functions, equivalent to the *C* combinator.
+----
+function swap = |v| -> match {
+  when isClosure(v) and v:arity() == 1 and not v: isVarargsCollector() then swapCurry(v)
+  when isClosure(v) then swapArgs(v)
+  when isCollection(v) then swapCouple(v)
+  otherwise
+    raise("Can't swap a " + v:getClass():getName())
+}
+
+
+#==== Composition and application =============================================
+
+----
+Reversed curried function application.
+
+Apply the given function to the given value.
+
+    invokeWith("a", "b", "c")(f) == f("a", "b", "c")
+
+For instance, given a list of functions:
+
+    list[f, g, h]: map(invokeWith(42)) == list[f(42), g(42), h(42)]
+
+It can also be used to promote a value in continuation passing style.
+
+- *param* `args` the values on which apply the function
+----
+function invokeWith = |args...| -> |f| -> f: invoke(args)
+
+----
+Function chaining.
+
+This is similar to Unix pipe:
+
+    pipe(f1, f2, f3)(x) == f3(f2(f1(x))))
+
+i.e. apply `f1` to `x`, then pass it to `f2`, and then `f3`.
+This is the same as `f1: andThen(f2): andThen(f3)(x)`
+
+You can insert a side-effect only function in the chain using [`io`](#io_block):
+
+    pipe(f1, io({println("hello")}), f2)(42)
+
+is equivalent to:
+
+    let tmp = f1(x)
+    println("hello")
+    f2(tmp)
+
+This is similar to [`compose`](#compose_funcs), but with functions order
+reversed.
+
+Example:
+
+    let cmd = pipe(mul(2), add(4), ^toString, addTo("val: "))
+    cmd(19) == "val: 42"
+    let other = pipe(^intValue, add(4), mul(2))
+    other("17") == 42
+
+If no function is given, returns [`id`](#id_x)
+
+For a similar construct that deal with errors, see for instance the
+[`gololang.Errors`](Errors.html#java.util.Optional.andThen_this_f) module
+----
+function pipe = |funcs...| {
+  var r = ^id
+  foreach f in funcs {
+    r = r: andThen(f)
+  }
+  return r
+}
+
+----
+Function composition.
+
+    compose(f1, f2, f3)(x) == f1(f2(f3(x)))
+
+This is similar to [`pipe`](#pipe_funcs), but with functions order
+reversed (*B* combinator).
+----
+function compose = |funcs...| {
+  var r = ^id
+  for (var i = funcs: length() - 1, i >= 0, i = i - 1) {
+    r = r: andThen(funcs: get(i))
+  }
+  return r
+}
+
+----
+Transform a function with side effects (generally IO operations, thus the name)
+into a function applying the side effect and returning its argument.
+
+The given function can have no parameters, or accept an argument.
+
+This can be used to insert such a function into a composition chain:
+
+    f1: andThen(io({println("hello")})): andThen(f2)
+    f1: andThen(io(|x|{println("got " + x)})): andThen(f2)
+
+- *param* `block` a function with side effects
+
+See also [`pipe`](#pipe_funcs) and [`compose`](#compose_funcs)
+----
+function io = |block| -> |x| {
+  if block: arity() == 1 {
+    block(x)
+  } else {
+    block()
+  }
+  return x
+}
+
+----
+Apply the given function until the predicate holds.
+
+For instance:
+
+    let f = until(gt(10), mul(2))
+    f(15) == 15
+    f(2) == 16
+    f(9) == 18
+----
+function until = |predicate, fun| -> |x| {
+  var r = x
+  while not predicate: invoke(r) {
+    r = fun: invoke(r)
+  }
+  return r
+}
+
+----
+Fixed-point combinator.
+
+This is an abstraction of recursion.
+
+- *param* `f` the function that will recur
+- *retun* a function that makes recursive call to `f`
+----
+function recur = |f| -> (|x| -> f(|y| -> x(x)(y)))((|x| -> f(|y| -> x(x)(y))))
+
+----
+Conditional application combinator.
+
+Equivalent to using the `match` construct:
+
+    let r = cond(predicate, ifTrue, ifFalse, x)
+
+    # equivalent to
+    let r = match {
+      when predicate(x) then ifTrue(x)
+      otherwise ifFalse(x)
+    }
+
+Since this function is curried, it can be used as:
+
+    let f = cond(predicate, ifTrue, ifFalse)
+
+    # equivalent to
+    let f = |x| -> match {
+      when predicate(x) then ifTrue(x)
+      otherwise ifFalse(x)
+    }
+
+- *param* `predicate` a boolean function
+- *param* `ifTrue` the unary function to apply if `predicate` holds
+- *param* `ifFalse` the unary function to apply otherwise
+----
+@curry
+function cond = |predicate, ifTrue, ifFalse, x| -> match {
+  when predicate(x) then ifTrue(x)
+  otherwise ifFalse(x)
+}
+

--- a/src/main/golo/standard-augmentations.golo
+++ b/src/main/golo/standard-augmentations.golo
@@ -629,7 +629,7 @@ augment java.util.Map {
   }
 
   ----
-  Adds a tuple [key, value] or a map entry and returns the map.
+  Adds a tuple `[key, value]` or a map entry and returns the map.
   ----
   function add = |this, kv| {
     case {
@@ -758,7 +758,7 @@ augment java.util.Map {
   Maps entries of the map using a function.
 
   `func` takes 2 arguments: a key and a value. The returned value must have `getKey()` and
-  getValue()` to represent a map entry. We suggest using the predefined `mapEntry(key, value)`
+  `getValue()` to represent a map entry. We suggest using the predefined `mapEntry(key, value)`
   function as it returns such object.
   ----
   function map = |this, func| {
@@ -822,6 +822,11 @@ augment java.util.Map$Entry {
   Destructurate a map entry in key and value
   ----
   function destruct = |this| -> [ this: getKey(), this: getValue() ]
+
+  ----
+  Convert then entry into an array containing the key and the value.
+  ----
+  function toArray = |this| -> array[this: getKey(), this: getValue()]
 }
 # ............................................................................................... #
 

--- a/src/main/java/gololang/GoloStruct.java
+++ b/src/main/java/gololang/GoloStruct.java
@@ -63,6 +63,15 @@ public abstract class GoloStruct implements Iterable<Tuple>, Comparable<GoloStru
   }
 
   /**
+   * Array conversion.
+   *
+   * @return an array containing the values (in member orders)
+   */
+  public Object[] toArray() {
+    return values().toArray();
+  }
+
+  /**
    * Compares this structure with the specified structure for order.
    * <p>Returns a negative integer, zero, or a positive integer as this structure is less than,
    * equal to, or greater than the specified structure.

--- a/src/main/java/gololang/Tuple.java
+++ b/src/main/java/gololang/Tuple.java
@@ -222,7 +222,9 @@ public final class Tuple implements HeadTail<Object>, Comparable<Tuple> {
   }
 
   /**
-   * Returns a array of this tuple data.
+   * Returns an array containing all of the elements in this tuple.
+   *
+   * @return an array of values
    */
   public Object[] toArray() {
     return Arrays.copyOf(data, data.length);

--- a/src/main/java/gololang/Union.java
+++ b/src/main/java/gololang/Union.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012-2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package gololang;
+
+/**
+ * Base class for Golo union objects.
+ * <p>
+ * This class defines common behavior.
+ */
+public abstract class Union {
+  /**
+   * Array conversion.
+   *
+   * @return an array containing the values (in member orders)
+   */
+  public Object[] toArray() {
+    return new Object[]{};
+  }
+
+  /**
+   * Destructuration helper.
+   *
+   * @return a tuple with the current values.
+   */
+  public Tuple destruct() {
+    return Tuple.fromArray(toArray());
+  }
+}

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUnionGenerator.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUnionGenerator.java
@@ -32,8 +32,8 @@ class JavaBytecodeUnionGenerator {
     ClassWriter classWriter = new ClassWriter(COMPUTE_FRAMES | COMPUTE_MAXS);
     classWriter.visitSource(sourceFilename, null);
     classWriter.visit(V1_8, ACC_PUBLIC | ACC_SUPER | ACC_ABSTRACT,
-        union.getPackageAndClass().toJVMType(), null, "java/lang/Object", null);
-    makeDefaultConstructor(classWriter, "java/lang/Object");
+        union.getPackageAndClass().toJVMType(), null, "gololang/Union", null);
+    makeDefaultConstructor(classWriter, "gololang/Union");
     HashMap<String, PackageAndClass> staticFields = new HashMap<>();
     for (UnionValue value : union.getValues()) {
       makeMatchlikeTestMethod(classWriter, value, false);
@@ -186,7 +186,7 @@ class JavaBytecodeUnionGenerator {
       makeValuedConstructor(classWriter, value);
       makeHashCode(classWriter, value);
       makeEquals(classWriter, value);
-      makeDestruct(classWriter, value);
+      makeToArray(classWriter, value);
     } else {
       makeDefaultConstructor(classWriter, unionType);
       parentClassWriter.visitField(ACC_PUBLIC | ACC_FINAL | ACC_STATIC, value.getName(),
@@ -285,6 +285,15 @@ class JavaBytecodeUnionGenerator {
     mv.visitCode();
     loadMembersArray(mv, value);
     mv.visitMethodInsn(INVOKESTATIC, "gololang/Tuple", "fromArray", "([Ljava/lang/Object;)Lgololang/Tuple;", false);
+    mv.visitInsn(ARETURN);
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+  }
+
+  private void makeToArray(ClassWriter cw, UnionValue value) {
+    MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "toArray", "()[Ljava/lang/Object;", null, null);
+    mv.visitCode();
+    loadMembersArray(mv, value);
     mv.visitInsn(ARETURN);
     mv.visitMaxs(0, 0);
     mv.visitEnd();

--- a/src/main/java/org/eclipse/golo/runtime/ArrayMethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/ArrayMethodFinder.java
@@ -33,7 +33,7 @@ class ArrayMethodFinder extends MethodFinder {
   @Override
   public MethodHandle find() {
     try {
-      return resolve().asType(invocation.type());
+      return invocation.coerce(resolve());
     } catch (NoSuchMethodException | IllegalAccessException e) {
       throw new RuntimeException(e);
     }
@@ -50,20 +50,23 @@ class ArrayMethodFinder extends MethodFinder {
       case "size":
       case "length":
         checkArity(0);
-        return lookup.findStatic(Array.class, "getLength",
-                                 methodType(int.class, Object.class));
+        return lookup.findStatic(Array.class, "getLength", methodType(int.class, Object.class));
       case "iterator":
         checkArity(0);
         return lookup.findConstructor(PrimitiveArrayIterator.class,
                                       methodType(void.class, Object[].class));
       case "toString":
         checkArity(0);
-        return lookup.findStatic(Arrays.class, "toString",
-                                 methodType(String.class, Object[].class));
+        return lookup.findStatic(Arrays.class, "toString", methodType(String.class, Object[].class));
       case "asList":
         checkArity(0);
-        return lookup.findStatic(Arrays.class, "asList",
-                                 methodType(List.class, Object[].class)).asFixedArity();
+        return lookup.findStatic(Arrays.class, "asList", methodType(List.class, Object[].class));
+      case "toArray":
+        checkArity(0);
+        return MethodHandles.identity(invocation.receiverClass());
+      case "destruct":
+        checkArity(0);
+        return lookup.findStatic(gololang.Tuple.class, "fromArray", methodType(gololang.Tuple.class, Object[].class));
       case "equals":
         checkArity(1);
         return lookup.findStatic(Arrays.class, "equals",
@@ -76,18 +79,15 @@ class ArrayMethodFinder extends MethodFinder {
       case "head":
         checkArity(0);
         return lookup.findStatic(
-            ArrayHelper.class, "head", methodType(Object.class, Object[].class))
-          .asType(invocation.type());
+            ArrayHelper.class, "head", methodType(Object.class, Object[].class));
       case "tail":
         checkArity(0);
         return lookup.findStatic(
-            ArrayHelper.class, "tail", methodType(Object[].class, Object[].class))
-          .asType(invocation.type());
+            ArrayHelper.class, "tail", methodType(Object[].class, Object[].class));
       case "isEmpty":
         checkArity(0);
         return lookup.findStatic(
-            ArrayHelper.class, "isEmpty", methodType(boolean.class, Object[].class))
-          .asType(invocation.type());
+            ArrayHelper.class, "isEmpty", methodType(boolean.class, Object[].class));
       default:
         throw new UnsupportedOperationException(invocation.name() + " is not supported on arrays");
     }

--- a/src/test/java/gololang/OperatorsAndHofTest.java
+++ b/src/test/java/gololang/OperatorsAndHofTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012-2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package gololang;
+
+import org.testng.annotations.Test;
+import org.eclipse.golo.internal.testing.GoloTest;
+
+import java.util.function.*;
+
+
+public class OperatorsAndHofTest extends GoloTest {
+
+  @Override
+  protected String srcDir() {
+    return "for-test/";
+  }
+
+  @Test
+  public void testFunctools() throws Throwable {
+    run("functions");
+  }
+
+}

--- a/src/test/resources/for-execution/destruct.golo
+++ b/src/test/resources/for-execution/destruct.golo
@@ -53,6 +53,13 @@ function test_list = {
 
 }
 
+function test_array = {
+  let fst, scd, rest... = array[1, 2, 3, 4, 5]
+  require(fst == 1, "err")
+  require(scd == 2, "err")
+  require(rest == [3, 4, 5], "err")
+}
+
 function test_range = {
   let fst, scd, rest... = [1..6]
   require(fst == 1, "err")

--- a/src/test/resources/for-test/functions.golo
+++ b/src/test/resources/for-test/functions.golo
@@ -1,0 +1,416 @@
+module golo.test.Functions
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest
+
+import gololang.Functions
+
+local function assertEquals = |value, expected| {
+  assertThat(value, Matchers.equalTo(expected))
+}
+
+# ........................................................................... #
+struct Plop = { a, b, c }
+
+union Tada = {
+  C = { a, b, c }
+}
+
+function foo = |a, b, cs...| {
+  let l = list[a, b]
+  l: addAll(cs: asList())
+  return l: join(":")
+}
+
+function varonly = |args...| -> args: asList(): join(":")
+
+function bar = |a, b, c| -> a + b + c
+
+function curried = |a| -> |b| -> |c| -> a + b + c
+
+function curriedvar = |a| -> |b| -> |c...| ->
+  a + ":" + b + ":" + c: asList(): join(":")
+
+# ........................................................................... #
+function test_add = {
+  assertEquals(add(3, 4), 7)
+  assertEquals(add("b", "a"), "ab")
+
+  assertEquals(list[1, 2, 3]: map(add(3)), list[4, 5, 6])
+
+  assertEquals(add(2.5, 4.2), 6.7)
+
+  let f = add(42): andThen(add(1337)): andThen(add(69))
+  assertEquals(f(list[]), list[42, 1337, 69])
+  assertEquals(f(0), 1448)
+  assertEquals(f(StringBuilder()): toString(), "42133769")
+
+  assertEquals(add("a", StringBuilder()): toString(), "a")
+}
+
+function test_operators = {
+  assertEquals(succ(41), 42)
+  assertEquals(succ(1.2), 2.2)
+  assertEquals(pred(43), 42)
+  assertThat(pred(2.2), Matchers.closeTo(1.2, 0.0001))
+
+  assertEquals(mul(2, 21), 42)
+  assertEquals(mul(2)(21), 42)
+
+  assertEquals(neg(5), -5)
+  assertEquals(neg(5_L), -5_L)
+  assertEquals(neg(2.5), -2.5)
+
+  assertEquals(sub(3, 2), 1)
+  assertEquals(sub(2, 3), -1)
+  assertEquals(sub(2.5, 0.5), 2.0)
+  assertEquals(sub(2)(1), 1)
+  assertEquals(rsub(2, 3), 1)
+  assertEquals(rsub(1)(2), 1)
+
+  assertThat(div(1, 2), Matchers.equalTo(0))
+  assertThat(div(1.0, 2.0), Matchers.closeTo(0.5, 0.001))
+  assertThat(div(1)(2.0), Matchers.closeTo(0.5, 0.001))
+  assertThat(div(1.0)(2), Matchers.closeTo(0.5, 0.001))
+
+  assertThat(rdiv(2, 1), Matchers.equalTo(0))
+  assertThat(rdiv(2.0, 1.0), Matchers.closeTo(0.5, 0.001))
+  assertThat(rdiv(2)(1.0), Matchers.closeTo(0.5, 0.001))
+  assertThat(rdiv(2.0)(1), Matchers.closeTo(0.5, 0.001))
+
+  assertEquals(`orIfNull(0, 3), 3)
+  assertEquals(`orIfNull(0, null), 0)
+  assertEquals(`orIfNull(0)(3), 3)
+  assertEquals(`orIfNull(0)(null), 0)
+
+  assertEquals(`is(null)(null), true)
+  assertEquals(`is(null)(42), false)
+  assertEquals(`isnt(null)(42), true)
+  assertEquals(`isnt(null)(null), false)
+
+  assertEquals(`oftype(Integer.class)(42), true)
+  assertEquals(`oftype(Integer.class)("foo"), false)
+
+  let predicate = contains(42)
+  assertEquals(predicate(list[1, 42, 3]), true)
+  assertEquals(predicate(list[1, 3]), false)
+}
+
+function test_booleans = {
+  assertEquals(`and(true, true), true)
+  assertEquals(`and(false, true), false)
+  assertEquals(`and(false)(true), false)
+  assertEquals(`and(true)(true), true)
+
+  assertEquals(`and(^gololang.Functions::id, ^gololang.Functions::id)(true), true)
+  assertEquals(`and(^gololang.Functions::id)(^gololang.Functions::id)(true), true)
+  assertEquals(`and(^gololang.Functions::id)(^gololang.Functions::id, true), true)
+  assertEquals(`and(^gololang.Functions::id, ^gololang.Functions::id, true), true)
+
+  assertEquals(`and(^gololang.Functions::id, ^gololang.Functions::id)(false), false)
+  assertEquals(`and(^gololang.Functions::id, ^gololang.Functions::not)(true), false)
+  assertEquals(`and(^gololang.Functions::id, ^gololang.Functions::not)(false), false)
+
+  assertEquals(`or(true, true), true)
+  assertEquals(`or(false, true), true)
+  assertEquals(`or(false, false), false)
+  assertEquals(`or(false)(true), true)
+  assertEquals(`or(true)(true), true)
+  assertEquals(`or(false)(false), false)
+  assertEquals(`or(^gololang.Functions::id, ^gololang.Functions::id)(true), true)
+  assertEquals(`or(^gololang.Functions::id)(^gololang.Functions::id)(true), true)
+  assertEquals(`or(^gololang.Functions::id)(^gololang.Functions::id, true), true)
+  assertEquals(`or(^gololang.Functions::id, ^gololang.Functions::id, true), true)
+
+  assertEquals(`or(^gololang.Functions::id, ^gololang.Functions::id)(false), false)
+  assertEquals(`or(^gololang.Functions::id, ^gololang.Functions::not)(true), true) 
+  assertEquals(`or(^gololang.Functions::id, ^gololang.Functions::not)(false), true)
+
+  assertEquals(xor(true, true), false)
+  assertEquals(xor(true, false), true)
+  assertEquals(xor(false, true), true)
+  assertEquals(xor(false, false), false)
+  assertEquals(xor(true)(true), false)
+  assertEquals(xor(true)(false), true)
+  assertEquals(xor(false)(true), true)
+  assertEquals(xor(false)(false), false)
+}
+
+function test_extractors = {
+  assertEquals(fst([1, 2]), 1)
+  assertEquals(snd([1, 2]), 2)
+  assertEquals(getitem([1, 2, 3], 2), 3)
+  assertEquals(getter(2)([1, 2, 3]), 3)
+}
+
+function test_not = {
+  assertEquals(`not(true), false)
+  assertEquals(`not(false), true)
+  assertEquals(`not(^gololang.Functions::isEmpty)(list[1]), true)
+
+  assertEquals(list[true, false, false]: map(^gololang.Functions::not),
+               list[false, true, true])
+
+  let e = |a| -> (a % 2) == 0
+  let o = `not(e)
+
+  assertEquals(o(3), true)
+  assertEquals(o(2), false)
+}
+
+function test_const = {
+    let theAnswerTo = const(42)
+
+    assertEquals(theAnswerTo(), 42)
+    assertEquals(theAnswerTo(1, 2, 3), 42)
+    assertEquals(theAnswerTo("Life, the Universe and Everything"), 42)
+}
+
+function test_until = {
+  let f = until(gt(10), mul(2))
+
+  assertEquals(f(15), 15)
+  assertEquals(f(2), 16)
+  assertEquals(f(9), 18)
+}
+
+function test_curry = {
+  let barc = curry(^bar)
+  assertEquals(42, barc(29, 10, 3))
+  assertEquals(42, barc(29)(10, 3))
+  assertEquals(42, barc(29)(10)(3))
+  assertEquals(42, barc(29, 10)(3))
+
+  let barc2 = barc(29)
+  let barc3 = barc2(10)
+  let barc4 = barc(29)(10)
+  assertEquals(42, barc2(10)(3))
+  assertEquals(42, barc3(3))
+  assertEquals(42, barc4(3))
+
+  let f = barc(2, 20): andThen(barc("The answer", " is "))
+  assertEquals(f(20), "The answer is 42")
+}
+
+function test_base_varargs = {
+  assertEquals(foo("a", "b"), "a:b")
+  assertEquals(foo("a", "b", "c"), "a:b:c")
+  assertEquals(foo("a", "b", "c1", "c2"), "a:b:c1:c2")
+  assertEquals(foo("a", "b", array["c1", "c2"]), "a:b:c1:c2")
+
+  assertEquals(varonly("a", "b", "c"), "a:b:c")
+}
+
+function test_curry_varargs = {
+  let fooc = curry(^foo)
+  assertEquals(fooc("a", "b", "c"), "a:b:c")
+  assertEquals(fooc("a", "b", "c1", "c2"), "a:b:c1:c2")
+  assertEquals(fooc("a", "b")(), "a:b")
+  assertEquals(fooc("a", "b")("c"), "a:b:c")
+  assertEquals(fooc("a", "b")("c1", "c2"), "a:b:c1:c2")
+  assertEquals(fooc("a", "b")(array["c1", "c2"]), "a:b:c1:c2")
+  assertEquals(fooc("a")("b")("c"), "a:b:c")
+  assertEquals(fooc("a")("b")("c1", "c2"), "a:b:c1:c2")
+  assertEquals(fooc("a")("b")(array["c1", "c2"]), "a:b:c1:c2")
+  assertEquals(fooc("a")("b", "c"), "a:b:c")
+  assertEquals(fooc("a")("b", "c1", "c2"), "a:b:c1:c2")
+}
+
+function test_arity = {
+  assertEquals((-> "dhoo"): arity(), 0)
+  assertEquals((|a| -> "dhoo"): arity(), 1)
+  assertEquals((|a...| -> "dhoo"): arity(), 1)
+  assertEquals((|a, b| -> "dhoo"): arity(), 2)
+  assertEquals((|a, b...| -> "dhoo"): arity(), 2)
+}
+
+function test_iob = {
+  assertEquals(^bar: invokeOrBind("a"): invokeOrBind("b"): invokeOrBind("c"),
+               "abc")
+  assertEquals(^bar: invokeOrBind("a"): invoke("b", "c"), "abc")
+  assertEquals(^bar: invokeOrBind("a")("b", "c"), "abc")
+  assertEquals(^bar: invokeOrBind("a", "b")("c"), "abc")
+  assertEquals(^bar: invokeOrBind("a", "b", "c"), "abc")
+}
+
+function test_iob_varargs = {
+  assertEquals(^foo: invokeOrBind("a", "b", "c"), "a:b:c")
+  assertEquals(^foo: invokeOrBind("a", "b", "c1", "c2"), "a:b:c1:c2")
+  assertEquals(^foo: invokeOrBind("a", "b"): invoke(array["c1", "c2"]),
+                "a:b:c1:c2")
+
+  assertEquals(^foo: invokeOrBind("a", "b")(), "a:b")
+  assertEquals(^foo: invokeOrBind("a", "b")("c"), "a:b:c")
+  assertEquals(^foo: invokeOrBind("a", "b")("c1", "c2"), "a:b:c1:c2")
+
+  assertEquals(^foo: invokeOrBind("a")("b", "c"), "a:b:c")
+  assertEquals(^foo: invokeOrBind("a")("b", "c1", "c2"), "a:b:c1:c2")
+}
+
+function test_unary = {
+  let bu = unary(^bar)
+  assertEquals(bu(array["a", "b", "c"]), "abc")
+  assertEquals(bu(tuple["a", "b", "c"]), "abc")
+  assertEquals(bu(list["a", "b", "c"]), "abc")
+  assertEquals(bu(Plop("a", "b", "c")), "abc")
+  assertEquals(bu(C("a", "b", "c")), "abc")
+}
+
+function test_unary_varargs = {
+  let fu = unary(^foo)
+  assertEquals(fu(array["a", "b"]), "a:b")
+  assertEquals(fu(array["a", "b", "c"]), "a:b:c")
+  assertEquals(fu(tuple["a", "b", "c"]), "a:b:c")
+  assertEquals(fu(list["a", "b", "c"]), "a:b:c")
+  assertEquals(fu(Plop("a", "b", "c")), "a:b:c")
+  assertEquals(fu(C("a", "b", "c")), "a:b:c")
+  assertEquals(fu(array["a", "b", "c", "d"]), "a:b:c:d")
+
+  let vu = unary(^varonly)
+  assertEquals(vu(array["a", "b", "c"]), "a:b:c")
+  assertEquals(vu(tuple["a", "b", "c"]), "a:b:c")
+  assertEquals(vu(list["a", "b", "c"]), "a:b:c")
+  assertEquals(vu(Plop("a", "b", "c")), "a:b:c")
+  assertEquals(vu(C("a", "b", "c")), "a:b:c")
+}
+
+function test_varargs = {
+  let f = varargs(|a| -> a: get(0) + a: get(1) + a: get(2))
+  let g = varargs(|a| -> a: asList(): join(":"))
+
+  assertEquals(f("a", "b", "c"), "abc")
+  assertEquals(g("a", "b", "c"), "a:b:c")
+}
+
+function test_spreader = {
+  let bu = spreader(^bar)
+  assertEquals(bu(array["a", "b", "c"]), "abc")
+  assertEquals(bu(tuple["a", "b", "c"]), "abc")
+  assertEquals(bu(list["a", "b", "c"]), "abc")
+  assertEquals(bu(Plop("a", "b", "c")), "abc")
+  assertEquals(bu(C("a", "b", "c")), "abc")
+}
+
+function test_spreader_varargs = {
+  let fu = spreader(^foo)
+  assertEquals(fu(array["a", "b", array[]]), "a:b")
+  assertEquals(fu(array["a", "b", "c"]), "a:b:c")
+  assertEquals(fu(tuple["a", "b", "c"]), "a:b:c")
+  assertEquals(fu(list["a", "b", "c"]), "a:b:c")
+  assertEquals(fu(Plop("a", "b", "c")), "a:b:c")
+  assertEquals(fu(C("a", "b", "c")), "a:b:c")
+  assertEquals(fu(array["a", "b", array["c", "d"]]), "a:b:c:d")
+}
+
+function test_uncurry = {
+  let uc = uncurry(^curried)
+  assertEquals("abc", uc()()()("a", "b", "c"))
+  assertEquals("abc", uc("a", "b", "c"))
+  assertEquals("abc", uc(array["a", "b", "c"]))
+  assertEquals("abc", uc("a")("b", "c"))
+  assertEquals("abc", uc("a")("b")("c"))
+  assertEquals("abc", uc("a", "b")("c"))
+}
+
+function test_uncurry_varargs = {
+  let uc = uncurry(^curriedvar)
+  assertEquals(uc("a", "b", "c"), "a:b:c")
+  assertEquals(uc("a", "b", "c1", "c2"), "a:b:c1:c2")
+  assertEquals(uc("a", "b")(), "a:b:")
+  assertEquals(uc("a", "b")("c"), "a:b:c")
+  assertEquals(uc("a", "b")("c1", "c2"), "a:b:c1:c2")
+  assertEquals(uc("a", "b")(array["c1", "c2"]), "a:b:c1:c2")
+  assertEquals(uc("a")("b")("c"), "a:b:c")
+
+  assertEquals(uc("a")("b")("c1", "c2"), "a:b:c1:c2")
+  assertEquals(uc("a")("b")(array["c1", "c2"]), "a:b:c1:c2")
+  assertEquals(uc("a")("b", "c"), "a:b:c")
+  assertEquals(uc("a")("b", "c1", "c2"), "a:b:c1:c2")
+}
+
+function test_swap = {
+  assertEquals(swap(tuple[1, 2]), tuple[2, 1])
+  assertEquals(swap(list[1, 2]), list[2, 1])
+  assertEquals(swap(array[1, 2]), array[2, 1])
+  assertEquals(swap(vector[1, 2]), vector[2, 1])
+
+  let c = |a| -> |b| -> a + b
+  let f = |a, b| -> a + b
+
+  assertEquals(swap(c)("a")("b"), "ba")
+  assertEquals(swap(f)("a", "b"), "ba")
+
+  assertEquals(unary(f)(swap(["a", "b"])), unary(swap(f))(["a", "b"]))
+}
+
+function test_swap_varargs = {
+  let v = |a, b...| -> a + ":" + b: asList(): join(":")
+  let vv = |a...| -> a: get(0) + a: get(1)
+  assertEquals(swap(vv)("a", "b"), "ba")
+  assertEquals(swap(vv)(array["a", "b"]), "ba")
+  assertEquals(swap(v)(array["a", "b"], "c"), "c:a:b")
+}
+
+function test_swap_curry_uncurry = {
+  let c = uncurry(|a| -> |b| -> a + b)
+  let f = curry(|a, b| -> a + b)
+  assertEquals(swap(c)("a", "b"), "ba")
+  assertEquals(swap(f)("a", "b"), "ba")
+}
+
+function test_invokeWith = {
+  let f = |a| -> "f: " + a
+
+  assertEquals(invokeWith(42)(f), "f: 42")
+  assertEquals(invokeWith("a", "b", "c")(^bar), "abc")
+  assertEquals(invokeWith(array["a", "b", "c"])(^bar), "abc")
+  assertEquals(invokeWith("a", "b", "c", "d")(^foo), "a:b:c:d")
+  assertEquals(invokeWith("a", "b", "c")(^varonly), "a:b:c")
+  assertEquals(invokeWith(array["a", "b", "c"])(^varonly), "a:b:c")
+}
+
+function test_io = {
+  let l = list[]
+
+  let i1 = io({l: add(1)})
+  let i2 = io(|x| {l: add(x)})
+
+  let p = ^gololang.Functions::id
+          : andThen(^gololang.Functions::succ)
+          : andThen(i1)
+          : andThen(i2)
+          : andThen(^gololang.Functions::succ)
+
+  let r = p(1)
+  assertEquals(r, 3)
+  assertEquals(l, list[1, 2])
+}
+
+function test_pipe = {
+  let p = pipe(add(1), mul(2), add("2"))
+  assertEquals(p(1), "42")
+
+  let l = list[add(1), mul(2), add("2")]
+  assertEquals(pipe(l: toArray())(1), "42")
+
+  assertEquals(pipe()(42), 42)
+
+  let cmd1 = pipe(mul(2), add(4), ^gololang.Functions::str, addTo("val: "))
+  assertEquals(cmd1(19), "val: 42")
+
+  let cmd2 = pipe(^gololang.Predefined::intValue, add(4), mul(2))
+  assertEquals(cmd2("17"), 42)
+}
+
+function test_compose = {
+  let p = compose(add("2"), mul(2), add(1))
+  assertEquals(p(1), "42")
+
+  let l = list[add("2"), mul(2), add(1)]
+  assertEquals(compose(l: toArray())(1), "42")
+
+  assertEquals(compose()(42), 42)
+}
+
+function main = |args| {
+}


### PR DESCRIPTION
Adds a module containing useful functions to create
or change functions, to use in HOF for example.

Mainly operators as curried functions, composition functions, arity changing functions.

Adds a `toArray` and a `destruct` method to tuples, arrays, unions and structs to ease
polymorphism:

Adds tooling method to `FunctionReference`:
an `arity` function, and `invokeOrBind`: a function that apply arguments, binding them or
invoking the function according to the number.