### PR TITLE
Extended literal notation for floating numbers

### DIFF
--- a/doc/basics.asciidoc
+++ b/doc/basics.asciidoc
@@ -272,6 +272,10 @@ API. We give them along with examples in <<data-literals,the data literals table
 
 |`java.lang.Float` | `1.234_F`, `-1.234_F`, `1.234e9_F`, ...
 
+|`java.math.BigInteger` | `1_B`, `-42_B`, `1_234_B`, ...
+
+|`java.math.BigDecimal` | `1.0_B`, `-1_234.56_B`, `1.234e-4_B`, ...
+
 |`java.lang.Class` | `String.class`, `java.lang.String.class`, `gololang.Predef.module`, ...
 
 | `gololang.FunctionReference` | `^foo`, `^some.module::foo`, ...
@@ -542,8 +546,7 @@ aList: filter(^pred): map(^f)
 Thus, should you use collection comprehension or higher-order functions? Despite some
 implementation differences, it's above all a matter of taste. Some people
 consider comprehension more readable, since it is more similar to the
-mathematical
-[set-builder notation](https://en.wikipedia.org/wiki/Set-builder_notation).
+mathematical https://en.wikipedia.org/wiki/Set-builder_notation[set-builder notation].
 As an example, compare the two functionally equivalent expressions:
 [source,golo]
 ----
@@ -660,7 +663,7 @@ Golo supports the following <<operators,set of operators>>.
 
 |`+`|
 Addition on numbers and strings.|
-`1 + 2` gives 3.
+`1 + 2` gives `3`.
 
 `"foo" + "bar"` gives `"foobar"`.
 
@@ -709,6 +712,9 @@ Evaluates an expression and returns the value of another one if `null`.|
 `foo()` returns `null`.
 
 |===
+
+NOTE: The algebraic operators can be used with any numeric type having a literal notation
+(see <<data-literals,the data literals table>> ), including `java.math.BigInteger` and `java.math.BigDecimal`.
 
 The operator precedence rules are as follows:
 

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
@@ -17,6 +17,8 @@ import org.objectweb.asm.*;
 
 import java.lang.invoke.MethodType;
 import java.util.*;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import static org.eclipse.golo.compiler.JavaBytecodeUtils.loadInteger;
 import static org.eclipse.golo.compiler.JavaBytecodeUtils.loadLong;
@@ -408,6 +410,20 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
       boolean b = (Boolean) value;
       loadInteger(methodVisitor, b ? 1 : 0);
       methodVisitor.visitMethodInsn(INVOKESTATIC, "java/lang/Boolean", "valueOf", "(Z)Ljava/lang/Boolean;", false);
+      return;
+    }
+    if (value instanceof BigDecimal) {
+      methodVisitor.visitTypeInsn(NEW, "java/math/BigDecimal");
+      methodVisitor.visitInsn(DUP);
+      methodVisitor.visitLdcInsn(value.toString());
+      methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/math/BigDecimal", "<init>", "(Ljava/lang/String;)V", false);
+      return;
+    }
+    if (value instanceof BigInteger) {
+      methodVisitor.visitTypeInsn(NEW, "java/math/BigInteger");
+      methodVisitor.visitInsn(DUP);
+      methodVisitor.visitLdcInsn(value.toString());
+      methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/math/BigInteger", "<init>", "(Ljava/lang/String;)V", false);
       return;
     }
     if (value instanceof String) {

--- a/src/main/java/org/eclipse/golo/runtime/OperatorSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/OperatorSupport.java
@@ -13,6 +13,8 @@ import java.lang.invoke.*;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Objects;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.invoke.MethodType.methodType;
@@ -1259,6 +1261,885 @@ public final class OperatorSupport {
     return ((double) a) >= ((double) b);
   }
 
+  public static Object equals(BigDecimal a, Integer b) {
+    return (a).compareTo(new BigDecimal(b)) == 0;
+  }
+
+  public static Object equals(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) == 0;
+  }
+
+  public static Object notequals(BigDecimal a, Integer b) {
+    return (a).compareTo(new BigDecimal(b)) != 0;
+  }
+
+  public static Object notequals(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) != 0;
+  }
+
+  public static Object less(BigDecimal a, Integer b) {
+    return (a).compareTo(new BigDecimal(b)) < 0;
+  }
+
+  public static Object less(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) < 0;
+  }
+
+  public static Object lessorequals(BigDecimal a, Integer b) {
+    return (a).compareTo(new BigDecimal(b)) <= 0;
+  }
+
+  public static Object lessorequals(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) <= 0;
+  }
+
+  public static Object more(BigDecimal a, Integer b) {
+    return (a).compareTo(new BigDecimal(b)) > 0;
+  }
+
+  public static Object more(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) > 0;
+  }
+
+  public static Object moreorequals(BigDecimal a, Integer b) {
+    return (a).compareTo(new BigDecimal(b)) >= 0;
+  }
+
+  public static Object moreorequals(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) >= 0;
+  }
+
+  public static Object plus(BigDecimal a, Integer b) {
+    return (a).add(new BigDecimal(b));
+  }
+
+  public static Object plus(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).add(b);
+  }
+
+  public static Object minus(BigDecimal a, Integer b) {
+    return (a).subtract(new BigDecimal(b));
+  }
+
+  public static Object minus(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).subtract(b);
+  }
+
+  public static Object times(BigDecimal a, Integer b) {
+    return (a).multiply(new BigDecimal(b));
+  }
+
+  public static Object times(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).multiply(b);
+  }
+
+  public static Object divide(BigDecimal a, Integer b) {
+    return (a).divide(new BigDecimal(b));
+  }
+
+  public static Object divide(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).divide(b);
+  }
+
+  public static Object modulo(BigDecimal a, Integer b) {
+    return (a).remainder(new BigDecimal(b));
+  }
+
+  public static Object modulo(Integer a, BigDecimal b) {
+    return (new BigDecimal(a)).remainder(b);
+  }
+
+  public static Object equals(BigDecimal a, Long b) {
+    return (a).compareTo(new BigDecimal(b)) == 0;
+  }
+
+  public static Object equals(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) == 0;
+  }
+
+  public static Object notequals(BigDecimal a, Long b) {
+    return (a).compareTo(new BigDecimal(b)) != 0;
+  }
+
+  public static Object notequals(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) != 0;
+  }
+
+  public static Object less(BigDecimal a, Long b) {
+    return (a).compareTo(new BigDecimal(b)) < 0;
+  }
+
+  public static Object less(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) < 0;
+  }
+
+  public static Object lessorequals(BigDecimal a, Long b) {
+    return (a).compareTo(new BigDecimal(b)) <= 0;
+  }
+
+  public static Object lessorequals(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) <= 0;
+  }
+
+  public static Object more(BigDecimal a, Long b) {
+    return (a).compareTo(new BigDecimal(b)) > 0;
+  }
+
+  public static Object more(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) > 0;
+  }
+
+  public static Object moreorequals(BigDecimal a, Long b) {
+    return (a).compareTo(new BigDecimal(b)) >= 0;
+  }
+
+  public static Object moreorequals(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) >= 0;
+  }
+
+  public static Object plus(BigDecimal a, Long b) {
+    return (a).add(new BigDecimal(b));
+  }
+
+  public static Object plus(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).add(b);
+  }
+
+  public static Object minus(BigDecimal a, Long b) {
+    return (a).subtract(new BigDecimal(b));
+  }
+
+  public static Object minus(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).subtract(b);
+  }
+
+  public static Object times(BigDecimal a, Long b) {
+    return (a).multiply(new BigDecimal(b));
+  }
+
+  public static Object times(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).multiply(b);
+  }
+
+  public static Object divide(BigDecimal a, Long b) {
+    return (a).divide(new BigDecimal(b));
+  }
+
+  public static Object divide(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).divide(b);
+  }
+
+  public static Object modulo(BigDecimal a, Long b) {
+    return (a).remainder(new BigDecimal(b));
+  }
+
+  public static Object modulo(Long a, BigDecimal b) {
+    return (new BigDecimal(a)).remainder(b);
+  }
+
+  public static Object equals(BigDecimal a, BigInteger b) {
+    return (a).compareTo(new BigDecimal(b)) == 0;
+  }
+
+  public static Object equals(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) == 0;
+  }
+
+  public static Object notequals(BigDecimal a, BigInteger b) {
+    return (a).compareTo(new BigDecimal(b)) != 0;
+  }
+
+  public static Object notequals(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) != 0;
+  }
+
+  public static Object less(BigDecimal a, BigInteger b) {
+    return (a).compareTo(new BigDecimal(b)) < 0;
+  }
+
+  public static Object less(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) < 0;
+  }
+
+  public static Object lessorequals(BigDecimal a, BigInteger b) {
+    return (a).compareTo(new BigDecimal(b)) <= 0;
+  }
+
+  public static Object lessorequals(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) <= 0;
+  }
+
+  public static Object more(BigDecimal a, BigInteger b) {
+    return (a).compareTo(new BigDecimal(b)) > 0;
+  }
+
+  public static Object more(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) > 0;
+  }
+
+  public static Object moreorequals(BigDecimal a, BigInteger b) {
+    return (a).compareTo(new BigDecimal(b)) >= 0;
+  }
+
+  public static Object moreorequals(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) >= 0;
+  }
+
+  public static Object plus(BigDecimal a, BigInteger b) {
+    return (a).add(new BigDecimal(b));
+  }
+
+  public static Object plus(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).add(b);
+  }
+
+  public static Object minus(BigDecimal a, BigInteger b) {
+    return (a).subtract(new BigDecimal(b));
+  }
+
+  public static Object minus(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).subtract(b);
+  }
+
+  public static Object times(BigDecimal a, BigInteger b) {
+    return (a).multiply(new BigDecimal(b));
+  }
+
+  public static Object times(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).multiply(b);
+  }
+
+  public static Object divide(BigDecimal a, BigInteger b) {
+    return (a).divide(new BigDecimal(b));
+  }
+
+  public static Object divide(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).divide(b);
+  }
+
+  public static Object modulo(BigDecimal a, BigInteger b) {
+    return (a).remainder(new BigDecimal(b));
+  }
+
+  public static Object modulo(BigInteger a, BigDecimal b) {
+    return (new BigDecimal(a)).remainder(b);
+  }
+
+  public static Object equals(BigDecimal a, Float b) {
+    return (a).compareTo(new BigDecimal(b)) == 0;
+  }
+
+  public static Object equals(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) == 0;
+  }
+
+  public static Object notequals(BigDecimal a, Float b) {
+    return (a).compareTo(new BigDecimal(b)) != 0;
+  }
+
+  public static Object notequals(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) != 0;
+  }
+
+  public static Object less(BigDecimal a, Float b) {
+    return (a).compareTo(new BigDecimal(b)) < 0;
+  }
+
+  public static Object less(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) < 0;
+  }
+
+  public static Object lessorequals(BigDecimal a, Float b) {
+    return (a).compareTo(new BigDecimal(b)) <= 0;
+  }
+
+  public static Object lessorequals(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) <= 0;
+  }
+
+  public static Object more(BigDecimal a, Float b) {
+    return (a).compareTo(new BigDecimal(b)) > 0;
+  }
+
+  public static Object more(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) > 0;
+  }
+
+  public static Object moreorequals(BigDecimal a, Float b) {
+    return (a).compareTo(new BigDecimal(b)) >= 0;
+  }
+
+  public static Object moreorequals(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) >= 0;
+  }
+
+  public static Object plus(BigDecimal a, Float b) {
+    return (a).add(new BigDecimal(b));
+  }
+
+  public static Object plus(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).add(b);
+  }
+
+  public static Object minus(BigDecimal a, Float b) {
+    return (a).subtract(new BigDecimal(b));
+  }
+
+  public static Object minus(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).subtract(b);
+  }
+
+  public static Object times(BigDecimal a, Float b) {
+    return (a).multiply(new BigDecimal(b));
+  }
+
+  public static Object times(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).multiply(b);
+  }
+
+  public static Object divide(BigDecimal a, Float b) {
+    return (a).divide(new BigDecimal(b));
+  }
+
+  public static Object divide(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).divide(b);
+  }
+
+  public static Object modulo(BigDecimal a, Float b) {
+    return (a).remainder(new BigDecimal(b));
+  }
+
+  public static Object modulo(Float a, BigDecimal b) {
+    return (new BigDecimal(a)).remainder(b);
+  }
+
+  public static Object equals(BigDecimal a, Double b) {
+    return (a).compareTo(new BigDecimal(b)) == 0;
+  }
+
+  public static Object equals(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) == 0;
+  }
+
+  public static Object notequals(BigDecimal a, Double b) {
+    return (a).compareTo(new BigDecimal(b)) != 0;
+  }
+
+  public static Object notequals(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) != 0;
+  }
+
+  public static Object less(BigDecimal a, Double b) {
+    return (a).compareTo(new BigDecimal(b)) < 0;
+  }
+
+  public static Object less(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) < 0;
+  }
+
+  public static Object lessorequals(BigDecimal a, Double b) {
+    return (a).compareTo(new BigDecimal(b)) <= 0;
+  }
+
+  public static Object lessorequals(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) <= 0;
+  }
+
+  public static Object more(BigDecimal a, Double b) {
+    return (a).compareTo(new BigDecimal(b)) > 0;
+  }
+
+  public static Object more(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) > 0;
+  }
+
+  public static Object moreorequals(BigDecimal a, Double b) {
+    return (a).compareTo(new BigDecimal(b)) >= 0;
+  }
+
+  public static Object moreorequals(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).compareTo(b) >= 0;
+  }
+
+  public static Object plus(BigDecimal a, Double b) {
+    return (a).add(new BigDecimal(b));
+  }
+
+  public static Object plus(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).add(b);
+  }
+
+  public static Object minus(BigDecimal a, Double b) {
+    return (a).subtract(new BigDecimal(b));
+  }
+
+  public static Object minus(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).subtract(b);
+  }
+
+  public static Object times(BigDecimal a, Double b) {
+    return (a).multiply(new BigDecimal(b));
+  }
+
+  public static Object times(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).multiply(b);
+  }
+
+  public static Object divide(BigDecimal a, Double b) {
+    return (a).divide(new BigDecimal(b));
+  }
+
+  public static Object divide(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).divide(b);
+  }
+
+  public static Object modulo(BigDecimal a, Double b) {
+    return (a).remainder(new BigDecimal(b));
+  }
+
+  public static Object modulo(Double a, BigDecimal b) {
+    return (new BigDecimal(a)).remainder(b);
+  }
+
+  public static Object equals(BigDecimal a, BigDecimal b) {
+    return (a).compareTo(b) == 0;
+  }
+
+  public static Object notequals(BigDecimal a, BigDecimal b) {
+    return (a).compareTo(b) != 0;
+  }
+
+  public static Object less(BigDecimal a, BigDecimal b) {
+    return (a).compareTo(b) < 0;
+  }
+
+  public static Object lessorequals(BigDecimal a, BigDecimal b) {
+    return (a).compareTo(b) <= 0;
+  }
+
+  public static Object more(BigDecimal a, BigDecimal b) {
+    return (a).compareTo(b) > 0;
+  }
+
+  public static Object moreorequals(BigDecimal a, BigDecimal b) {
+    return (a).compareTo(b) >= 0;
+  }
+
+  public static Object plus(BigDecimal a, BigDecimal b) {
+    return (a).add(b);
+  }
+
+  public static Object minus(BigDecimal a, BigDecimal b) {
+    return (a).subtract(b);
+  }
+
+  public static Object times(BigDecimal a, BigDecimal b) {
+    return (a).multiply(b);
+  }
+
+  public static Object divide(BigDecimal a, BigDecimal b) {
+    return (a).divide(b);
+  }
+
+  public static Object modulo(BigDecimal a, BigDecimal b) {
+    return (a).remainder(b);
+  }
+
+  public static Object equals(BigInteger a, Integer b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) == 0;
+  }
+
+  public static Object equals(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) == 0;
+  }
+
+  public static Object notequals(BigInteger a, Integer b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) != 0;
+  }
+
+  public static Object notequals(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) != 0;
+  }
+
+  public static Object less(BigInteger a, Integer b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) < 0;
+  }
+
+  public static Object less(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) < 0;
+  }
+
+  public static Object lessorequals(BigInteger a, Integer b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) <= 0;
+  }
+
+  public static Object lessorequals(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) <= 0;
+  }
+
+  public static Object more(BigInteger a, Integer b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) > 0;
+  }
+
+  public static Object more(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) > 0;
+  }
+
+  public static Object moreorequals(BigInteger a, Integer b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) >= 0;
+  }
+
+  public static Object moreorequals(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) >= 0;
+  }
+
+  public static Object plus(BigInteger a, Integer b) {
+    return (a).add(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object plus(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).add(b);
+  }
+
+  public static Object minus(BigInteger a, Integer b) {
+    return (a).subtract(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object minus(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).subtract(b);
+  }
+
+  public static Object times(BigInteger a, Integer b) {
+    return (a).multiply(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object times(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).multiply(b);
+  }
+
+  public static Object divide(BigInteger a, Integer b) {
+    return (a).divide(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object divide(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).divide(b);
+  }
+
+  public static Object modulo(BigInteger a, Integer b) {
+    return (a).remainder(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object modulo(Integer a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).remainder(b);
+  }
+
+  public static Object equals(BigInteger a, Long b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) == 0;
+  }
+
+  public static Object equals(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) == 0;
+  }
+
+  public static Object notequals(BigInteger a, Long b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) != 0;
+  }
+
+  public static Object notequals(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) != 0;
+  }
+
+  public static Object less(BigInteger a, Long b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) < 0;
+  }
+
+  public static Object less(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) < 0;
+  }
+
+  public static Object lessorequals(BigInteger a, Long b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) <= 0;
+  }
+
+  public static Object lessorequals(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) <= 0;
+  }
+
+  public static Object more(BigInteger a, Long b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) > 0;
+  }
+
+  public static Object more(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) > 0;
+  }
+
+  public static Object moreorequals(BigInteger a, Long b) {
+    return (a).compareTo(BigInteger.valueOf(b.longValue())) >= 0;
+  }
+
+  public static Object moreorequals(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).compareTo(b) >= 0;
+  }
+
+  public static Object plus(BigInteger a, Long b) {
+    return (a).add(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object plus(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).add(b);
+  }
+
+  public static Object minus(BigInteger a, Long b) {
+    return (a).subtract(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object minus(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).subtract(b);
+  }
+
+  public static Object times(BigInteger a, Long b) {
+    return (a).multiply(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object times(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).multiply(b);
+  }
+
+  public static Object divide(BigInteger a, Long b) {
+    return (a).divide(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object divide(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).divide(b);
+  }
+
+  public static Object modulo(BigInteger a, Long b) {
+    return (a).remainder(BigInteger.valueOf(b.longValue()));
+  }
+
+  public static Object modulo(Long a, BigInteger b) {
+    return (BigInteger.valueOf(a.longValue())).remainder(b);
+  }
+
+  public static Object equals(BigInteger a, BigInteger b) {
+    return (a).compareTo(b) == 0;
+  }
+
+  public static Object notequals(BigInteger a, BigInteger b) {
+    return (a).compareTo(b) != 0;
+  }
+
+  public static Object less(BigInteger a, BigInteger b) {
+    return (a).compareTo(b) < 0;
+  }
+
+  public static Object lessorequals(BigInteger a, BigInteger b) {
+    return (a).compareTo(b) <= 0;
+  }
+
+  public static Object more(BigInteger a, BigInteger b) {
+    return (a).compareTo(b) > 0;
+  }
+
+  public static Object moreorequals(BigInteger a, BigInteger b) {
+    return (a).compareTo(b) >= 0;
+  }
+
+  public static Object plus(BigInteger a, BigInteger b) {
+    return (a).add(b);
+  }
+
+  public static Object minus(BigInteger a, BigInteger b) {
+    return (a).subtract(b);
+  }
+
+  public static Object times(BigInteger a, BigInteger b) {
+    return (a).multiply(b);
+  }
+
+  public static Object divide(BigInteger a, BigInteger b) {
+    return (a).divide(b);
+  }
+
+  public static Object modulo(BigInteger a, BigInteger b) {
+    return (a).remainder(b);
+  }
+
+  public static Object equals(BigInteger a, Float b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) == 0;
+  }
+
+  public static Object equals(Float a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) == 0;
+  }
+
+  public static Object notequals(BigInteger a, Float b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) != 0;
+  }
+
+  public static Object notequals(Float a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) != 0;
+  }
+
+  public static Object less(BigInteger a, Float b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) < 0;
+  }
+
+  public static Object less(Float a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) < 0;
+  }
+
+  public static Object lessorequals(BigInteger a, Float b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) <= 0;
+  }
+
+  public static Object lessorequals(Float a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) <= 0;
+  }
+
+  public static Object more(BigInteger a, Float b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) > 0;
+  }
+
+  public static Object more(Float a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) > 0;
+  }
+
+  public static Object moreorequals(BigInteger a, Float b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) >= 0;
+  }
+
+  public static Object moreorequals(Float a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) >= 0;
+  }
+
+  public static Object plus(BigInteger a, Float b) {
+    return (new BigDecimal(a)).add(new BigDecimal(b));
+  }
+
+  public static Object plus(Float a, BigInteger b) {
+    return (new BigDecimal(a)).add(new BigDecimal(b));
+  }
+
+  public static Object minus(BigInteger a, Float b) {
+    return (new BigDecimal(a)).subtract(new BigDecimal(b));
+  }
+
+  public static Object minus(Float a, BigInteger b) {
+    return (new BigDecimal(a)).subtract(new BigDecimal(b));
+  }
+
+  public static Object times(BigInteger a, Float b) {
+    return (new BigDecimal(a)).multiply(new BigDecimal(b));
+  }
+
+  public static Object times(Float a, BigInteger b) {
+    return (new BigDecimal(a)).multiply(new BigDecimal(b));
+  }
+
+  public static Object divide(BigInteger a, Float b) {
+    return (new BigDecimal(a)).divide(new BigDecimal(b));
+  }
+
+  public static Object divide(Float a, BigInteger b) {
+    return (new BigDecimal(a)).divide(new BigDecimal(b));
+  }
+
+  public static Object modulo(BigInteger a, Float b) {
+    return (new BigDecimal(a)).remainder(new BigDecimal(b));
+  }
+
+  public static Object modulo(Float a, BigInteger b) {
+    return (new BigDecimal(a)).remainder(new BigDecimal(b));
+  }
+
+  public static Object equals(BigInteger a, Double b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) == 0;
+  }
+
+  public static Object equals(Double a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) == 0;
+  }
+
+  public static Object notequals(BigInteger a, Double b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) != 0;
+  }
+
+  public static Object notequals(Double a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) != 0;
+  }
+
+  public static Object less(BigInteger a, Double b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) < 0;
+  }
+
+  public static Object less(Double a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) < 0;
+  }
+
+  public static Object lessorequals(BigInteger a, Double b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) <= 0;
+  }
+
+  public static Object lessorequals(Double a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) <= 0;
+  }
+
+  public static Object more(BigInteger a, Double b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) > 0;
+  }
+
+  public static Object more(Double a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) > 0;
+  }
+
+  public static Object moreorequals(BigInteger a, Double b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) >= 0;
+  }
+
+  public static Object moreorequals(Double a, BigInteger b) {
+    return (new BigDecimal(a)).compareTo(new BigDecimal(b)) >= 0;
+  }
+
+  public static Object plus(BigInteger a, Double b) {
+    return (new BigDecimal(a)).add(new BigDecimal(b));
+  }
+
+  public static Object plus(Double a, BigInteger b) {
+    return (new BigDecimal(a)).add(new BigDecimal(b));
+  }
+
+  public static Object minus(BigInteger a, Double b) {
+    return (new BigDecimal(a)).subtract(new BigDecimal(b));
+  }
+
+  public static Object minus(Double a, BigInteger b) {
+    return (new BigDecimal(a)).subtract(new BigDecimal(b));
+  }
+
+  public static Object times(BigInteger a, Double b) {
+    return (new BigDecimal(a)).multiply(new BigDecimal(b));
+  }
+
+  public static Object times(Double a, BigInteger b) {
+    return (new BigDecimal(a)).multiply(new BigDecimal(b));
+  }
+
+  public static Object divide(BigInteger a, Double b) {
+    return (new BigDecimal(a)).divide(new BigDecimal(b));
+  }
+
+  public static Object divide(Double a, BigInteger b) {
+    return (new BigDecimal(a)).divide(new BigDecimal(b));
+  }
+
+  public static Object modulo(BigInteger a, Double b) {
+    return (new BigDecimal(a)).remainder(new BigDecimal(b));
+  }
+
+  public static Object modulo(Double a, BigInteger b) {
+    return (new BigDecimal(a)).remainder(new BigDecimal(b));
+  }
 
   // END GENERATED
 

