### PR TITLE
Experiment on TCE

### DIFF
--- a/doc/decorators.adoc
+++ b/doc/decorators.adoc
@@ -1,4 +1,5 @@
 
+[[decorators]]
 == Decorators
 
 Golo features Python-like decorators.

--- a/doc/functions.adoc
+++ b/doc/functions.adoc
@@ -288,6 +288,183 @@ function i_will_crash = {
 }
 ----
 
+
+=== Recursive Tail Call Optimization
+
+Golo feature recursive https://en.wikipedia.org/wiki/Tail_call[tail call] optimization. If a function last action is to return the result of a recursive call, it is optimized to not stack a new call and is compiled in code equivalent to a loop. For instance, a function like:
+
+[source,golo]
+----
+function fact = |acc, v| -> match {
+  when v == 0 then acc
+  otherwise fact(acc * v, v - 1)
+}
+----
+
+is compiled into something roughly equivalent to :
+
+[source,golo]
+----
+function fact = |acc, v| {
+  var acc_ = acc
+  var v_ = v
+  while v_ != 0 {
+    acc_ = acc_ * v_
+    v_ = v_ - 1
+  }
+  return acc_
+}
+----
+
+This allows to create recursive functions that will not throw a `StackOverflowError` even in the presence of a large number or recursive call.
+The optimization can be disabled by setting the `golo.optimize.tce` system property to `false` (e.g. `export GOLO_OPTS='-Dgolo.optimize.tce=false`).
+
+A call is tail recursive when the function returns the result of calling itself directly. Indeed, since no evaluation nor flow analysis is done, many effectively tail recursive calls can't be identified as such, and thus are not optimized. It is recommended to rewrite the code to make the tail call more direct. For instance, the following two functions are not optimized:
+
+[source,golo]
+----
+function foo = |a, v| {
+  let r = ^foo
+  if v == 0 {
+    return a
+  }
+  return r(a + v, v - 1)
+}
+
+function bar = |a, v| {
+  var r = null
+  if v == 0 {
+    r = a
+  } else {
+    r = bar(a + v, v - 1)
+  }
+  return r
+}
+----
+
+while the following one is:
+[source,golo]
+----
+function ref = |a, v| {
+  if v == 0 {
+    return a
+  }
+  return ref(a + v, v - 1)
+}
+----
+
+Note that returning a `match` expression that may evaluate to a tail call will be optimized, such that the function
+[source,golo]
+----
+function baz = |a, v| -> match {
+  when v == 0 then a
+  otherwise ref(a + v, v - 1)
+}
+----
+will be strictly equivalent to the previous one. A consequence of this behavior is that mutual recursions are not optimized.
+
+==== On augmentations
+
+Functions defined in augmentations can be optimized if written in a tail call style. For instance, in the following sample, the `reduce` function is not optimized since it is viewed as a method call:
+[source,golo]
+----
+struct Cons = {head, tail}
+
+augment Cons {
+  function reduce = |this, f, z| -> match {
+    when this: isEmpty() then z
+    otherwise this: tail(): reduce(f, f(this: head(), z))
+  }
+}
+----
+
+On the other hand, the following one is optimized and works as expected:
+[source,golo]
+----
+augment Cons {
+  function reduce = |this, f, z| -> match {
+    when this: isEmpty() then z
+    otherwise reduce(this: tail(), f, f(this: head(), z))
+  }
+}
+----
+
+==== Limitations on decorators
+
+Since the optimization is done at compile time, most of dynamic features are not available. For instance, <<decorators,decorated functions>>
+can't be optimized. Indeed, in that case, the decorator would not be applied on each call but only on the first one, which could lead to unexpected results.
+
+For instance, the code:
+
+[source,golo]
+----
+function log = |f| -> |a, v| {
+  println("function called with " + a + ", " + v)
+  return f(a, v)
+}
+
+@log
+function fact = |acc, v| -> match {
+  when v == 0 then acc
+  otherwise fact(acc * v, v - 1)
+}
+----
+
+when optimised would print the message only for the first call. The tail call optimization is thus disabled for decorated functions. If the desired behavior is to optimize the function and apply the decorator only for the first call, one can create an undecorated version, and decorate explicitly direct calls or create a decorated wrapper, as in:
+
+[source,golo]
+----
+function log = |f| -> |a, v| {
+  println("function called with " + a + ", " + v)
+  return f(a, v)
+}
+
+function fact = |acc, v| -> match {
+  when v == 0 then acc
+  otherwise fact(acc * v, v - 1)
+}
+
+@log
+function decoratedFact = |acc, v| -> fact(acc, v)
+
+#(...)
+
+let direclyDecorated = log(^fact)
+directlyDecorated(1, 5)
+log(^fact)(1, 5)
+----
+
+Note that this approach is not as cumbersome, since most of the time, tail recursive functions introduce an “artificial” accumulator that is hidden by a function calling the recursive one with the default accumulator value.
+For instance, in the factorial case, one would write:
+[source,golo]
+----
+local function fact = |acc, v| -> match {
+  when v == 0 then acc
+  otherwise fact(acc * v, v - 1)
+}
+
+function fact = |v| -> fact(1, v)
+----
+
+or equivalently:
+[source,golo]
+----
+function fact = |n| {
+  let _fact = |acc, v| -> match {
+    when v == 0 then acc
+    otherwise _fact(acc * v, v - 1)
+  }
+  return _fact(1, n)
+}
+----
+
+In this case, the both the local `fact` and the `_fact` closure are optimized, while the public one can be decorated.
+
+
+Similarly, variadic functions are not optimized, since we can't know at compile-time if the last argument is already an array or a simple value that must be collected. The same kind of approach is recommended, by defining a (local) fixed arguments recursive version that is optimized and a variadic one that delegates on it.
+
+
+
 === Module-level state
 
 You can declare `let` and `var` references at the module level, as in:

