### PR TITLE
Fix fragile test on a not case sensitive FS

### DIFF
--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -2123,8 +2123,8 @@ public class CompileAndRunTest {
       moduleClass.getMethod("unknown_class").invoke(null);
       fail();
     } catch (Exception e) {
-      assertThat(e.getCause().getClass(), equalTo(BootstrapMethodError.class));
       assertThat(e.getClass(), equalTo(InvocationTargetException.class));
+      assertThat(e.getCause().getClass(), equalTo(BootstrapMethodError.class));
       assertThat(e.getCause().getCause().getClass(), equalTo(ClassNotFoundException.class));
     }
 

--- a/src/test/resources/for-execution/classes.golo
+++ b/src/test/resources/for-execution/classes.golo
@@ -14,4 +14,4 @@ function boolean_class = -> boolean.class
 function arraylist_class = -> ArrayList.class
 function concurrentlist_class = -> concurrent.CopyOnWriteArrayList.class
 
-function unknown_class = -> unknown.class
+function unknown_class = -> johndoe.class


### PR DESCRIPTION
TL;DR: the case unsensitive filesystems sucks :wink:.

Class resolution requires classpath walking, especially from imports resolution.
If a class is not found, then a `ClassNotFoundException` should be thrown.

for example the following test should throw a `ClassNotFoundException`:

```golo
function unknown_class = -> unknown.class
```

but , in some cases, it's a `NoClassDefFoundError` that is thrown.

This is because:
- the `gololang.Unknown` class exists
- the `Unknown.class` file is in the filesystem (not in a jar file)
- the filesystem is not case sensitive
- Jacoco use `loader.getResourceAsStream("gololang/unknown.class")` to get the bytecode to instrument
- `loader.getResourceAsStream("gololang/unknown.class")` return the content of the `"gololang/Unknown.class"` file in this case
- the JVM verify that the class that it try to load is in a file named correctly

So it seems to me decent to just rename the unknown class in the test:

```golo
function unknown_class = -> johndoe.class
```