### PR TITLE
Refactor reordering of named parameters

### DIFF
--- a/doc/java-interop.adoc
+++ b/doc/java-interop.adoc
@@ -98,6 +98,15 @@ function main = |args...| {
 
 Further documentation about https://docs.oracle.com/javase/tutorial/reflect/member/methodparameterreflection.html[Names Method Parameters with Java 8.]
 
+[[warning-no-parameter-names]]
+[WARNING]
+====================
+If the java code was not compiled with named parameters, the named arguments syntax is still valid, but the names are simply ignored and  _no reordering_ will be done. You can therefore use the argument names to improve readability and with the hope that the java library you use will later be compiled with the options, but keep them in the expected order, or you could have unexpected results.
+
+A warning is displayed when named arguments are used with functions without named parameters. It can be disabled by setting the `golo.warnings.no-parameter-names` system property to `false`.
+====================
+
+
 === `null`-safe instance method invocations
 
 Golo supports *`null`-safe* methods invocations using the *"Elvis"* symbol: `?:`.

--- a/src/main/java/org/eclipse/golo/runtime/AugmentationMethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/AugmentationMethodFinder.java
@@ -10,13 +10,16 @@
 package org.eclipse.golo.runtime;
 
 import java.lang.invoke.*;
+import java.lang.reflect.Method;
 import java.util.stream.Stream;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.List;
 import org.eclipse.golo.runtime.augmentation.DefiningModule;
 
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.reflect.Modifier.*;
+import static org.eclipse.golo.runtime.NamedArgumentsHelper.checkArgumentPosition;
 
 class AugmentationMethodFinder extends MethodFinder {
 
@@ -67,6 +70,19 @@ class AugmentationMethodFinder extends MethodFinder {
         getCallStack(),
         getCallStack().flatMap(defining -> getImportedModules(defining.module())))
       .reduce(Stream.empty(), Stream::concat);
+  }
+
+  @Override
+  protected int[] getArgumentsOrder(Method method, List<String> parameterNames, String[] argumentNames) {
+    // redefined to ignore the first parameter (explicit receiver)
+    int[] argumentsOrder = new int[parameterNames.size()];
+    argumentsOrder[0] = 0;
+    for (int i = 0; i < argumentNames.length; i++) {
+      int actualPosition = parameterNames.indexOf(argumentNames[i]);
+      checkArgumentPosition(actualPosition, method.getName(), parameterNames, argumentNames[i]);
+      argumentsOrder[actualPosition] = i + 1;
+    }
+    return argumentsOrder;
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/runtime/AugmentationMethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/AugmentationMethodFinder.java
@@ -79,7 +79,7 @@ class AugmentationMethodFinder extends MethodFinder {
     argumentsOrder[0] = 0;
     for (int i = 0; i < argumentNames.length; i++) {
       int actualPosition = parameterNames.indexOf(argumentNames[i]);
-      checkArgumentPosition(actualPosition, method.getName(), parameterNames, argumentNames[i]);
+      checkArgumentPosition(actualPosition, argumentNames[i], method.getName() + parameterNames);
       argumentsOrder[actualPosition] = i + 1;
     }
     return argumentsOrder;

--- a/src/main/java/org/eclipse/golo/runtime/ClosureCallSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/ClosureCallSupport.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import static java.lang.invoke.MethodHandles.guardWithTest;
 import static java.lang.invoke.MethodHandles.permuteArguments;
 import static java.lang.invoke.MethodType.methodType;
+import static org.eclipse.golo.runtime.NamedArgumentsHelper.checkArgumentPosition;
 
 public final class ClosureCallSupport {
 
@@ -132,15 +133,12 @@ public final class ClosureCallSupport {
             actualPosition = j;
           }
         }
-        if (actualPosition == -1) {
-          throw new IllegalArgumentException(
-              "Argument name " + argumentNames[i]
-              + " not in parameter names used in declaration: " + Arrays.toString(parameterNames));
-        }
+        checkArgumentPosition(actualPosition, argumentNames[i], "closure " + Arrays.toString(parameterNames));
         argumentsOrder[actualPosition + 1] = i + 1;
       }
       return permuteArguments(handle, handle.type(), argumentsOrder);
     }
+    Warnings.noParameterNames("closure " + Arrays.toString(parameterNames), argumentNames);
     return handle;
   }
 }