--- a/src/main/java/gololang/ir/FunctionInvocation.java
+++ b/src/main/java/gololang/ir/FunctionInvocation.java
@@ -176,7 +176,7 @@ public final class FunctionInvocation extends AbstractInvocation<FunctionInvocat
    */
   @Override
   public String toString() {
-    return String.format("FunctionInvocation{name=%s}", getName());
+    return String.format("FunctionInvocation{name=%s, arity=%s}", getName(), getArity());
   }
 
   /**

--- a/src/main/java/gololang/ir/GoloFunction.java
+++ b/src/main/java/gololang/ir/GoloFunction.java
@@ -189,6 +189,10 @@ public final class GoloFunction extends ExpressionStatement<GoloFunction> implem
     return Scope.AUGMENT.equals(scope);
   }
 
+  public boolean isInModule() {
+    return Scope.MODULE.equals(scope);
+  }
+
   public GoloFunction asClosure() {
     this.scope = Scope.CLOSURE;
     return this;

--- a/src/main/java/gololang/ir/IrTreeDumper.java
+++ b/src/main/java/gololang/ir/IrTreeDumper.java
@@ -141,7 +141,11 @@ public class IrTreeDumper implements GoloIrVisitor {
   public void visitFunction(GoloFunction function) {
     incr();
     space();
-    this.out.print("Function ");
+    if (function.isLocal()) {
+      this.out.print("Local function ");
+    } else {
+      this.out.print("Function ");
+    }
     this.out.append(function.getName()).append(" = ");
     visitFunctionDefinition(function);
     decr();

--- a/src/main/java/org/eclipse/golo/compiler/ClosureCaptureGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ClosureCaptureGoloIrVisitor.java
@@ -147,6 +147,7 @@ public class ClosureCaptureGoloIrVisitor extends AbstractGoloIrVisitor {
         accessed(name);
       }
     }
+
     functionInvocation.walk(this);
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
@@ -54,11 +54,12 @@ final class JavaBytecodeUtils {
     }
   }
 
-  static void visitLine(GoloElement<?> element, MethodVisitor visitor) {
+  static Label visitLine(GoloElement<?> element, MethodVisitor visitor) {
+    Label label = new Label();
+    visitor.visitLabel(label);
     if (element.hasPosition()) {
-      Label label = new Label();
-      visitor.visitLabel(label);
       visitor.visitLineNumber(element.positionInSourceCode().getStartLine(), label);
     }
+    return label;
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -587,7 +587,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
       if (!invocation.namedArgumentsComplete()) {
         context.errorMessage(INCOMPLETE_NAMED_ARGUMENTS_USAGE, node,
             message("incomplete_named_arguments_usage",
-            invocation.getClass(), invocation.getName()));
+            invocation.getClass().getName(), invocation.getName()));
       }
       invocation.withNamedArguments();
     }

--- a/src/main/java/org/eclipse/golo/runtime/AugmentationMethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/AugmentationMethodFinder.java
@@ -74,16 +74,13 @@ class AugmentationMethodFinder extends MethodFinder {
   }
 
   @Override
-  protected int[] getArgumentsOrder(Method method, List<String> parameterNames, String[] argumentNames) {
-    // redefined to ignore the first parameter (explicit receiver)
-    int[] argumentsOrder = new int[parameterNames.size()];
-    argumentsOrder[0] = 0;
-    for (int i = 0; i < argumentNames.length; i++) {
-      int actualPosition = parameterNames.indexOf(argumentNames[i]);
-      checkArgumentPosition(actualPosition, argumentNames[i], method.getName() + parameterNames);
-      argumentsOrder[actualPosition] = i + 1;
-    }
-    return argumentsOrder;
+  public MethodHandle reorderArguments(Method method, MethodHandle handle) {
+    return NamedArgumentsHelper.reorderArguments(
+        method.getName(),
+        NamedArgumentsHelper.getParameterNames(method),
+        handle,
+        invocation.argumentNames(),
+        1, 0);
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/runtime/ClosureCallSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/ClosureCallSupport.java
@@ -124,23 +124,10 @@ public final class ClosureCallSupport {
   }
 
   private static MethodHandle reorderArguments(String[] parameterNames, MethodHandle handle, String[] argumentNames) {
-    if (parameterNames.length > 0) {
-      int[] argumentsOrder = new int[parameterNames.length + 1];
-      argumentsOrder[0] = 0;
-      argumentsOrder[1] = 1;
-      for (int i = 0; i < argumentNames.length; i++) {
-        int actualPosition = -1;
-        for (int j = 0; j < parameterNames.length; j++) {
-          if (parameterNames[j].equals(argumentNames[i])) {
-            actualPosition = j;
-          }
-        }
-        checkArgumentPosition(actualPosition, argumentNames[i], "closure " + Arrays.toString(parameterNames));
-        argumentsOrder[actualPosition + 1] = i + 1;
-      }
-      return permuteArguments(handle, handle.type(), argumentsOrder);
-    }
-    Warnings.noParameterNames("closure " + Arrays.toString(parameterNames), argumentNames);
-    return handle;
+    return NamedArgumentsHelper.reorderArguments(
+        "closure " + Arrays.toString(parameterNames),
+        Arrays.asList(parameterNames),
+        handle,
+        argumentNames, 1, 1);
   }
 }

--- a/src/main/java/org/eclipse/golo/runtime/FunctionCallSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/FunctionCallSupport.java
@@ -220,23 +220,12 @@ public final class FunctionCallSupport {
           || argumentNames.length > 0);
   }
 
-  private static int[] getArgumentsOrder(Method method, List<String> parameterNames, String[] argumentNames) {
-    int[] argumentsOrder = new int[parameterNames.size()];
-    for (int i = 0; i < argumentNames.length; i++) {
-      int actualPosition = parameterNames.indexOf(argumentNames[i]);
-      checkArgumentPosition(actualPosition, argumentNames[i], method.getName() + parameterNames);
-      argumentsOrder[actualPosition] = i;
-    }
-    return argumentsOrder;
-  }
-
   public static MethodHandle reorderArguments(Method method, MethodHandle handle, String[] argumentNames) {
-    if (argumentNames.length == 0) { return handle; }
-    if (hasNamedParameters(method)) {
-      return permuteArguments(handle, handle.type(), getArgumentsOrder(method, getParameterNames(method), argumentNames));
-    }
-    Warnings.noParameterNames(method.getName(), argumentNames);
-    return handle;
+    return NamedArgumentsHelper.reorderArguments(
+        method.getName(),
+        getParameterNames(method),
+        handle,
+        argumentNames, 0, 0);
   }
 
   public static MethodHandle insertSAMFilter(MethodHandle handle, Lookup caller, Class<?>[] types, int startIndex) {

--- a/src/main/java/org/eclipse/golo/runtime/MethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/MethodFinder.java
@@ -37,26 +37,13 @@ abstract class MethodFinder {
 
   abstract MethodHandle find();
 
-  protected int[] getArgumentsOrder(Method method, List<String> parameterNames, String[] argumentNames) {
-    // deal with the first parameter (implicit receiver).
-    int[] argumentsOrder = new int[parameterNames.size() + 1];
-    argumentsOrder[0] = 0;
-    for (int i = 0; i < argumentNames.length; i++) {
-      int actualPosition = parameterNames.indexOf(argumentNames[i]);
-      checkArgumentPosition(actualPosition, argumentNames[i], method.getName() + parameterNames);
-      argumentsOrder[actualPosition + 1] = i + 1;
-    }
-    return argumentsOrder;
-  }
-
-  MethodHandle reorderArguments(Method method, MethodHandle handle) {
-    String[] argumentNames = invocation.argumentNames();
-    if (argumentNames.length == 0) { return handle; }
-    if (hasNamedParameters(method)) {
-      return permuteArguments(handle, handle.type(), getArgumentsOrder(method, getParameterNames(method), argumentNames));
-    }
-    Warnings.noParameterNames(method.getName(), argumentNames);
-    return handle;
+  public MethodHandle reorderArguments(Method method, MethodHandle handle) {
+    return NamedArgumentsHelper.reorderArguments(
+        method.getName(),
+        getParameterNames(method),
+        handle,
+        invocation.argumentNames(),
+        1, 1);
   }
 
   protected Optional<MethodHandle> toMethodHandle(Method method) {

--- a/src/main/java/org/eclipse/golo/runtime/NamedArgumentsHelper.java
+++ b/src/main/java/org/eclipse/golo/runtime/NamedArgumentsHelper.java
@@ -12,11 +12,14 @@ package org.eclipse.golo.runtime;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Collections;
 
 import static java.util.stream.Collectors.toList;
 import static gololang.Messages.message;
+import static java.lang.invoke.MethodHandles.permuteArguments;
 
 public final class NamedArgumentsHelper {
 
@@ -29,9 +32,12 @@ public final class NamedArgumentsHelper {
   }
 
   public static List<String> getParameterNames(Method method) {
-    return Arrays.stream(method.getParameters())
-        .map(Parameter::getName)
-        .collect(toList());
+    if (hasNamedParameters(method)) {
+      return Arrays.stream(method.getParameters())
+          .map(Parameter::getName)
+          .collect(toList());
+    }
+    return Collections.emptyList();
   }
 
   public static void checkArgumentPosition(int position, String argument, String declaration) {
@@ -39,4 +45,27 @@ public final class NamedArgumentsHelper {
       throw new IllegalArgumentException(message("invalid_argument_name", argument, declaration));
     }
   }
+
+  public static int[] getArgumentsOrder(String methodName, List<String> parameterNames, String[] argumentNames, int nameOffset, int orderOffset) {
+    int[] argumentsOrder = new int[parameterNames.size() + orderOffset];
+    for (int i = 0; i <= orderOffset; i++) {
+      argumentsOrder[i] = i;
+    }
+    for (int i = 0; i < argumentNames.length; i++) {
+      int actualPosition = parameterNames.indexOf(argumentNames[i]);
+      checkArgumentPosition(actualPosition, argumentNames[i], methodName + parameterNames);
+      argumentsOrder[actualPosition + orderOffset] = i + nameOffset;
+    }
+    return argumentsOrder;
+  }
+
+  public static MethodHandle reorderArguments(String methodName, List<String> parameterNames, MethodHandle handle, String[] argumentNames, int nameOffset, int orderOffset) {
+    if (argumentNames.length == 0) { return handle; }
+    if (parameterNames.isEmpty()) {
+      Warnings.noParameterNames(methodName, argumentNames);
+      return handle;
+    }
+    return permuteArguments(handle, handle.type(), getArgumentsOrder(methodName, parameterNames, argumentNames, nameOffset, orderOffset));
+  }
+
 }

--- a/src/test/java/org/eclipse/golo/compiler/TceTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/TceTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2012-2017 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.golo.compiler;
+
+import org.testng.annotations.Test;
+import org.eclipse.golo.internal.testing.GoloTest;
+
+public class TceTest extends GoloTest {
+
+  @Override
+  public String srcDir() {
+    return "for-parsing-and-compilation/";
+  }
+
+  @Test
+  public void testTce() throws Throwable {
+    run("tce");
+  }
+
+}

--- a/src/test/resources/for-execution/comprehension.golo
+++ b/src/test/resources/for-execution/comprehension.golo
@@ -162,8 +162,8 @@ function run = |tests...| {
     println("FAILED")
     System.exit(1)
   }
-
 }
+
 function main = |args| {
   run(
     ^test_forloop,

--- a/src/test/resources/for-parsing-and-compilation/tce.golo
+++ b/src/test/resources/for-parsing-and-compilation/tce.golo
@@ -1,0 +1,88 @@
+module TCEOptimized
+
+local function direct = |a, v| {
+  if v == 0 {
+    return a
+  }
+  return direct(a + v, v - 1)
+}
+
+local function withMatch = |a, v| -> match {
+  when v == 0 then a
+  otherwise withMatch(a + v, v - 1)
+}
+
+local function lambda = |n| {
+  let rec = |a, v| {
+    if v == 0 {
+      return a
+    }
+    return rec(a + v, v - 1)
+  }
+  return rec(0, n)
+}
+
+local function noopt = |a, v| {
+  var r = null
+  if v == 0 {
+    r = a
+  } else {
+    r = noopt(a + v, v - 1)
+  }
+  return r
+}
+
+local function withClosure = |a, v, c| -> match {
+  when v == 0 then a
+  otherwise withClosure(c(a, v), v - 1, c)
+}
+
+local function run = |closure, name| {
+  let r = box(null)
+  let t = Thread(null, {
+    require(closure() == 500500, "bad result for " + name)
+  }, name, 262144_L)
+  t: setUncaughtExceptionHandler(|t, e| {
+    r: set(e)
+  })
+  t: start()
+  t: join()
+  if r: get() isnt null {
+    throw r: get()
+  }
+}
+
+function test_direct = {
+  run(-> direct(0, 1000), "direct")
+}
+
+function test_match = {
+  run(-> withMatch(0, 1000), "match")
+}
+
+function test_lambda = {
+  run(-> lambda(1000), "lambda")
+}
+
+function test_with_closure = {
+  let i = 1
+  let f = |a, v| -> i * (a + v)
+  run(-> withClosure(0, 1000, f), "closure")
+}
+
+function test_noopt = {
+  try {
+    run(-> noopt(0, 1000), "noopt")
+    raise("should fail")
+  } catch (e) {
+    require(e oftype java.lang.StackOverflowError.class, "not a stack overflow")
+  }
+}
+
+function main = |args| {
+  test_direct()
+  test_match()
+  test_lambda()
+  test_with_closure()
+  test_noopt()
+}

--- a/src/test/resources/for-test/local-declaration.golo
+++ b/src/test/resources/for-test/local-declaration.golo
@@ -33,7 +33,6 @@ function sum = |lst| -> sum(0, lst) with {
   }
 }
 
-
 function h = |x| -> match {
   when a < 0 then 1337
   when a > 10 then 2 * a


### PR DESCRIPTION
This is just a small experiment on tail call elimination (#388). This is preliminary work here for feed back.

Since we just identify tail call recursion with a `ReturnStatement` whose expression is a `FunctionCall` to the same function it pertains to, a lot of effectively TC constructions are not covered. For instance, none of the following functions will be optimized, despite being effectively tail recursive:
```golo
function foo = |acc, i| {
  if i <= 0 {
    return acc
  }
  let res = foo(acc + 1, i - 1)
  return res
}
```

The next step (the hard one) is to try to identify such cases and rewrite the IR to allow the optimization. I fear a lot of special cases that would lead to ugly code.
The other option would be to let the developer properly code the function, but this forbid interesting constructs (e.g. the `-> match` one).

Here is a snippet to “test” the feature:
```golo
module AsmTceStack

function blowup = |i| {
  if (i % 100) == 0 {
    println(i)
  }
  return blowup(i + 1)
}

function main = |args| {
  try {
    blowup(1)
  } catch (e) {
    println(e)
  }
}
```

when running it with
```bash
> GOLO_OPTS='-Xss256k -Dgolo.optimize.tce=false' golo golo --files asmtce-stack.golo
100
200
300
400
500
java.lang.StackOverflowError
```

using TCE, (`-Dgolo.optimize.tce=true` which is the default) will not overflow :tada:


## TODO:

- [x] deal with named arguments
- [x] deal with closed arguments (i.e. synthetic parameters)
- [x] deal with varargs: seams not doable...
- [x] deal with decorators: decorated functions are not optimized
- [x] documentation
- [x] tests
