### PR TITLE
Special last argument

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
@@ -66,10 +66,10 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
 
   private static Handle makeHandle(String methodName, String description) {
     return new Handle(H_INVOKESTATIC,
-      "org/eclipse/golo/runtime/" + methodName,
-      "bootstrap",
-      "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;"
-      + description + ")Ljava/lang/invoke/CallSite;", false);
+        "org/eclipse/golo/runtime/" + methodName,
+        "bootstrap",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;"
+        + description + ")Ljava/lang/invoke/CallSite;", false);
   }
 
   private static RuntimeException invalidElement(GoloElement element) {
@@ -115,6 +115,11 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
   @Override
   public void visitDestructuringAssignment(DestructuringAssignment statement) {
     throw invalidElement(statement);
+  }
+
+  @Override
+  public void visitNoop(Noop noop) {
+    // do nothing...
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -83,7 +83,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
    * have no way to decide if it should be the last argument of the current call (aside from the
    * line number, which is pretty fragile).
    */
-  private void specialLastArgument(FunctionInvocation invocation) {
+  private void specialLastArgument(AbstractInvocation invocation) {
     GoloElement next = invocation.getNextSibling();
     if (next != null
         && (next instanceof ClosureReference

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -55,6 +55,20 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
     }
   }
 
+  @Override
+  public void visitFunctionInvocation(FunctionInvocation invocation) {
+    closureAsLastArgument(invocation);
+    invocation.walk(this);
+  }
+
+  private void closureAsLastArgument(FunctionInvocation invocation) {
+    GoloElement next = invocation.getNextSibling();
+    if (next != null && next instanceof ClosureReference) {
+      next.replaceInParentBy(null);
+      invocation.withArgs(next);
+    }
+  }
+
   /**
    * Case expansion.
    * <p>

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -57,13 +57,15 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
 
   @Override
   public void visitFunctionInvocation(FunctionInvocation invocation) {
-    closureAsLastArgument(invocation);
+    specialLastArgument(invocation);
     invocation.walk(this);
   }
 
-  private void closureAsLastArgument(FunctionInvocation invocation) {
+  private void specialLastArgument(FunctionInvocation invocation) {
     GoloElement next = invocation.getNextSibling();
-    if (next != null && next instanceof ClosureReference) {
+    if (next != null
+        && (next instanceof ClosureReference
+          || next instanceof ConstantStatement)) {
       next.replaceInParentBy(null);
       invocation.withArgs(next);
     }

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -153,6 +153,12 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
     construct.accept(this);
   }
 
+  /**
+   * Function reference expansion.
+   * <p>
+   * Replace a literal function reference {@code ^myfun} by a call to
+   * {@code gololang.Predefined.fun("myfun")}
+   */
   @Override
   public void visitConstantStatement(ConstantStatement constantStatement) {
     constantStatement.walk(this);

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -61,6 +61,13 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
     invocation.walk(this);
   }
 
+  @Override
+  public void visitMethodInvocation(MethodInvocation invocation) {
+    specialLastArgument(invocation);
+    invocation.walk(this);
+  }
+
+
   /**
    * Adds the following node as the last argument of the invocation.
    * <p>

--- a/src/main/java/org/eclipse/golo/compiler/ir/AbstractGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/AbstractGoloIrVisitor.java
@@ -183,4 +183,8 @@ public abstract class AbstractGoloIrVisitor implements GoloIrVisitor {
     localRef.walk(this);
   }
 
+  @Override
+  public void visitNoop(Noop noop) {
+    noop.walk(this);
+  }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/AssignmentStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/AssignmentStatement.java
@@ -79,4 +79,13 @@ public final class AssignmentStatement extends GoloStatement {
       throw cantReplace(original, newElement);
     }
   }
+
+  @Override
+  protected GoloElement nextSiblingOf(GoloElement current) {
+    if (expressionStatement == current) {
+      return this.getNextSibling();
+    }
+    return null;
+  }
+
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
@@ -91,4 +91,16 @@ public final class BinaryOperation extends ExpressionStatement {
     }
   }
 
+  @Override
+  protected GoloElement nextSiblingOf(GoloElement current) {
+    // TODO: makes a lot of tests fail. Why?
+    // if (leftExpression == current) {
+    //   return rightExpression;
+    // }
+    if (rightExpression == current) {
+      return this.getNextSibling();
+    }
+    return null;
+  }
+
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/Block.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Block.java
@@ -174,4 +174,23 @@ public final class Block extends ExpressionStatement implements Scope {
       throw cantReplace(original, newElement);
     }
   }
+
+  @Override
+  protected GoloElement previousSiblingOf(GoloElement current) {
+    int idx = statements.indexOf(current);
+    if (idx < 1) {
+      return null;
+    }
+    return statements.get(idx - 1);
+  }
+
+  @Override
+  protected GoloElement nextSiblingOf(GoloElement current) {
+    int idx = statements.indexOf(current);
+    if (idx == -1 || idx == statements.size() - 1) {
+      return null;
+    }
+    return statements.get(idx + 1);
+  }
+
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -70,6 +70,30 @@ public abstract class GoloElement {
     }
   }
 
+  protected GoloElement previousSiblingOf(GoloElement current) {
+    return null;
+  }
+
+  protected GoloElement nextSiblingOf(GoloElement current) {
+    return null;
+  }
+
+  public GoloElement getPreviousSibling() {
+    if (this.parent.isPresent()) {
+      return this.parent.get().previousSiblingOf(this);
+    } else {
+      return null;
+    }
+  }
+
+  public GoloElement getNextSibling() {
+    if (this.parent.isPresent()) {
+      return this.parent.get().nextSiblingOf(this);
+    } else {
+      return null;
+    }
+  }
+
   protected RuntimeException cantReplace() {
     return new UnsupportedOperationException(getClass().getName() + " can't replace elements");
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -111,11 +111,15 @@ public abstract class GoloElement {
   }
 
   public void replaceInParentBy(GoloElement newElement) {
+    GoloElement replacement = newElement;
+    if (newElement == null) {
+      replacement = new Noop(this.getClass().getSimpleName() + " was removed");
+    }
     if (this.parent.isPresent()) {
-      this.parent.get().replaceElement(this, newElement);
-      this.parent.get().makeParentOf(newElement);
+      this.parent.get().replaceElement(this, replacement);
+      this.parent.get().makeParentOf(replacement);
       if (hasASTNode()) {
-        getASTNode().setIrElement(newElement);
+        getASTNode().setIrElement(replacement);
       }
       this.setParentNode(null);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloIrVisitor.java
@@ -76,4 +76,6 @@ public interface GoloIrVisitor {
   void visitNamedArgument(NamedArgument namedArgument);
 
   void visitLocalReference(LocalReference localRef);
+
+  void visitNoop(Noop noop);
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/IrTreeDumper.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/IrTreeDumper.java
@@ -457,4 +457,12 @@ public class IrTreeDumper implements GoloIrVisitor {
     namedArgument.getExpression().accept(this);
     decr();
   }
+
+  @Override
+  public void visitNoop(Noop noop) {
+    incr();
+    space();
+    System.out.println("Noop: " + noop.comment());
+    decr();
+  }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/Noop.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Noop.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012-2015 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.golo.compiler.ir;
+
+/**
+ * Empty IR node.
+ * <p>
+ * This is used to replace macros that returns nothing.
+ */
+public final class Noop extends GoloStatement {
+
+  private final String comment;
+
+  public Noop(String comment) {
+    this.comment = comment;
+  }
+
+  public String comment() {
+    return this.comment;
+  }
+
+  @Override
+  public void accept(GoloIrVisitor visitor) {
+    visitor.visitNoop(this);
+  }
+
+  @Override
+  public void walk(GoloIrVisitor visitor) {
+    // do nothing, not a composite
+  }
+
+  @Override
+  public void replaceElement(GoloElement original, GoloElement newElement) {
+    throw cantReplace();
+  }
+}

--- a/src/test/java/org/eclipse/golo/compiler/ir/SiblingTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/ir/SiblingTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2012-2016 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.golo.compiler.ir;
+
+import org.testng.annotations.Test;
+import org.testng.annotations.BeforeMethod;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class SiblingTest {
+
+  private Block block;
+
+  @BeforeMethod
+  public void setUp() {
+    block = Block.emptyBlock();
+    block.addStatement(new ConstantStatement(1));
+    block.addStatement(new ConstantStatement(2));
+    block.addStatement(new ConstantStatement(3));
+  }
+
+  @Test
+  public void previous() {
+    GoloStatement middle = block.getStatements().get(1);
+    GoloElement prev = middle.getPreviousSibling();
+    assertThat(prev, instanceOf(ConstantStatement.class));
+    Object value = ((ConstantStatement) prev).getValue();
+    assertThat(value, is(1));
+  }
+
+  @Test
+  public void next() {
+    GoloStatement middle = block.getStatements().get(1);
+    GoloElement next = middle.getNextSibling();
+    assertThat(next, instanceOf(ConstantStatement.class));
+    Object value = ((ConstantStatement) next).getValue();
+    assertThat(value, is(3));
+  }
+
+  @Test
+  public void notAChild() {
+    GoloStatement statement = new ConstantStatement(42);
+    assertThat(statement.getPreviousSibling(), is(nullValue()));
+    assertThat(statement.getNextSibling(), is(nullValue()));
+  }
+
+  @Test
+  public void lastChild() {
+    GoloStatement last = block.getStatements().get(2);
+    assertThat(last.getNextSibling(), is(nullValue()));
+  }
+
+  @Test
+  public void firstChild() {
+    GoloStatement first = block.getStatements().get(0);
+    assertThat(first.getPreviousSibling(), is(nullValue()));
+  }
+}

--- a/src/test/java/org/eclipse/golo/compiler/ir/SpecialLastArgument.java
+++ b/src/test/java/org/eclipse/golo/compiler/ir/SpecialLastArgument.java
@@ -1,0 +1,25 @@
+ /*
+* Copyright (c) 2012-2016 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*/
+
+package org.eclipse.golo.compiler.ir;
+
+import org.testng.annotations.Test;
+import org.eclipse.golo.internal.testing.GoloTest;
+
+public class SpecialLastArgument extends GoloTest {
+  @Override
+  protected String srcDir() {
+    return "for-test/";
+  }
+
+  @Test
+  public void testSpecialLastArg() throws Throwable {
+    run("special-last-arg");
+  }
+}

--- a/src/test/resources/for-test/special-last-arg.golo
+++ b/src/test/resources/for-test/special-last-arg.golo
@@ -1,0 +1,108 @@
+module golo.test.SpecialLastArg
+
+local function assertEquals = |value, expected| {
+  require(value == expected, "%s should be %s": format(value, expected))
+}
+
+
+# .......................................................................... #
+
+local function noParam = |a, f| -> [a, f()]
+
+function test_noparam = {
+  let r = noParam(1) {
+    return 2
+  }
+  assertEquals(r, [1, 2])
+}
+
+
+# .......................................................................... #
+local function apply = |a, f| -> f(a)
+
+function test_apply = {
+  let r = apply(21) |x| -> 2 * x
+  assertEquals(r, 42)
+}
+
+
+# .......................................................................... #
+local function revAppender = |v, l| {
+  return l: append(v)
+}
+
+function test_onlist = {
+  let r = revAppender(3) list[
+    1,
+    2
+  ]
+  assertEquals(r, list[1, 2, 3])
+}
+
+
+# .......................................................................... #
+local function appender = |l, v| {
+  return l: append(v)
+}
+
+function test_sideeffect = {
+  let l = list[4, 2]
+  appender(l) 42
+  assertEquals(l, list[4, 2, 42])
+}
+
+
+
+# .......................................................................... #
+
+struct MyStuct = { x }
+augment MyStuct {
+  function effectfull = |this, a, f| {
+    this: x(): append(f(a))
+  }
+
+  function pure = |this, a, f| {
+    return this: x(): size() + f(a)
+  }
+}
+
+function test_sideeffect_method = {
+  let f = MyStuct(list[])
+  f: effectfull(1) |x| -> x + 1
+  assertEquals(f: x(), list[2])
+}
+
+function test_pure_method = {
+  let f = MyStuct(list[1])
+  let r = f: pure(40) |x| -> x + 1
+  assertEquals(r, 42)
+}
+
+# .......................................................................... #
+
+local function inc = |x| -> x + 1
+
+function test_funref_method = {
+  let f = MyStuct(list[1])
+  let r = f: pure(40) ^inc
+  assertEquals(r, 42)
+}
+
+function test_funref_function = {
+  let r = apply(41) ^inc
+  assertEquals(r, 42)
+}
+
+# .......................................................................... #
+function main = |args| {
+  test_noparam()
+  test_apply()
+  test_onlist()
+  test_sideeffect()
+  test_sideeffect_method()
+  test_pure_method()
+  test_funref_method()
+  test_funref_function()
+
+  println("ok")
+}


### PR DESCRIPTION
Try to implement #403.

This is still a work in progress. I need feedback since it looks like a big bad hack to me.

It works when the special last argument is a constant (or a closure or a collection litteral, which are indeed constants), in the context of affectations of call as a single statement (see the test file). It's not yet tested in other contexts.

Still to do:
- [ ] make it work on unary functions without parenthesis
- [ ] documentation
- [ ] more tests
