### PR TITLE
Compile to Jar archives

### DIFF
--- a/doc/basics.asciidoc
+++ b/doc/basics.asciidoc
@@ -147,6 +147,15 @@ classes/
 $
 ----
 
+It is also possible to output to a Jar archive:
+
+[source]
+----
+golo compile --output hello.jar samples/*.golo
+----
+
+This would take all `.golo` files from the `sample` folder, and assemble the resulting JVM class files in `hello.jar`.
+
 === Running compiled Golo code
 
 Golo provides a `golo` command for running compiled Golo code:

--- a/src/main/java/org/eclipse/golo/cli/command/CompilerCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/CompilerCommand.java
@@ -17,14 +17,19 @@ import org.eclipse.golo.compiler.GoloCompiler;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
 
 @Parameters(commandNames = {"compile"}, commandDescription = "Compiles Golo source files")
 public class CompilerCommand implements CliCommand {
 
-  @Parameter(names = "--output", description = "The compiled classes output directory")
+  @Parameter(names = "--output", description = "The compiled classes output directory or Jar archive")
   String output = ".";
 
   @Parameter(description = "Golo source files (*.golo)")
@@ -33,11 +38,17 @@ public class CompilerCommand implements CliCommand {
   @Override
   public void execute() throws Throwable {
     GoloCompiler compiler = new GoloCompiler();
-    File outputDir = new File(this.output);
+    final boolean compilingToJar = this.output.endsWith(".jar");
+    File outputDir = compilingToJar ? null : new File(this.output);
+    JarOutputStream jarOutputStream = compilingToJar ? new JarOutputStream(new FileOutputStream(new File(this.output)), manifest()) : null;
     for (String source : this.sources) {
       File file = new File(source);
       try (FileInputStream in = new FileInputStream(file)) {
-        compiler.compileTo(file.getName(), in, outputDir);
+        if (compilingToJar) {
+          compiler.compileToJar(file.getName(), in, jarOutputStream);
+        } else {
+          compiler.compileTo(file.getName(), in, outputDir);
+        }
       } catch (IOException e) {
         System.out.println("[error] " + source + " does not exist or could not be opened.");
         return;
@@ -45,5 +56,16 @@ public class CompilerCommand implements CliCommand {
         handleCompilationException(e);
       }
     }
+    if (compilingToJar) {
+      jarOutputStream.close();
+    }
+  }
+
+  private Manifest manifest() {
+    Manifest manifest = new Manifest();
+    Attributes attributes = manifest.getMainAttributes();
+    attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+    attributes.put(new Attributes.Name("Created-By"), "Eclipse Golo " + Metadata.VERSION);
+    return manifest;
   }
 }


### PR DESCRIPTION
The golo compile used to work with an optional --output parameter to
specify a target directory.

With this change, if the target ends with '.jar', then the compilation
results are assembled to a Jar archive instead.