### PR TITLE
Move the JavaCC/JJTree generated code to src/main/generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tags
 build/
 .gradle/
 /.nb-gradle/
+src/main/generated

--- a/README.md
+++ b/README.md
@@ -67,32 +67,6 @@ Common tasks:
 
 The complete list of tasks is available by running `./gradlew tasks`.
 
-### IDE support
-
-#### Eclipse
-
-You should use the [buildship plugin](https://projects.eclipse.org/projects/tools.buildship).
-
-Note that you may have to manually adjust the Java source paths to include `build/generated/javacc`
-and `build/generated/jjtree`.
-
-#### Netbeans
-
-Netbeans has
-[a recommended community-supported Gradle plugin](https://github.com/kelemen/netbeans-gradle-project).
-
-It works with no required manual adjustment on the Golo code base in our tests.
-
-#### IntelliJ IDEA
-
-Gradle support is native in IntelliJ IDEA.
-
-Note that you may have to adjust the module settings to:
-
-1. remove `build` from the excluded folders, and
-2. add both `build/generated/javacc` and `build/generated/jjtree` as source folders, and
-3. exclude other folders in `build` to reduce completion scopes.
-
 ### Special build profiles
 
 #### Bootstrap mode

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,14 @@ tasks.withType(JavaCompile) {
 
 // .................................................................................................................. //
 
+compileJjtree {
+  outputDirectory = file("$rootProject.projectDir/src/main/generated")
+}
+
+compileJavacc {
+  outputDirectory = file("$rootProject.projectDir/src/main/generated")
+}
+
 sourceSets {
   main {
     java {

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,11 @@ compileJavacc {
   outputDirectory = file("$rootProject.projectDir/src/main/generated")
 }
 
+task cleanGenerateFiles(type: Delete) {
+  delete file("$rootProject.projectDir/src/main/generated")
+}
+clean.dependsOn cleanGenerateFiles
+
 sourceSets {
   main {
     java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Thu Oct 06 11:48:02 CEST 2016
+#Thu Dec 01 16:47:54 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This makes it easier to locate these files from an IDE.