### PR TITLE
Print a warning when unable to load a class

### DIFF
--- a/doc/functions.adoc
+++ b/doc/functions.adoc
@@ -219,12 +219,12 @@ These modules are imported *after* the module explicitly imported in the module,
 
 [[warning-unavailable-class]]
 [WARNING]
-====================
-When an imported module can't be loaded, either because it is not in the classpath or because of a typo in its name, a warning is printed. This does not preclude to code to work correctly since the looked up function can be present in another imported module.
+====
+When an imported module can't be loaded, either because it is not in the classpath or because of a typo in its name, a warning is printed. This does not preclude the code to work correctly since the looked up function can be present in another imported module.
 When the function is called prefixed with the module name, and the module can't be loaded, the warning is also printed, but the code will fail with a `NoSuchMethodError`.
 
 The warning can be disabled by setting the `golo.warnings.unavailable-class` system property to `false`.
-====================
+====
 
 
 === Local functions

--- a/doc/functions.adoc
+++ b/doc/functions.adoc
@@ -217,6 +217,16 @@ Golo modules have a set of implicit imports:
 
 These modules are imported *after* the module explicitly imported in the module, so that elements defined in these modules (e.g. predefined functions or xref:_augmentations_resolution_order[augmentations]) can be redefined.
 
+[[warning-unavailable-class]]
+[WARNING]
+====================
+When an imported module can't be loaded, either because it is not in the classpath or because of a typo in its name, a warning is printed. This does not preclude to code to work correctly since the looked up function can be present in another imported module.
+When the function is called prefixed with the module name, and the module can't be loaded, the warning is also printed, but the code will fail with a `NoSuchMethodError`.
+
+The warning can be disabled by setting the `golo.warnings.unavailable-class` system property to `false`.
+====================
+
+
 === Local functions
 
 By default, functions are visible outside of their module. You may

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
@@ -62,7 +62,9 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
 
   public Set<ModuleImport> getImports() {
     Set<ModuleImport> imp = new LinkedHashSet<>();
-    imp.add(new ModuleImport(this.getPackageAndClass().createSubPackage("types"), true));
+    if (!structs.isEmpty() || !unions.isEmpty()) {
+      imp.add(new ModuleImport(this.getPackageAndClass().createSubPackage("types"), true));
+    }
     imp.addAll(imports);
     imp.addAll(DEFAULT_IMPORTS);
     return imp;

--- a/src/main/java/org/eclipse/golo/runtime/ClassReferenceSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/ClassReferenceSupport.java
@@ -32,7 +32,7 @@ public final class ClassReferenceSupport {
     if (classRef != null) {
       return createCallSite(classRef);
     }
-    classRef = tryLoadingFromName(className, classLoader);
+    classRef = tryLoadingFromName(className, classLoader, callerClass.getName());
     if (classRef != null) {
       return createCallSite(classRef);
     }
@@ -40,25 +40,26 @@ public final class ClassReferenceSupport {
     if (classRef != null) {
       return createCallSite(classRef);
     }
-    throw new ClassNotFoundException("Dynamic resolution failed for name: " + name);
+    throw new ClassNotFoundException("Dynamic resolution failed for name: " + className);
   }
 
-  private static Class<?> tryLoadingFromName(String name, ClassLoader classLoader) {
+  private static Class<?> tryLoadingFromName(String name, ClassLoader classLoader, String callerName) {
     try {
       return Class.forName(name, true, classLoader);
     } catch (ClassNotFoundException e) {
+      Warnings.unavailableClass(name, callerName);
       return null;
     }
   }
 
   private static Class<?> tryLoadingFromImports(String className, Class<?> callerClass, ClassLoader classLoader) {
-    for (String importClassName : imports(callerClass)) {
-      Class<?> classRef = tryLoadingFromName(importClassName + "." + className, classLoader);
+    for (String importedClassName : imports(callerClass)) {
+      Class<?> classRef = tryLoadingFromName(importedClassName + "." + className, classLoader, callerClass.getName());
       if (classRef != null) {
         return classRef;
       } else {
-        if (importClassName.endsWith(className)) {
-          classRef = tryLoadingFromName(importClassName, classLoader);
+        if (importedClassName.endsWith(className)) {
+          classRef = tryLoadingFromName(importedClassName, classLoader, callerClass.getName());
           if (classRef != null) {
             return classRef;
           }

--- a/src/main/java/org/eclipse/golo/runtime/FunctionCallSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/FunctionCallSupport.java
@@ -289,24 +289,25 @@ public final class FunctionCallSupport {
           functionName.substring(classAndMethodSeparator + 1)
       };
     }
-    for (String importClassName : imports) {
+    for (String importedClassName : imports) {
       try {
-        Class<?> importClass;
+        Class<?> importedClass;
         try {
-          importClass = Class.forName(importClassName, true, callerClass.getClassLoader());
+          importedClass = Class.forName(importedClassName, true, callerClass.getClassLoader());
         } catch (ClassNotFoundException expected) {
           if (classAndMethod == null) {
             throw expected;
           }
-          importClass = Class.forName(importClassName + "." + classAndMethod[0], true, callerClass.getClassLoader());
+          importedClass = Class.forName(importedClassName + "." + classAndMethod[0], true, callerClass.getClassLoader());
         }
         String lookup = (classAndMethod == null) ? functionName : classAndMethod[1];
-        Object result = findStaticMethodOrField(importClass, lookup, args);
+        Object result = findStaticMethodOrField(importedClass, lookup, args);
         if (result != null) {
           return result;
         }
       } catch (ClassNotFoundException ignored) {
         // ignored to try the next strategy
+        Warnings.unavailableClass(importedClassName, callerClass.getName());
       }
     }
     return null;
@@ -322,6 +323,7 @@ public final class FunctionCallSupport {
         return findStaticMethodOrField(targetClass, methodName, args);
       } catch (ClassNotFoundException ignored) {
         // ignored to try the next strategy
+        Warnings.unavailableClass(className, callerClass.getName());
       }
     }
     return null;

--- a/src/main/java/org/eclipse/golo/runtime/Warnings.java
+++ b/src/main/java/org/eclipse/golo/runtime/Warnings.java
@@ -24,13 +24,21 @@ public final class Warnings {
 
   private static final String GUIDE_BASE = "http://golo-lang.org/documentation/next/";
   private static final boolean NO_PARAMETER_NAMES = Boolean.valueOf(System.getProperty("golo.warnings.no-parameter-names", "true"));
+  private static final boolean UNAVAILABLE_CLASS = Boolean.valueOf(System.getProperty("golo.warnings.unavailable-class", "true"));
   private static PrintStream out = System.err;
 
   public static void noParameterNames(String methodName, String[] argumentNames) {
     if (NO_PARAMETER_NAMES) {
-      out.format("[warning] the function %s has no parameter names but is called with %s as argument names%n",
+      out.format("[warning] the function `%s` has no parameter names but is called with %s as argument names%n",
           methodName, asList(argumentNames));
-      out.format("          see %s#warning-no-parameter-names for more informations%n", GUIDE_BASE);
+      out.format("          see %s#warning-no-parameter-names for more information.%n", GUIDE_BASE);
+    }
+  }
+
+  public static void unavailableClass(String className, String callerModule) {
+    if (UNAVAILABLE_CLASS && !className.startsWith("java.lang") && !className.startsWith("gololang")) {
+      out.format("[warning] `%s` used in `%s` can't be loaded.%n  See %s#warning-unavailable-class for more information.%n",
+          className, callerModule, GUIDE_BASE);
     }
   }
 }

--- a/src/test/resources/for-execution/imports-metadata.golo
+++ b/src/test/resources/for-execution/imports-metadata.golo
@@ -3,3 +3,5 @@ module golotest.execution.ImportsMetaData
 import java.util.List
 import java.util.LinkedList
 import java.lang.System
+
+struct Foo = {x}


### PR DESCRIPTION
FIX #439

When failing to load a class, either in a class reference or in a
function resolution (via imported modules or FQN call), a warning is
printed. This ease the debugging of typo or classpath errors.

The warning can be disabled by the `golo.warnings.unavailable-class`
system property.