### PR TITLE
Check command

### DIFF
--- a/doc/basics.adoc
+++ b/doc/basics.adoc
@@ -61,6 +61,7 @@ commands, notably:
 - `run` to execute some already compiled Golo code, and
 - `golo` to directly execute Golo code from source files, and
 - `diagnose` to print compiler internal diagnosis information, and
+- `check` to check code for compilation errors (e.g. as an editor hook), and
 - `doc` to generate module(s) documentation, and
 - `new` to generate new project(s).
 

--- a/share/shell-completion/golo-bash-completion
+++ b/share/shell-completion/golo-bash-completion
@@ -14,7 +14,7 @@ _golo ()
 
 	# Find out if we have a special word and our previous flag.
 	for (( i=1; i < ${#COMP_WORDS[@]}-1; i++ )); do
-		if [[ ${COMP_WORDS[i]} == @(compile|run|golo|diagnose|doc|version|new) ]]; then
+		if [[ ${COMP_WORDS[i]} == @(compile|check|run|golo|diagnose|doc|version|new) ]]; then
 			special=${COMP_WORDS[i]}
 		fi
 		if [[ ${COMP_WORDS[i]} == -* ]]; then
@@ -35,7 +35,7 @@ _golo ()
 
 	# Our special wasn't defined. We need to start there.
 	if [ -z ${special} ]; then
-		COMPREPLY=( $( compgen -W 'version compile run golo new doc diagnose --help' -- "$cur" ) )
+		COMPREPLY=( $( compgen -W 'version compile check run golo new doc diagnose --help' -- "$cur" ) )
 		return 0
 	fi
 
@@ -67,6 +67,9 @@ _golo ()
 	case "${special}" in
 		compile)
 			COMPREPLY=( $( compgen -W '--output' -- "$cur" ) )
+			;;
+		check)
+			COMPREPLY=( $( compgen -W '--exit' -- "$cur" ) )
 			;;
 		version)
 			COMPREPLY=( $( compgen -W '--full' -- "$cur" ) )

--- a/src/main/java/org/eclipse/golo/cli/command/CheckCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/CheckCommand.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-2016 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.golo.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.golo.cli.command.spi.CliCommand;
+import org.eclipse.golo.compiler.GoloCompilationException;
+import org.eclipse.golo.compiler.GoloCompiler;
+
+@Parameters(commandNames = {"check"}, commandDescription = "Check Golo source files for correctness")
+public class CheckCommand implements CliCommand {
+
+  @Parameter(names = {"--exit"}, description = "Exit on the first encountered error, or continue with the next file")
+  boolean exit = false;
+
+  @Parameter(description = "Golo source files (*.golo and directories))")
+  List<String> files = new LinkedList<>();
+
+  @Override
+  public void execute() throws Throwable {
+    GoloCompiler compiler = new GoloCompiler();
+    for (String file : files) {
+      check(new File(file), compiler);
+    }
+  }
+
+  private void check(File file, GoloCompiler compiler) {
+    if (file.isDirectory()) {
+      File[] directoryFiles = file.listFiles();
+      if (directoryFiles != null) {
+        for (File directoryFile : directoryFiles) {
+          check(directoryFile, compiler);
+        }
+      }
+    } else if (file.getName().endsWith(".golo")) {
+      try {
+        compiler.check(compiler.parse(file.getAbsolutePath()));
+      } catch (IOException e) {
+        System.out.println("[error] " + file + " does not exist or could not be opened.");
+      } catch (GoloCompilationException e) {
+        handleCompilationException(e, exit);
+      }
+    }
+  }
+}
+

--- a/src/main/java/org/eclipse/golo/cli/command/spi/CliCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/spi/CliCommand.java
@@ -41,6 +41,10 @@ public interface CliCommand {
   }
 
   default void handleCompilationException(GoloCompilationException e) {
+    handleCompilationException(e, true);
+  }
+
+  default void handleCompilationException(GoloCompilationException e, boolean exit) {
     if (e.getMessage() != null) {
       System.out.println("[error] " + e.getMessage());
     }
@@ -50,6 +54,8 @@ public interface CliCommand {
     for (GoloCompilationException.Problem problem : e.getProblems()) {
       System.out.println("[error] " + problem.getDescription());
     }
-    System.exit(1);
+    if (exit) {
+      System.exit(1);
+    }
   }
 }

--- a/src/main/resources/META-INF/services/org.eclipse.golo.cli.command.spi.CliCommand
+++ b/src/main/resources/META-INF/services/org.eclipse.golo.cli.command.spi.CliCommand
@@ -14,3 +14,4 @@ org.eclipse.golo.cli.command.GoloGoloCommand
 org.eclipse.golo.cli.command.InitCommand
 org.eclipse.golo.cli.command.RunCommand
 org.eclipse.golo.cli.command.VersionCommand
+org.eclipse.golo.cli.command.CheckCommand


### PR DESCRIPTION
Adds a `check` command to the `golo` binary. This command does the same
tasks as the `compile` command, namely parse input files and run the
compile time IR verifications, but does not produce result files.

This command can be useful to integrate golo with editor plugins such as
Vim Syntastic.

FIX #324