### PR TITLE
FIX: #407 Compiler hangs on unassigned variable

### DIFF
--- a/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
+++ b/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
@@ -1006,7 +1006,7 @@ void Statement() #void:{}
   |
   LOOKAHEAD(3) DestructuringAssignment()
   |
-  LOOKAHEAD(3) LetOrVar()
+  LOOKAHEAD(2) LetOrVar()
   |
   ExpressionStatement()
   |


### PR DESCRIPTION
Fix a bug introduced in https://github.com/eclipse/golo-lang/commit/2f1dc71787506edd45fa1d1242684cfbbb03b940 and identified by @vvdleun in #407 
When declaring a name with `let` or `var` but affecting no value, the parser hangs.

The issue was a lookahead to high for this expression, added for destructuring.