### PR TITLE
Fix destructuring assignment inside a closure

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/ir/ReferenceTable.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ReferenceTable.java
@@ -83,6 +83,11 @@ public final class ReferenceTable implements Scope {
 
   @Override
   public void relink(ReferenceTable parent) {
+    for(LocalReference reference : parent.references()) {
+      if(this.hasReferenceFor(reference.getName())){
+        this.remove(reference.getName());
+      }
+    }
     this.parent = parent;
   }
 

--- a/src/test/resources/for-execution/destruct.golo
+++ b/src/test/resources/for-execution/destruct.golo
@@ -130,6 +130,15 @@ function test_swap = {
   require(c == 1, "err")
 }
 
+# issue #391
+function test_destruct_affectation_inside_closure = {
+  let closure = {
+    let a, b = [1,2]
+    return a
+  }
+  require(closure() == 1, "err")
+}
+
 function main = |args| {
   test_tuple_samesize()
   test_tuple_rest()


### PR DESCRIPTION
Relinking reference tables for a block inside a block
may cause dublicate reference declaration.

This fixes #391