--- a/src/main/java/org/eclipse/golo/runtime/FunctionCallSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/FunctionCallSupport.java
@@ -208,7 +208,7 @@ public final class FunctionCallSupport {
     int[] argumentsOrder = new int[parameterNames.size()];
     for (int i = 0; i < argumentNames.length; i++) {
       int actualPosition = parameterNames.indexOf(argumentNames[i]);
-      checkArgumentPosition(actualPosition, method.getName(), parameterNames, argumentNames[i]);
+      checkArgumentPosition(actualPosition, argumentNames[i], method.getName() + parameterNames);
       argumentsOrder[actualPosition] = i;
     }
     return argumentsOrder;

--- a/src/main/java/org/eclipse/golo/runtime/MethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/MethodFinder.java
@@ -42,7 +42,7 @@ abstract class MethodFinder {
     argumentsOrder[0] = 0;
     for (int i = 0; i < argumentNames.length; i++) {
       int actualPosition = parameterNames.indexOf(argumentNames[i]);
-      checkArgumentPosition(actualPosition, method.getName(), parameterNames, argumentNames[i]);
+      checkArgumentPosition(actualPosition, argumentNames[i], method.getName() + parameterNames);
       argumentsOrder[actualPosition + 1] = i + 1;
     }
     return argumentsOrder;

--- a/src/main/java/org/eclipse/golo/runtime/MethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/MethodFinder.java
@@ -12,10 +12,15 @@ package org.eclipse.golo.runtime;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Method;
 import java.util.Optional;
+import java.util.List;
 import static org.eclipse.golo.runtime.DecoratorsHelper.getDecoratedMethodHandle;
 import static org.eclipse.golo.runtime.DecoratorsHelper.isMethodDecorated;
 
+import static java.lang.invoke.MethodHandles.permuteArguments;
 import static java.lang.invoke.MethodHandles.Lookup;
+import static org.eclipse.golo.runtime.NamedArgumentsHelper.hasNamedParameters;
+import static org.eclipse.golo.runtime.NamedArgumentsHelper.getParameterNames;
+import static org.eclipse.golo.runtime.NamedArgumentsHelper.checkArgumentPosition;
 
 abstract class MethodFinder {
 
@@ -30,6 +35,28 @@ abstract class MethodFinder {
   }
 
   public abstract MethodHandle find();
+
+  protected int[] getArgumentsOrder(Method method, List<String> parameterNames, String[] argumentNames) {
+    // deal with the first parameter (implicit receiver).
+    int[] argumentsOrder = new int[parameterNames.size() + 1];
+    argumentsOrder[0] = 0;
+    for (int i = 0; i < argumentNames.length; i++) {
+      int actualPosition = parameterNames.indexOf(argumentNames[i]);
+      checkArgumentPosition(actualPosition, method.getName(), parameterNames, argumentNames[i]);
+      argumentsOrder[actualPosition + 1] = i + 1;
+    }
+    return argumentsOrder;
+  }
+
+  public MethodHandle reorderArguments(Method method, MethodHandle handle) {
+    String[] argumentNames = invocation.argumentNames();
+    if (argumentNames.length == 0) { return handle; }
+    if (hasNamedParameters(method)) {
+      return permuteArguments(handle, handle.type(), getArgumentsOrder(method, getParameterNames(method), argumentNames));
+    }
+    Warnings.noParameterNames(method.getName(), argumentNames);
+    return handle;
+  }
 
   protected Optional<MethodHandle> toMethodHandle(Method method) {
     MethodHandle target = null;
@@ -46,10 +73,7 @@ abstract class MethodFinder {
         return Optional.empty();
       }
     }
-    if (invocation.argumentNames().length > 1) {
-      target = FunctionCallSupport.reorderArguments(method, target, invocation.argumentNames());
-    }
-    return Optional.of(invocation.coerce(target));
+    return Optional.of(invocation.coerce(reorderArguments(method, target)));
   }
 
 }

--- a/src/main/java/org/eclipse/golo/runtime/MethodInvocation.java
+++ b/src/main/java/org/eclipse/golo/runtime/MethodInvocation.java
@@ -33,9 +33,7 @@ public class MethodInvocation {
     this.arguments = args;
     this.arity = args.length;
     this.type = type;
-    this.argumentNames = new String[argNames.length + 1];
-    this.argumentNames[0] = "this";
-    System.arraycopy(argNames, 0, argumentNames, 1, argNames.length);
+    this.argumentNames = argNames;
   }
 
   public String name() {
@@ -80,6 +78,13 @@ public class MethodInvocation {
       && isPublic(method.getModifiers())
       && !isAbstract(method.getModifiers())
       && TypeMatching.argumentsMatch(method, arguments);
+  }
+
+  /**
+   * returns a new invocation having the given name.
+   */
+  MethodInvocation withName(String newName) {
+    return new MethodInvocation(newName, type, arguments, argumentNames);
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/runtime/NamedArgumentsHelper.java
+++ b/src/main/java/org/eclipse/golo/runtime/NamedArgumentsHelper.java
@@ -32,12 +32,11 @@ public final class NamedArgumentsHelper {
         .collect(toList());
   }
 
-  public static void checkArgumentPosition(int position, String methodName, List<String> parameterNames, String argument) {
+  public static void checkArgumentPosition(int position, String argument, String declaration) {
     if (position == -1) {
       throw new IllegalArgumentException(
           "Argument name " + argument
-          + " not in parameter names used in declaration: "
-          + methodName + parameterNames);
+          + " not in parameter names used in declaration: " + declaration);
     }
   }
 }

--- a/src/main/java/org/eclipse/golo/runtime/NamedArgumentsHelper.java
+++ b/src/main/java/org/eclipse/golo/runtime/NamedArgumentsHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2016 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.golo.runtime;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public final class NamedArgumentsHelper {
+
+  private NamedArgumentsHelper() {
+    // utility class
+  }
+
+  public static Boolean hasNamedParameters(Method method) {
+    return Arrays.stream(method.getParameters()).allMatch(Parameter::isNamePresent);
+  }
+
+  public static List<String> getParameterNames(Method method) {
+    return Arrays.stream(method.getParameters())
+        .map(Parameter::getName)
+        .collect(toList());
+  }
+
+  public static void checkArgumentPosition(int position, String methodName, List<String> parameterNames, String argument) {
+    if (position == -1) {
+      throw new IllegalArgumentException(
+          "Argument name " + argument
+          + " not in parameter names used in declaration: "
+          + methodName + parameterNames);
+    }
+  }
+}

--- a/src/main/java/org/eclipse/golo/runtime/PropertyMethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/PropertyMethodFinder.java
@@ -13,11 +13,9 @@ import gololang.Union;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Method;
 import java.util.Objects;
-import java.util.Optional;
 
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.invoke.MethodType.methodType;
-import static java.util.Arrays.copyOfRange;
 
 public class PropertyMethodFinder extends MethodFinder {
 
@@ -45,20 +43,12 @@ public class PropertyMethodFinder extends MethodFinder {
     this.propertyName = capitalize(invocation.name());
   }
 
-  private static MethodInvocation propertyInvocation(String propertyInvocationName, MethodInvocation parentInvocation) {
-    return new MethodInvocation(
-        propertyInvocationName,
-        parentInvocation.type(),
-        parentInvocation.arguments(),
-        copyOfRange(parentInvocation.argumentNames(), 0, parentInvocation.argumentNames().length - 1));
-  }
-
   private MethodHandle findMethodForGetter() {
-    if(Union.class.isAssignableFrom(invocation.receiverClass())) {
+    if (Union.class.isAssignableFrom(invocation.receiverClass())) {
       return null;
     }
     MethodHandle target = new RegularMethodFinder(
-        propertyInvocation("get" + propertyName, invocation),
+        invocation.withName("get" + propertyName),
         lookup
     ).find();
 
@@ -66,7 +56,7 @@ public class PropertyMethodFinder extends MethodFinder {
       return target;
     }
     return new RegularMethodFinder(
-        propertyInvocation("is" + propertyName, invocation),
+        invocation.withName("is" + propertyName),
         lookup
     ).find();
   }
@@ -86,7 +76,7 @@ public class PropertyMethodFinder extends MethodFinder {
 
   private MethodHandle findMethodForSetter() {
     return new RegularMethodFinder(
-        propertyInvocation("set" + propertyName, invocation),
+        invocation.withName("set" + propertyName),
         lookup)
         .findInMethods()
         .filter(method -> !Union.class.isAssignableFrom(method.getDeclaringClass()))

--- a/src/main/java/org/eclipse/golo/runtime/RegularMethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/RegularMethodFinder.java
@@ -47,10 +47,11 @@ class RegularMethodFinder extends MethodFinder {
   }
 
   private boolean overloadMatch(Method m) {
-    return Extractors.isPublic(m) &&
-        Extractors.isConcrete(m) &&
-        m.getName().equals(invocation.name()) &&
-        (m.getParameterCount() + 1 == invocation.arity()) || (m.isVarArgs() && (m.getParameterCount() <= invocation.arity()));
+    return Extractors.isPublic(m)
+      && Extractors.isConcrete(m)
+      && m.getName().equals(invocation.name())
+      && (m.getParameterCount() + 1 == invocation.arity())
+      || (m.isVarArgs() && (m.getParameterCount() <= invocation.arity()));
   }
 
   private Optional<MethodHandle> toMethodHandle(Field field) {
@@ -82,7 +83,7 @@ class RegularMethodFinder extends MethodFinder {
       method.setAccessible(true);
     }
     return super.toMethodHandle(method).map(
-        handle -> FunctionCallSupport.insertSAMFilter(handle, lookup, method.getParameterTypes(), 1));
+      handle -> FunctionCallSupport.insertSAMFilter(handle, lookup, method.getParameterTypes(), 1));
   }
 
   private boolean isValidPrivateStructAccess(Method method) {
@@ -103,7 +104,6 @@ class RegularMethodFinder extends MethodFinder {
     return receiverClassName.substring(0, receiverClassName.indexOf(".types"))
         + "$" + receiverClassName.replace('.', '$');
   }
-
 
   protected Stream<Method> findInMethods() {
     return Extractors.getMethods(invocation.receiverClass())

--- a/src/main/java/org/eclipse/golo/runtime/TypeMatching.java
+++ b/src/main/java/org/eclipse/golo/runtime/TypeMatching.java
@@ -9,8 +9,6 @@
 
 package org.eclipse.golo.runtime;
 
-import gololang.FunctionReference;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;

--- a/src/main/java/org/eclipse/golo/runtime/Warnings.java
+++ b/src/main/java/org/eclipse/golo/runtime/Warnings.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012-2016 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.golo.runtime;
+
+import java.io.PrintStream;
+
+import static java.util.Arrays.asList;
+
+/**
+ * A static class to deal with several kinds of warnings.
+ * <p>
+ */
+public final class Warnings {
+  private Warnings() {
+    // utility class
+  }
+
+  private static final String GUIDE_BASE = "http://golo-lang.org/documentation/next/";
+  private static final boolean NO_PARAMETER_NAMES = Boolean.valueOf(System.getProperty("golo.warnings.no-parameter-names", "true"));
+  private static PrintStream out = System.err;
+
+  public static void noParameterNames(String methodName, String[] argumentNames) {
+    if (NO_PARAMETER_NAMES) {
+      out.format("[warning] the function %s has no parameter names but is called with %s as argument names%n",
+          methodName, asList(argumentNames));
+      out.format("          see %s#warning-no-parameter-names for more informations%n", GUIDE_BASE);
+    }
+  }
+}

--- a/src/test/resources/for-execution/namedarguments-anoncall.golo
+++ b/src/test/resources/for-execution/namedarguments-anoncall.golo
@@ -16,7 +16,7 @@ function test_indirect = {
 
   let y = yo("sam")
   assertEquals(y(before="Hello", after="!"), expected)
-  
+
   let s = ^say: bindAt("message", "sam")
   assertEquals(s(before="Hello", after="!"), expected)
 
@@ -26,13 +26,6 @@ function test_indirect = {
   let l = |left, right| -> left + right
   assertEquals(l(left="a", right="b"), "ab")
 
-  assertEquals(yo("sam"): invoke(before="Hello", after="!"), expected)
-  assertEquals(
-    ^say: bindAt("message", "sam"): invoke(before="Hello", after="!"),
-    expected)
-
-  assertEquals(^add: invoke(left="a", right="b"), "ab")
-  assertEquals((|left, right| -> left + right): invoke(left="a", right="b"), "ab")
 }
 
 

--- a/src/test/resources/for-execution/namedparameters-function-calls.golo
+++ b/src/test/resources/for-execution/namedparameters-function-calls.golo
@@ -21,7 +21,7 @@ function joiner = |delimiter, values...| {
 function csv_builder = -> joiner(values = array["a", "b", "c"], delimiter = ",")
 
 augment java.lang.String {
- function decorate = |this, prefix, suffix| -> prefix + this + suffix
+ function decorate = |self, prefix, suffix| -> prefix + self + suffix
  function append = |this, values...| -> joiner("", values)
 }
 


### PR DESCRIPTION
partial fix for issues raised in #351 and #352 comments.

- deal with the receiver in method calls: the receiver argument has no
name; moreover, for regular methods, the receiver parameter has no name
(but is present in the signature)

- display a warning if calling a function without parameter names with
named arguments. It can be disabled via properties.