--- a/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
+++ b/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.LinkedList;
 import java.util.LinkedHashSet;
 import java.util.Collections;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import org.eclipse.golo.compiler.utils.StringUnescaping;
 import org.eclipse.golo.compiler.utils.StringBlockIndenter;
@@ -225,9 +227,13 @@ TOKEN :
   |
   < LONG_NUMBER: <NUMBER> "_L" >
   |
-  < FLOATING_NUMBER: ("-")? (["0"-"9"])+ ("." (["0"-"9"])+)? ("e" (["0"-"9"])+)? >
+  < BIGINTEGER: <NUMBER> "_B" >
+  |
+  < FLOATING_NUMBER: <NUMBER> ("." ["0"-"9"] (("_")? ["0"-"9"])*)? ("e" ("-")? (["0"-"9"])+)? >
   |
   < FLOAT: <FLOATING_NUMBER> "_F" >
+  |
+  < BIGDECIMAL: <FLOATING_NUMBER> "_B" >
   |
   < STRING: "\"" (
     (~["\"", "\\", "\n", "\r"])
@@ -574,6 +580,19 @@ Long LongLiteral() #void:
   }
 }
 
+BigInteger BigIntegerLiteral() #void:
+{
+  Token literal;
+}
+{
+  literal=<BIGINTEGER>
+  {
+    String image = literal.image.substring(0, literal.image.length() - 2);
+    return new BigInteger(image.replace("_",""));
+  }
+}
+
+
 Integer IntegerLiteral() #void:
 {
   Token literal;
@@ -606,7 +625,7 @@ Double DoubleLiteral() #void:
 {
   literal=<FLOATING_NUMBER>
   {
-    return Double.valueOf(literal.image);
+    return Double.valueOf(literal.image.replace("_", ""));
   }
 }
 
@@ -617,7 +636,22 @@ Float FloatLiteral() #void:
 {
   literal=<FLOAT>
   {
-    return Float.valueOf(literal.image.substring(0, literal.image.length() - 2));
+    return Float.valueOf(literal.image
+        .substring(0, literal.image.length() - 2)
+        .replace("_", ""));
+  }
+}
+
+BigDecimal BigDecimalLiteral() #void:
+{
+  Token literal;
+}
+{
+  literal=<BIGDECIMAL>
+  {
+    return new BigDecimal(literal.image
+        .substring(0, literal.image.length() - 2)
+        .replace("_", ""));
   }
 }
 
@@ -1288,6 +1322,16 @@ void Literal():
     }
     |
     value=CharLiteral()
