### PR TITLE
Add the ability to use either with Java 8

### DIFF
--- a/src/main/java/gololang/error/Result.java
+++ b/src/main/java/gololang/error/Result.java
@@ -9,16 +9,12 @@
 
 package gololang.error;
 
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.List;
-import java.util.Iterator;
-import java.util.Collections;
+import gololang.FunctionReference;
+import gololang.Tuple;
+
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import gololang.Tuple;
-import gololang.FunctionReference;
 
 /**
  * A container object which represent the result of a maybe failing operation.
@@ -476,7 +472,25 @@ public final class Result<T, E extends Throwable> implements Iterable<T> {
     return mapping.invoke(value);
   }
 
-    /**
+  /**
+   * Case analysis for the result.
+   * <p>
+   * If the result is a value, apply the first function to it;
+   * if it is an error, apply the second function to it.
+   * <p>
+   *
+   * @param mapping the function to apply to the contained value
+   * @param recover the function to apply to the contained error
+   * @return the result of applying the corresponding function
+   */
+  public T either(Function<T,T> mapping, Function<E,T> recover) {
+    if (isError()) {
+      return recover.apply(error);
+    }
+    return mapping.apply(value);
+  }
+
+  /**
    * Three way case analysis for the result.
    * <p>
    * If the result is a value, apply the first function to it;


### PR DESCRIPTION
It could be interesting to use golo as library for Java:

```java
import gololang.error.Result;
import java.util.function.Function;
...

Function<String, Result<Integer, RuntimeException>> toInt = (String val) -> {
  try {
    return Result.ok(Integer.parseInt(val));
  } catch (Exception e) {
    return Result.fail("Huston? We've got a problem!");
  }
};

Integer result = toInt.apply("fourty-two").either(value -> {
  System.out.println("Success: " + value);
  return value;
}, err -> {
  System.out.println(err.getMessage());
  return 42;
});
```