### PR TITLE
Add compiler option to set UTF-8 as default encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ targetCompatibility = 1.8
 
 tasks.withType(JavaCompile) {
   options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation"]
+  options.encoding = "UTF-8"
 }
 
 // .................................................................................................................. //


### PR DESCRIPTION
When I try to compile the Golo project on an OS that does use UTF-8 as default encoding some warnings are displayed beacause of some UTF-8 chars present in Java comments and javadoc.
This one fixes this issue.