### PR TITLE
Run Golo application from a shebanged script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,6 +206,17 @@ startScripts.dependsOn vanillaScripts
 
 // .................................................................................................................. //
 
+task goloshScripts(type: CreateStartScripts) {
+  outputDir = file('build/golosh')
+  mainClassName = goloCliMain + ' shebang'
+  applicationName = 'golosh'
+  classpath = startScripts.classpath
+}
+
+startScripts.dependsOn goloshScripts
+
+// .................................................................................................................. //
+
 distributions {
   main {
     baseName = 'golo'
@@ -233,6 +244,9 @@ distributions {
         exclude 'html5'
       }
       from(vanillaScripts) {
+        into 'bin'
+      }
+      from(goloshScripts) {
         into 'bin'
       }
     }

--- a/doc/basics.adoc
+++ b/doc/basics.adoc
@@ -198,7 +198,7 @@ Naturally the main goal is to use this command to make the script self-executabl
 
 [source,golo]
 ----
-#! /path/to/golo shebang
+#!/path/to/golo shebang
 module hello
 
 function main = |args| {
@@ -221,7 +221,7 @@ a golo script can be hasbanged with `env`:
 
 [source,golo]
 ----
-#! /usr/bin/env golosh
+#!/usr/bin/env golosh
 module hello
 
 function main = |args| {

--- a/doc/basics.adoc
+++ b/doc/basics.adoc
@@ -171,6 +171,85 @@ $
 
 Simple, isn't it?
 
+=== Running Golo script
+
+Golo provides a `shebang` command for running a Golo file as a simple script.
+
+[source,golo]
+----
+module hello
+
+function main = |args| {
+  require(args: length() > 1, "You should set at least one argument!")
+  println("Hello " + args: get(1) + " from '" + args: get(0) + "'!")
+}
+----
+
+the script above can be executed with:
+
+[source]
+----
+$ golo shebang hello.golo World
+Hello World from 'hello.golo'!
+$
+----
+
+Naturally the main goal is to use this command to make the script self-executable:
+
+[source,golo]
+----
+#! /path/to/golo shebang
+module hello
+
+function main = |args| {
+  require(args: length() > 1, "You should set at least one argument!")
+  println("Hello " + args: get(1) + " from '" + args: get(0) + "'!")
+}
+----
+
+Now, we can run the script directly:
+
+----
+$ chmod +x hello.golo
+$ ./hello.golo World
+Hello World from 'hello.golo'!
+$
+----
+
+NOTE: Golo also provides `golosh` script that is a shortcut for the `golo shebang` command, thus
+a golo script can be hasbanged with `env`:
+
+[source,golo]
+----
+#! /usr/bin/env golosh
+module hello
+
+function main = |args| {
+  require(args: length() > 1, "You should set at least one argument!")
+  println("Hello " + args: get(1) + " from '" + args: get(0) + "'!")
+}
+----
+
+NOTE: Each `golo` and `jar` files present in the script file's directory or the sub directories
+will be scaned.
+
+[source]
+----
+$ tree ./
+./
+└── libs
+    └── libA.jar
+    └── libB.jar
+└── commons
+    └── utils.golo
+    └── others.golo
+    └── vendors
+        └── otherlib.jar
+└── hello.golo
+└── library.golo
+$
+----
+
 === Passing JVM-specific flags
 
 Both `golo` and `run` commands can be given JVM-specific flags using the `JAVA_OPTS` environment

--- a/src/main/java/org/eclipse/golo/cli/Main.java
+++ b/src/main/java/org/eclipse/golo/cli/Main.java
@@ -16,8 +16,6 @@ import org.eclipse.golo.cli.command.spi.CliCommand;
 import java.io.*;
 import java.util.*;
 
-import static java.lang.invoke.MethodType.methodType;
-
 public class Main {
 
   static class GlobalArguments {

--- a/src/main/java/org/eclipse/golo/cli/command/CompilerCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/CompilerCommand.java
@@ -21,7 +21,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;

--- a/src/main/java/org/eclipse/golo/cli/command/DiagnoseCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/DiagnoseCommand.java
@@ -21,7 +21,6 @@ import org.eclipse.golo.compiler.ir.IrTreeDumper;
 import org.eclipse.golo.compiler.parser.ASTCompilationUnit;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/org/eclipse/golo/cli/command/GoloGoloCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/GoloGoloCommand.java
@@ -36,10 +36,11 @@ public class GoloGoloCommand implements CliCommand {
   @Parameter(names = "--classpath", variableArity = true, description = "Classpath elements (.jar and directories)")
   List<String> classpath = new LinkedList<>();
 
+  @Override
   public void execute() throws Throwable {
     URLClassLoader primaryClassLoader = primaryClassLoader(this.classpath);
     GoloClassLoader loader = new GoloClassLoader(primaryClassLoader);
-     Thread.currentThread().setContextClassLoader(loader);
+    Thread.currentThread().setContextClassLoader(loader);
     Class<?> lastClass = null;
     for (String goloFile : this.files) {
       lastClass = loadGoloFile(goloFile, this.module, loader);

--- a/src/main/java/org/eclipse/golo/cli/command/ShebangCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/ShebangCommand.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2012-2016 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.golo.cli.command;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLClassLoader;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eclipse.golo.cli.command.spi.CliCommand;
+import org.eclipse.golo.compiler.GoloClassLoader;
+import org.eclipse.golo.compiler.GoloCompilationException;
+
+@Parameters(commandNames = {"shebang"}, commandDescription = "Dynamically loads and runs from Golo script file")
+public class ShebangCommand implements CliCommand {
+
+  @Parameter(description = "Shebang arguments", required = true)
+  List<String> arguments = new LinkedList<>();
+
+  @Override
+  public void execute() throws Throwable {
+    Path script = Paths.get(arguments.get(0));
+    while (Files.isSymbolicLink(script)) {
+      script = Files.readSymbolicLink(script);
+    }
+    Path basedir = script.getParent();
+    URLClassLoader primaryClassLoader = primaryClassLoader(classpath(basedir));
+    GoloClassLoader loader = new GoloClassLoader(primaryClassLoader);
+    Thread.currentThread().setContextClassLoader(loader);
+    try {
+      loadOtherGoloFiles(loader, basedir, script);
+      callRun(loadGoloFile(loader, script), this.arguments.toArray(new String[this.arguments.size()]));
+    } catch (GoloCompilationException e) {
+      handleCompilationException(e);
+    }
+  }
+
+  private List<String> classpath(Path basedir) throws IOException {
+    PathMatcher jarFiles = FileSystems.getDefault().getPathMatcher("glob:**/*.jar");
+    return Files.walk(basedir)
+        .filter(path -> jarFiles.matches(path))
+        .map(path -> path.toAbsolutePath().toString())
+        .collect(Collectors.toList());
+  }
+
+  private void loadOtherGoloFiles(GoloClassLoader loader, Path basedir, Path script) throws IOException {
+    PathMatcher goloFiles = FileSystems.getDefault().getPathMatcher("glob:**/*.golo");
+    Files.walk(basedir)
+        .filter(path -> goloFiles.matches(path) && path.compareTo(script) != 0)
+        .forEach(path -> loadGoloFile(loader, path));
+  }
+
+  private Class<?> loadGoloFile(GoloClassLoader loader, Path path) {
+    try (InputStream is = Files.newInputStream(path)) {
+      Path filename = path.getFileName();
+      if (filename != null) {
+        return loader.load(filename.toString(), is);
+      } else {
+        throw new RuntimeException("Path " + path + " is not a regular file.");
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/src/main/resources/META-INF/services/org.eclipse.golo.cli.command.spi.CliCommand
+++ b/src/main/resources/META-INF/services/org.eclipse.golo.cli.command.spi.CliCommand
@@ -15,3 +15,4 @@ org.eclipse.golo.cli.command.InitCommand
 org.eclipse.golo.cli.command.RunCommand
 org.eclipse.golo.cli.command.VersionCommand
 org.eclipse.golo.cli.command.CheckCommand
+org.eclipse.golo.cli.command.ShebangCommand


### PR DESCRIPTION
ref: [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix))

This feature aim to run golo application as simple runnable script.

```
golo shebang /path/to/script.golo arg1 arg2
```
this command do:
 - compile every golo files in the `/path/to/` directory recursively
 - add every `jar` files in the `/path/to/` directory recursively to the current classpath
 - run `script.golo` main funtion with `/path/to/script.golo`, `args1` and `arg2` as parameters

so we can now shebang this script file (script.golo):
```golo
#!/path/to/golo  shebang
module script

function main = |args| {
  foreach arg in args {
    println(arg)
  }
}

```
then in a shell `./script.golo arg1 arg2` will print
```
./script.golo
arg1
arg2
```