### PR TITLE
Link golodoc and source file

### DIFF
--- a/src/main/java/org/eclipse/golo/doc/AbstractProcessor.java
+++ b/src/main/java/org/eclipse/golo/doc/AbstractProcessor.java
@@ -37,7 +37,7 @@ public abstract class AbstractProcessor {
     if (templateCache.containsKey(key)) {
       return templateCache.get(key);
     }
-    InputStream in = AbstractProcessor.class.getResourceAsStream("/org/eclipse/golo/doc/" + name + "-" + format);
+    InputStream in = AbstractProcessor.class.getResourceAsStream("/org/eclipse/golo/doc/" + key);
     if (in == null) {
       throw new IllegalArgumentException("There is no template " + name + " for format: " + format);
     }

--- a/src/main/java/org/eclipse/golo/doc/HtmlProcessor.java
+++ b/src/main/java/org/eclipse/golo/doc/HtmlProcessor.java
@@ -25,11 +25,13 @@ import com.github.rjeschke.txtmark.Processor;
 
 public class HtmlProcessor extends AbstractProcessor {
 
+  private Path srcFile;
+
   @Override
   public String render(ASTCompilationUnit compilationUnit) throws Throwable {
     FunctionReference template = template("template", "html");
     ModuleDocumentation documentation = new ModuleDocumentation(compilationUnit);
-    return (String) template.handle().invokeWithArguments(documentation);
+    return (String) template.handle().invokeWithArguments(documentation, srcFile);
   }
 
   @Override
@@ -39,6 +41,7 @@ public class HtmlProcessor extends AbstractProcessor {
     for (ASTCompilationUnit unit : units.values()) {
       String moduleName = moduleName(unit);
       Path docFile = outputFile(targetFolder, moduleName, ".html");
+      srcFile = outputFile(targetFolder, moduleName, ".src.html");
       ensureFolderExists(docFile.getParent());
       Predefined.textToFile(render(unit), docFile);
       moduleDocFile.put(moduleName, targetFolder.relativize(docFile).toString());

--- a/src/main/java/org/eclipse/golo/doc/HtmlProcessor.java
+++ b/src/main/java/org/eclipse/golo/doc/HtmlProcessor.java
@@ -25,7 +25,10 @@ import com.github.rjeschke.txtmark.Processor;
 
 public class HtmlProcessor extends AbstractProcessor {
 
+  private String moduleName;
+  private Path targetFolder;
   private Path srcFile;
+
 
   @Override
   public String render(ASTCompilationUnit compilationUnit) throws Throwable {
@@ -34,16 +37,34 @@ public class HtmlProcessor extends AbstractProcessor {
     return (String) template.handle().invokeWithArguments(documentation, srcFile);
   }
 
+  private String renderSource(String filename) throws Throwable {
+    FunctionReference template = template("src", "html");
+    String content = (String) Predefined.fileToText(filename, "UTF-8");
+    int nbLines = 0;
+    for (int i = 0; i < content.length(); i++) {
+      if (content.charAt(i) == '\n') {
+        nbLines++;
+      }
+    }
+    return (String) template.handle().invokeWithArguments(moduleName, content, nbLines);
+  }
+
+  private Path createFile(String ext, String content) throws Throwable {
+    Path outFile = outputFile(this.targetFolder, this.moduleName, "." + ext);
+    ensureFolderExists(outFile.getParent());
+    Predefined.textToFile(content, outFile);
+    return outFile;
+  }
+
   @Override
   public void process(Map<String, ASTCompilationUnit> units, Path targetFolder) throws Throwable {
+    this.targetFolder = targetFolder;
     TreeMap<String, String> moduleDocFile = new TreeMap<>();
     ensureFolderExists(targetFolder);
-    for (ASTCompilationUnit unit : units.values()) {
-      String moduleName = moduleName(unit);
-      Path docFile = outputFile(targetFolder, moduleName, ".html");
-      srcFile = outputFile(targetFolder, moduleName, ".src.html");
-      ensureFolderExists(docFile.getParent());
-      Predefined.textToFile(render(unit), docFile);
+    for (Map.Entry<String, ASTCompilationUnit> unit : units.entrySet()) {
+      this.moduleName = moduleName(unit.getValue());
+      srcFile = createFile("src.html", renderSource(unit.getKey()));
+      Path docFile = createFile("html", render(unit.getValue()));
       moduleDocFile.put(moduleName, targetFolder.relativize(docFile).toString());
     }
     FunctionReference indexTemplate = template("index", "html");

--- a/src/main/resources/org/eclipse/golo/doc/src-html
+++ b/src/main/resources/org/eclipse/golo/doc/src-html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<%@params moduleName, src, nbOfLines %>
+<html>
+<head>
+  <title><%= moduleName %> source</title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <style>
+    pre {
+        font-family: monospace;
+        font-size: 90%;
+        background-color: #eee;
+        padding: 0;
+        margin: 0;
+    }
+
+    pre code {
+        font-family: monospace;
+        font-size: inherit;
+        padding: 0.5em ;
+        margin: 0;
+    }
+
+    :target {
+        background-color: yellow;
+    }
+
+    #line-numbers {
+        float: left;
+        position: relative;
+        padding: 0.5em;
+    }
+
+    #src {
+        float: left;
+        position: relative;
+    }
+  </style>
+</head>
+<body>
+<pre id="line-numbers">
+<% for (var i = 1, i <= nbOfLines, i = i + 1) {%><span class="line-number" id="l-<%= i %>"><%=i%></span>
+<%}%></pre>
+<pre id="src" class="highlight highlightjs">
+<code class="language-golo" data-lang="golo"><%= src %></code>
+</pre>
+<link rel="stylesheet" href="http://golo-lang.org/documentation/next/styles/github.min.css"/>
+<script src="http://golo-lang.org/documentation/next/highlight.min.js"></script>
+<script>
+hljs.initHighlighting();
+</script>
+</body>
+</html>

--- a/src/main/resources/org/eclipse/golo/doc/template-html
+++ b/src/main/resources/org/eclipse/golo/doc/template-html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<%@params doc %>
+<%@params doc, src %>
 <%@import org.eclipse.golo.doc.HtmlProcessor %>
 <%
 let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
@@ -186,6 +186,18 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
       padding-left: 1.5em;
     }
 
+    .srclink {
+      float:  right;
+      text-align: right;
+      color: #999;
+      font-size: 75%;
+      margin-top: -2em;
+    }
+
+    .srclink a {
+      color: inherit;
+    }
+
     @media (max-width: 50em) {
       #toc {
         display: none;
@@ -275,6 +287,11 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
   <% foreach structDoc in doc: structs() { %>
     <h3 id="<%= structDoc: name() %>"><%= structDoc: name() %>
     <a class="permalink" href="#<%= structDoc: name() %>" title="link to this section">&#182;</a></h3>
+    <% if src isnt null { %>
+    <nav class="srclink"><a href="<%= src %>#l-<%= structDoc: line() %>"
+                            rel="source" title="link to the corresponding
+                            source">Source</a></nav>
+    <% } %>
 
     <h5>Members</h5>
     <ul>
@@ -293,6 +310,11 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
   <% foreach unionDoc in doc: unions() { %>
     <h3 id="<%= unionDoc: name() %>"><%= unionDoc: name() %>
     <a class="permalink" href="#<%= unionDoc: name() %>" title="link to this section">&#182;</a></h3>
+    <% if src isnt null { %>
+    <nav class="srclink"><a href="<%= src %>#l-<%= unionDoc: line() %>"
+                            rel="source" title="link to the corresponding
+                            source">Source</a></nav>
+    <% } %>
 
     <div class="golodoc">
     <%= process(unionDoc: documentation(), 3, CONFIG) %>
@@ -325,6 +347,11 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     <h3 id="<%= namedAugmentationDoc: name()%>"><%= namedAugmentationDoc: name()%>
     <a class="permalink" href="#<%= namedAugmentationDoc: name()%>" title="link
     to this section">&#182;</a></h3>
+    <% if src isnt null { %>
+    <nav class="srclink"><a href="<%= src %>#l-<%= namedAugmentationDoc: line() %>"
+                            rel="source" title="link to the corresponding
+                            source">Source</a></nav>
+    <% } %>
     <div class="golodoc">
       <%= process(namedAugmentationDoc: documentation(), 3, CONFIG) %>
     </div>
@@ -335,6 +362,11 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
         <h4 id="<%= namedAugmentationDoc: name() %>.<%= funcDoc: name() %>_<%= funcDoc: arguments(): size() %>"><%= funcDoc: name() %>(<%= funcDoc: arguments(): join(", ") %>)
       <% } %>
       <a class="permalink" href="#<%= namedAugmentationDoc: name() %>.<%= funcDoc: name() %>_<%= funcDoc: arguments(): size() %>" title="link to this section">&#182;</a></h4>
+    <% if src isnt null { %>
+    <nav class="srclink"><a href="<%= src %>#l-<%= funcDoc: line() %>"
+                            rel="source" title="link to the corresponding
+                            source">Source</a></nav>
+    <% } %>
       <div class="golodoc">
         <%= process(funcDoc: documentation(), 4, CONFIG) %>
       </div>
@@ -348,6 +380,11 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
   <% foreach augmentDoc in doc: augmentations() { %>
     <h3 id="augment.<%= augmentDoc: target() %>"><%= augmentDoc: target() %>
     <a class="permalink" href="#augment.<%= augmentDoc: target() %>" title="link to this section">&#182;</a></h3>
+    <% if src isnt null { %>
+    <nav class="srclink"><a href="<%= src %>#l-<%= augmentDoc: line() %>"
+                            rel="source" title="link to the corresponding
+                            source">Source</a></nav>
+    <% } %>
     <div class="golodoc">
       <%= process(augmentDoc: documentation(), 3, CONFIG) %>
     </div>
@@ -372,6 +409,11 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
         <h4 id="<%= augmentDoc: target() %>.<%= funcDoc: name() %>_<%= funcDoc: arguments(): size() %>"><%= funcDoc: name() %>(<%= funcDoc: arguments(): join(", ") %>)
       <% } %>
       <a class="permalink" href="#<%= augmentDoc: target() %>.<%= funcDoc: name() %>_<%= funcDoc: arguments(): size() %>" title="link to this section">&#182;</a></h4>
+    <% if src isnt null { %>
+    <nav class="srclink"><a href="<%= src %>#l-<%= funcDoc: line() %>"
+                            rel="source" title="link to the corresponding
+                            source">Source</a></nav>
+    <% } %>
       <div class="golodoc">
         <%= process(funcDoc: documentation(), 4, CONFIG) %>
       </div>
@@ -384,6 +426,11 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
   <% foreach funcDoc in doc: functions() { %>
     <h3 id="<%= funcDoc: name() %>_<%= funcDoc: arguments(): size() %>"><%= funcDoc: name() %>(<%= funcDoc: arguments(): join(", ") %>)
     <a class="permalink" href="#<%= funcDoc: name() %>_<%= funcDoc: arguments(): size() %>" title="link to this section">&#182;</a></h3>
+    <% if src isnt null { %>
+    <nav class="srclink"><a href="<%= src %>#l-<%= funcDoc: line() %>"
+                            rel="source" title="link to the corresponding
+                            source">Source</a></nav>
+    <% } %>
     <div class="golodoc">
       <%= process(funcDoc: documentation(), 3, CONFIG) %>
     </div>

--- a/src/main/resources/org/eclipse/golo/doc/template-html
+++ b/src/main/resources/org/eclipse/golo/doc/template-html
@@ -289,8 +289,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     <a class="permalink" href="#<%= structDoc: name() %>" title="link to this section">&#182;</a></h3>
     <% if src isnt null { %>
     <nav class="srclink"><a href="<%= src %>#l-<%= structDoc: line() %>"
-                            rel="source" title="link to the corresponding
-                            source">Source</a></nav>
+                            rel="source" title="Link to the corresponding source">Source</a></nav>
     <% } %>
 
     <h5>Members</h5>
@@ -312,8 +311,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     <a class="permalink" href="#<%= unionDoc: name() %>" title="link to this section">&#182;</a></h3>
     <% if src isnt null { %>
     <nav class="srclink"><a href="<%= src %>#l-<%= unionDoc: line() %>"
-                            rel="source" title="link to the corresponding
-                            source">Source</a></nav>
+                            rel="source" title="Link to the corresponding source">Source</a></nav>
     <% } %>
 
     <div class="golodoc">
@@ -349,8 +347,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     to this section">&#182;</a></h3>
     <% if src isnt null { %>
     <nav class="srclink"><a href="<%= src %>#l-<%= namedAugmentationDoc: line() %>"
-                            rel="source" title="link to the corresponding
-                            source">Source</a></nav>
+                            rel="source" title="Link to the corresponding source">Source</a></nav>
     <% } %>
     <div class="golodoc">
       <%= process(namedAugmentationDoc: documentation(), 3, CONFIG) %>
@@ -364,8 +361,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
       <a class="permalink" href="#<%= namedAugmentationDoc: name() %>.<%= funcDoc: name() %>_<%= funcDoc: arguments(): size() %>" title="link to this section">&#182;</a></h4>
     <% if src isnt null { %>
     <nav class="srclink"><a href="<%= src %>#l-<%= funcDoc: line() %>"
-                            rel="source" title="link to the corresponding
-                            source">Source</a></nav>
+                            rel="source" title="Link to the corresponding source">Source</a></nav>
     <% } %>
       <div class="golodoc">
         <%= process(funcDoc: documentation(), 4, CONFIG) %>
@@ -382,8 +378,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     <a class="permalink" href="#augment.<%= augmentDoc: target() %>" title="link to this section">&#182;</a></h3>
     <% if src isnt null { %>
     <nav class="srclink"><a href="<%= src %>#l-<%= augmentDoc: line() %>"
-                            rel="source" title="link to the corresponding
-                            source">Source</a></nav>
+                            rel="source" title="Link to the corresponding source">Source</a></nav>
     <% } %>
     <div class="golodoc">
       <%= process(augmentDoc: documentation(), 3, CONFIG) %>
@@ -411,8 +406,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
       <a class="permalink" href="#<%= augmentDoc: target() %>.<%= funcDoc: name() %>_<%= funcDoc: arguments(): size() %>" title="link to this section">&#182;</a></h4>
     <% if src isnt null { %>
     <nav class="srclink"><a href="<%= src %>#l-<%= funcDoc: line() %>"
-                            rel="source" title="link to the corresponding
-                            source">Source</a></nav>
+                            rel="source" title="Link to the corresponding source">Source</a></nav>
     <% } %>
       <div class="golodoc">
         <%= process(funcDoc: documentation(), 4, CONFIG) %>
@@ -428,8 +422,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     <a class="permalink" href="#<%= funcDoc: name() %>_<%= funcDoc: arguments(): size() %>" title="link to this section">&#182;</a></h3>
     <% if src isnt null { %>
     <nav class="srclink"><a href="<%= src %>#l-<%= funcDoc: line() %>"
-                            rel="source" title="link to the corresponding
-                            source">Source</a></nav>
+                            rel="source" title="Link to the corresponding source">Source</a></nav>
     <% } %>
     <div class="golodoc">
       <%= process(funcDoc: documentation(), 3, CONFIG) %>


### PR DESCRIPTION
This implements the first point in #383: the golodoc now links to a html version of the source file, to the line where the documented element is.