### PR TITLE
Fix a bug on self reference in closures

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
@@ -252,7 +252,7 @@ public final class GoloFunction extends ExpressionStatement implements Scope {
       LocalReference self = block.getReferenceTable().get(syntheticSelfName);
       ClosureReference closureReference = asClosureReference();
       closureReference.updateCapturedReferenceNames();
-      block.prependStatement(Builders.assign(closureReference).to(self));
+      block.prependStatement(Builders.define(self).as(closureReference));
     }
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/IrTreeDumper.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/IrTreeDumper.java
@@ -206,7 +206,8 @@ public class IrTreeDumper implements GoloIrVisitor {
   public void visitAssignmentStatement(AssignmentStatement assignmentStatement) {
     incr();
     space();
-    System.out.println("Assignment: " + assignmentStatement.getLocalReference());
+    System.out.print("Assignment: " + assignmentStatement.getLocalReference());
+    System.out.println(assignmentStatement.isDeclaring() ? " (declaring)" : "");
     assignmentStatement.walk(this);
     decr();
   }

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -1027,6 +1027,9 @@ public class CompileAndRunTest {
     Method closure_self_reference = moduleClass.getMethod("closure_self_reference");
     assertThat((Integer) closure_self_reference.invoke(null), is(1));
 
+    closure_self_reference = moduleClass.getMethod("closure_self_reference2");
+    assertThat(closure_self_reference.invoke(null), instanceOf(FunctionReference.class));
+
     Method closure_with_trailing_varargs_and_capture = moduleClass.getMethod("closure_with_trailing_varargs_and_capture");
     assertThat((String) closure_with_trailing_varargs_and_capture.invoke(null), is("|1|12|123"));
 

--- a/src/test/resources/for-execution/closures.golo
+++ b/src/test/resources/for-execution/closures.golo
@@ -283,3 +283,11 @@ function closure_with_named_args = {
   let create_post = |title, body| -> title + " " + body
   return create_post(body = "Rocks", title = "It")
 }
+
+function closure_self_reference2 = {
+  let fun = |x| -> match {
+    when x is null then fun
+    otherwise x
+  }
+  return fun(null)
+}


### PR DESCRIPTION
When a closure references itself elsewhere than in a recursive call,
an `Uninitialized reference` error is raised. For instance, in

```golo
function test = {
  let fun = |x| -> match {
    when x is null then fun
    otherwise x
  }
  return fun(null)
}
```

the null case fails. In the generated function `__$$_sugar_closure_X`,
an assignment to `fun` of the closure reference is injected, but it was
mistakenly not defined as a declaring one, which fool the
`LocalReferenceAssignmentAndVerificationVisitor` in thinking the
reference is not initialized.