+    {
+      jjtThis.setLiteralValue(value);
+    }
+    |
+    value=BigDecimalLiteral()
+    {
+      jjtThis.setLiteralValue(value);
+    }
+    |
+    value=BigIntegerLiteral()
     {
       jjtThis.setLiteralValue(value);
     }

--- a/src/main/ruby/generate_math.rb
+++ b/src/main/ruby/generate_math.rb
@@ -7,31 +7,27 @@
 
 # Quick and dirty script to generate the arithmetic operation methods
 
-TYPES = [ :Character, :Integer, :Long, :Double, :Float ]
-
-OPS = [ :plus, :minus, :divide, :times, :modulo,
-        :equals, :notequals, :less, :lessorequals, :more, :moreorequals ]
-
+## On primitive types (box/unbox)
 OPS_SYMB = {
   :plus => '+',
   :minus => '-',
-  :times => '*',
   :divide => '/',
+  :times => '*',
   :modulo => '%',
-  :less => '<',
-  :more => '>',
-  :lessorequals => '<=',
-  :moreorequals => '>=',
   :equals => '==',
-  :notequals => '!='
+  :notequals => '!=',
+  :less => '<',
+  :lessorequals => '<=',
+  :more => '>',
+  :moreorequals => '>='
 }
 
 PRIM = {
   :Character => :char,
   :Integer => :int,
   :Long => :long,
-  :Float => :float,
-  :Double => :double
+  :Double => :double,
+  :Float => :float
 }
 
 WEIGHT = {
@@ -42,30 +38,91 @@ WEIGHT = {
   :Double => 5
 }
 
-TYPES.each do |type|
-  OPS.each do |op|
+PRIM.each do |type, prim|
+  OPS_SYMB.each do |op, symb|
     puts "  public static Object #{op}(#{type} a, #{type} b) {"
-    puts "    return ((#{PRIM[type]}) a) #{OPS_SYMB[op]} ((#{PRIM[type]}) b);"
+    puts "    return ((#{prim}) a) #{symb} ((#{prim}) b);"
     puts "  }"
     puts
   end
 end
 
-combinations = TYPES.combination(2).to_a
+combinations = PRIM.keys().combination(2).to_a
 combinations = combinations + combinations.map { |pair| [pair[1], pair[0]] }
 combinations.each do |pair|
   left = pair[0]
   right = pair[1]
-  OPS.each do |op|
+  OPS_SYMB.each do |op, symb|
     puts "  public static Object #{op}(#{left} a, #{right} b) {"
     if WEIGHT[left] < WEIGHT[right]
         type = PRIM[right]
     else
         type = PRIM[left]
     end
-    puts "    return ((#{type}) a) #{OPS_SYMB[op]} ((#{type}) b);"
+    puts "    return ((#{type}) a) #{symb} ((#{type}) b);"
     puts "  }"
     puts
   end
 end
+
+# ..........................................................................
+# On BigDecimal/BigInteger
+
+INT_NUMBERS = [ :Integer, :Long, :BigInteger ]
+REAL_NUMBERS = [ :Float, :Double ]
+COMPARISONS = [ :equals, :notequals, :less, :lessorequals, :more, :moreorequals ]
+OPS_METH = {
+  :plus => :add,
+  :minus => :subtract,
+  :times => :multiply,
+  :divide => :divide,
+  :modulo => :remainder
+}
+
+toBigDecimal = -> (arg, type) { case type
+  when :BigDecimal then arg
+  else "new BigDecimal(#{arg})"
+  end }
+
+
+toBigInteger = -> (arg, type) { case type
+  when :BigInteger then arg
+  when :BigDecimal then "#{arg}.toBigInteger()"
+  else "BigInteger.valueOf(#{arg}.longValue())"
+end }
+
+def generateOperators(numbers, the_type, the_conversion)
+  numbers.each do |type|
+    COMPARISONS.each do |op|
+      puts "  public static Object #{op}(#{the_type} a, #{type} b) {"
+      puts "    return (#{the_conversion.("a", the_type)}).compareTo(#{the_conversion.("b", type)}) #{OPS_SYMB[op]} 0;"
+      puts "  }"
+      puts
+      if type != the_type
+        puts "  public static Object #{op}(#{type} a, #{the_type} b) {"
+        puts "    return (#{the_conversion.("a", type)}).compareTo(#{the_conversion.("b", the_type)}) #{OPS_SYMB[op]} 0;"
+        puts "  }"
+        puts
+      end
+    end
+    OPS_METH.each do |op, meth|
+      puts "  public static Object #{op}(#{the_type} a, #{type} b) {"
+      puts "    return (#{the_conversion.("a", the_type)}).#{meth}(#{the_conversion.("b", type)});"
+      puts "  }"
+      puts
+      if type != the_type
+        puts "  public static Object #{op}(#{type} a, #{the_type} b) {"
+        puts "    return (#{the_conversion.("a", type)}).#{meth}(#{the_conversion.("b", the_type)});"
+        puts "  }"
+        puts
+      end
+    end
+  end
+end
+
+
+generateOperators(INT_NUMBERS, :BigDecimal, toBigDecimal)
+generateOperators(REAL_NUMBERS + [ :BigDecimal ], :BigDecimal, toBigDecimal)
+generateOperators(INT_NUMBERS, :BigInteger, toBigInteger)
+generateOperators(REAL_NUMBERS, :BigInteger, toBigDecimal)
 

--- a/src/test/resources/for-execution/arrays.golo
+++ b/src/test/resources/for-execution/arrays.golo
@@ -13,11 +13,19 @@ function array_of = |value| {
 }
 
 function array_of_doubles = {
-  return array[123.0, -123.0, 123.456, 123.0e3]
+  return array[123.0, -123.0, 123.456, 123.0e3, 1_234.0_10e-3]
 }
 
 function array_of_floats = {
-  return array[123.0_F, -123.0_F, 123.456_F, 123.0e3_F]
+  return array[123.0_F, -123.0_F, 123.456_F, 123.0e3_F, 1_234.0_10e-3_F]
+}
+
+function array_of_big_decimals = {
+  return array[123.0_B, -123.0_B, 123.456_B, 123.0e3_B, 1_234.0_10e-3_B]
+}
+
+function array_of_big_integers = {
+  return array[123_B, -123_B, 1_234_B, -1_234_B]
 }
 
 function as_list = {

--- a/src/test/resources/for-execution/operators.golo
+++ b/src/test/resources/for-execution/operators.golo
@@ -4,17 +4,29 @@ function plus_one = |a| {
   return a + 1
 }
 
+function plus = |a, b| {
+  return a + b
+}
+
 function minus_one = |a| {
   return a - 1
 }
+
+function minus = |a, b| -> a - b
 
 function half = |a| {
   return a / 2
 }
 
+function divide = |a, b| -> a / b
+
 function twice = |a| {
   return a * 2
 }
+
+function multiply = |a, b| -> a * b
+
+function modulo = |a, b| -> a % b
 
 function compute_92 = {
   return ((1 + 2 + 3) * (5) * 6 + (10 / 2) - 1) / 2
@@ -92,8 +104,8 @@ function lazy_ifnull = {
 }
 
 function polymorphic_number_comparison = {
-  let left = list[1, 1_L, 1.0, 1.0_F]
-  let right = list[2, 2_L, 1.1, 1.1_F]
+  let left = list[1, 1_L, 1.0, 1.0_F, 1.0_B, 1_B]
+  let right = list[2, 2_L, 1.1, 1.1_F, 1.1_B, 2_B]
 
   foreach a in left {
     foreach b in right {

--- a/src/test/resources/for-parsing-and-compilation/simple-returns.golo
+++ b/src/test/resources/for-parsing-and-compilation/simple-returns.golo
@@ -26,12 +26,21 @@ function doubles = {
   let a = 123.45
   let b = -123.45
   let c = 123.4e5
+  let d = 1_234.000_123e-5
 }
 
 function floats = {
   let a = 123.45_F
   let b = -123.45_F
   let c = 123.4e5_F
+  let d = 1_234.000_123e-5_F
+}
+
+function big_decimals = {
+  let a = 123.45_B
+  let b = -123.45_B
+  let c = 123.4e5_B
+  let d = 1_234.000_123e-5_B
 }
 
 function escaped = {


### PR DESCRIPTION
Fix #374 by:
* allowing `_` in floating numbers and negative exponent in scientific notation;
* adding literal notation for `BigInteger` and `BigDecimal` using the `_B` suffix;
* extending operators to deal with `BigInteger` and `BigDecimal` values.