### PR TITLE
FIX #249: use imported modules in fun

### DIFF
--- a/src/main/java/org/eclipse/golo/runtime/Extractors.java
+++ b/src/main/java/org/eclipse/golo/runtime/Extractors.java
@@ -17,6 +17,9 @@ import java.util.stream.Stream;
 import java.lang.reflect.Modifier;
 import java.util.function.Predicate;
 
+import static org.eclipse.golo.runtime.TypeMatching.argumentsNumberMatches;
+import static org.eclipse.golo.runtime.DecoratorsHelper.isMethodDecorated;
+
 public final class Extractors {
   private Extractors() {
     throw new UnsupportedOperationException("don't instantiate");
@@ -84,8 +87,15 @@ public final class Extractors {
     return !Modifier.isAbstract(m.getModifiers());
   }
 
-  public static Predicate<? extends Member> isNamed(String name) {
+  public static Predicate<Member> isNamed(String name) {
     return m -> m.getName().equals(name);
+  }
+
+  public static Predicate<Method> matchFunctionReference(String name, int arity, boolean varargs) {
+    return m ->
+      m.getName().equals(name)
+      && (isMethodDecorated(m) || argumentsNumberMatches(m.getParameterCount(), arity, varargs))
+      && (arity < 0 || m.isVarArgs() == varargs);
   }
 
 }

--- a/src/main/java/org/eclipse/golo/runtime/Loader.java
+++ b/src/main/java/org/eclipse/golo/runtime/Loader.java
@@ -37,7 +37,7 @@ public final class Loader implements Function<String, Class<?>> {
    * @param klass the class whose {@code ClassLoader} to use
    * @return a {@code Loader}
    * */
-  static Loader forClass(Class<?> klass) {
+  public static Loader forClass(Class<?> klass) {
     return new Loader(klass.getClassLoader());
   }
 

--- a/src/main/java/org/eclipse/golo/runtime/TypeMatching.java
+++ b/src/main/java/org/eclipse/golo/runtime/TypeMatching.java
@@ -99,8 +99,10 @@ public final class TypeMatching {
     return index > 0 && args.length == index && args[index - 1] instanceof Object[];
   }
 
-  private static boolean argumentsNumberMatches(int paramsNumber, int argsNumber, boolean isVarArgs) {
-    return (!isVarArgs && paramsNumber == argsNumber) || (isVarArgs && argsNumber >= paramsNumber - 1);
+  public static boolean argumentsNumberMatches(int paramsNumber, int argsNumber, boolean isVarArgs) {
+    return argsNumber < 0
+           || (!isVarArgs && paramsNumber == argsNumber)
+           || (isVarArgs && argsNumber >= paramsNumber - 1);
   }
 
   public static boolean argumentsMatch(Method method, Object[] arguments) {
@@ -113,13 +115,13 @@ public final class TypeMatching {
       : copyOfRange(arguments, 1, arguments.length);
     return
       isMethodDecorated(method)
-      || (argumentsNumberMatches(method.getParameterTypes().length, args.length, varargs)
+      || (argumentsNumberMatches(method.getParameterCount(), args.length, varargs)
           && canAssign(method.getParameterTypes(), args, varargs));
   }
 
   public static boolean argumentsMatch(Constructor<?> constructor, Object[] arguments) {
     return
-      argumentsNumberMatches(constructor.getParameterTypes().length, arguments.length, constructor.isVarArgs())
+      argumentsNumberMatches(constructor.getParameterCount(), arguments.length, constructor.isVarArgs())
       && canAssign(constructor.getParameterTypes(), arguments, constructor.isVarArgs());
   }
 

--- a/src/test/java/gololang/PredefinedTest.java
+++ b/src/test/java/gololang/PredefinedTest.java
@@ -145,13 +145,13 @@ public class PredefinedTest {
 
   @Test
   public void test_fun() throws Throwable {
-    FunctionReference hello = (FunctionReference) Predefined.fun("hello", MyCallable.class, 0);
+    FunctionReference hello = Predefined.fun("hello", MyCallable.class, 0);
     assertThat((String) hello.handle().invoke(), is("Hello!"));
   }
 
   @Test
   public void test_fun_no_arity() throws Throwable {
-    FunctionReference hello = (FunctionReference) Predefined.fun("hello", MyCallable.class);
+    FunctionReference hello = Predefined.fun("hello", MyCallable.class);
     assertThat((String) hello.handle().invoke(), is("Hello!"));
   }
 
@@ -162,24 +162,24 @@ public class PredefinedTest {
 
   @Test(expectedExceptions = AmbiguousFunctionReferenceException.class)
   public void test_fun_ambiguous() throws Throwable {
-    MethodHandle overloaded = (MethodHandle) Predefined.fun("overloaded", MyCallable.class);
+    Object overloaded = Predefined.fun("overloaded", MyCallable.class);
   }
 
   @Test(expectedExceptions = WrongMethodTypeException.class)
   public void test_fun_wrong_arity() throws Throwable {
-    FunctionReference overloaded = (FunctionReference) Predefined.fun("overloaded", MyCallable.class, 1);
+    FunctionReference overloaded = Predefined.fun("overloaded", MyCallable.class, 1);
     overloaded.handle().invoke(1, 2);
   }
 
   @Test
   public void test_fun_overloaded1() throws Throwable {
-    FunctionReference overloaded = (FunctionReference) Predefined.fun("overloaded", MyCallable.class, 1);
+    FunctionReference overloaded = Predefined.fun("overloaded", MyCallable.class, 1);
     assertThat((Integer) overloaded.handle().invoke(2), is(3));
   }
 
   @Test
   public void test_fun_overloaded2() throws Throwable {
-    FunctionReference overloaded = (FunctionReference) Predefined.fun("overloaded", MyCallable.class, 2);
+    FunctionReference overloaded = Predefined.fun("overloaded", MyCallable.class, 2);
     assertThat((Integer) overloaded.handle().invoke(1, 2), is(3));
   }
 

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -896,6 +896,15 @@ public class CompileAndRunTest {
     Method call_java_func_literal = moduleClass.getMethod("call_java_func_literal");
     assertThat((Tuple) call_java_func_literal.invoke(null), is(equalTo(new Tuple(true, false))));
 
+    Method call_imported_java_func_literal = moduleClass.getMethod("call_imported_java_func_literal");
+    assertThat((Tuple) call_imported_java_func_literal.invoke(null), is(equalTo(new Tuple(true, false))));
+
+    Method call_imported_overridden_java_func_literal = moduleClass.getMethod("call_imported_overridden_java_func_literal");
+    assertThat((Tuple) call_imported_overridden_java_func_literal.invoke(null), is(equalTo(new Tuple("n", "o"))));
+
+    Method call_varargs_overloaded_fun = moduleClass.getMethod("call_varargs_overloaded_fun");
+    assertThat((Tuple) call_varargs_overloaded_fun.invoke(null), is(equalTo(new Tuple("p", "pv"))));
+
     Method call_java_method_literal = moduleClass.getMethod("call_java_method_literal");
     assertThat((List) call_java_method_literal.invoke(null), is(equalTo(asList(5, 7, 3, 3))));
 

--- a/src/test/resources/for-execution/closures.golo
+++ b/src/test/resources/for-execution/closures.golo
@@ -4,6 +4,7 @@ import java.awt.event
 import java.util.HashMap
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
+import java.util.Objects
 
 function raw_handle = {
   return |obj| {
@@ -112,6 +113,21 @@ function call_java_func_literal = {
   return [ f(null), f("42") ]
 }
 
+function call_imported_java_func_literal = {
+  let f = ^isNull
+  return [ f(null), f("42") ]
+}
+
+function nonNull = |o| -> match {
+  when o is null then "n"
+  otherwise "o"
+}
+
+function call_imported_overridden_java_func_literal = {
+  let f = ^nonNull
+  return [ f(null), f("42") ]
+}
+
 function call_java_method_literal_arity2 = {
   let f = ^String::endsWith: bindAt(1, "o")
   return list[f("Hello"), f("Goodbye"), f("Foo"), f("Bar")]
@@ -120,6 +136,15 @@ function call_java_method_literal_arity2 = {
 function call_java_method_literal = {
   let f = ^String::length
   return list[f("Hello"), f("Goodbye"), f("Foo"), f("Bar")]
+}
+
+function plop = |a| -> "p"
+function plop = |a...| -> "pv"
+
+function call_varargs_overloaded_fun = {
+  let f = fun("plop", golotest.execution.Closures.module, 1, false)
+  let fv = fun("plop", golotest.execution.Closures.module, 1, true)
+  return [f(1), fv(1)]
 }
 
 function nested_closures = {


### PR DESCRIPTION
- small refactor of `Predefined::fun`:
    just use existing methods from `Extractors` and `TypeMatching`;
- add a `varargs` parameter to `fun` to specify if a variable arity
  method is required or not;
- search in modules imported by the one we are looking in if no function
  is found (use the first function found).