### PR TITLE
FIX: bug when checking several files

### DIFF
--- a/src/main/java/org/eclipse/golo/cli/command/CheckCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/CheckCommand.java
@@ -27,6 +27,9 @@ public class CheckCommand implements CliCommand {
   @Parameter(names = {"--exit"}, description = "Exit on the first encountered error, or continue with the next file")
   boolean exit = false;
 
+  @Parameter(names = {"--verbose"}, description = "Be more verbose")
+  boolean verbose = false;
+
   @Parameter(description = "Golo source files (*.golo and directories))")
   List<String> files = new LinkedList<>();
 
@@ -48,6 +51,10 @@ public class CheckCommand implements CliCommand {
       }
     } else if (file.getName().endsWith(".golo")) {
       try {
+        if (verbose) {
+          System.out.println(">>> Checking file `" + file.getAbsolutePath() + "`");
+        }
+        compiler.resetExceptionBuilder();
         compiler.check(compiler.parse(file.getAbsolutePath()));
       } catch (IOException e) {
         System.out.println("[error] " + file + " does not exist or could not be opened.");

--- a/src/main/java/org/eclipse/golo/compiler/GoloCompiler.java
+++ b/src/main/java/org/eclipse/golo/compiler/GoloCompiler.java
@@ -55,7 +55,7 @@ public class GoloCompiler {
     return exceptionBuilder;
   }
 
-  private void resetExceptionBuilder() {
+  public void resetExceptionBuilder() {
     exceptionBuilder = null;
   }
   /**
@@ -213,13 +213,15 @@ public class GoloCompiler {
   }
 
   public final GoloModule transform(ASTCompilationUnit compilationUnit) {
-    return new ParseTreeToGoloIrVisitor().transform(compilationUnit,exceptionBuilder);
+    return new ParseTreeToGoloIrVisitor().transform(compilationUnit, exceptionBuilder);
   }
 
   public final void refine(GoloModule goloModule) {
-    goloModule.accept(new SugarExpansionVisitor());
-    goloModule.accept(new ClosureCaptureGoloIrVisitor());
-    goloModule.accept(new LocalReferenceAssignmentAndVerificationVisitor(exceptionBuilder));
+    if (goloModule != null) {
+      goloModule.accept(new SugarExpansionVisitor());
+      goloModule.accept(new ClosureCaptureGoloIrVisitor());
+      goloModule.accept(new LocalReferenceAssignmentAndVerificationVisitor(exceptionBuilder));
+    }
     throwIfErrorEncountered();
   }
 


### PR DESCRIPTION
When processing several files, and without the `--exit` option, only the
first error was displayed, for every file with an error, because the
exception builder was not reset between files.

Also adds a verbose option to display the checked file name.