### PR TITLE
Turn warning on unfound import off by default

### DIFF
--- a/doc/functions.adoc
+++ b/doc/functions.adoc
@@ -220,10 +220,10 @@ These modules are imported *after* the module explicitly imported in the module,
 [[warning-unavailable-class]]
 [WARNING]
 ====
-When an imported module can't be loaded, either because it is not in the classpath or because of a typo in its name, a warning is printed. This does not preclude the code to work correctly since the looked up function can be present in another imported module.
+When an imported module can't be loaded, either because it is not in the classpath or because of a typo in its name, a warning can printed by setting the `golo.warnings.unavailable-class` system property to `true`.
+This does not preclude the code to work correctly since the looked up function can be present in another imported module.
 When the function is called prefixed with the module name, and the module can't be loaded, the warning is also printed, but the code will fail with a `NoSuchMethodError`.
-
-The warning can be disabled by setting the `golo.warnings.unavailable-class` system property to `false`.
+This option is mainly for debugging purpose and is not activated by default. Indeed, due to the way Golo load modules and lookup functions, many “false positives” can be reported. This can be changed in future a release.
 ====
 
 

--- a/src/main/java/org/eclipse/golo/runtime/Warnings.java
+++ b/src/main/java/org/eclipse/golo/runtime/Warnings.java
@@ -24,7 +24,7 @@ public final class Warnings {
 
   private static final String GUIDE_BASE = "http://golo-lang.org/documentation/next/";
   private static final boolean NO_PARAMETER_NAMES = Boolean.valueOf(System.getProperty("golo.warnings.no-parameter-names", "true"));
-  private static final boolean UNAVAILABLE_CLASS = Boolean.valueOf(System.getProperty("golo.warnings.unavailable-class", "true"));
+  private static final boolean UNAVAILABLE_CLASS = Boolean.valueOf(System.getProperty("golo.warnings.unavailable-class", "false"));
   private static PrintStream out = System.err;
 
   public static void noParameterNames(String methodName, String[] argumentNames) {


### PR DESCRIPTION
In #440, a warning was added when a module can't be loaded.

The feature works well when importing Golo modules or Java classes in
order to use static functions (e.g. `import java.util.Collections`)

However, many false positives are reported. For instance, it is common
practice to import a Java package in Golo code, to use provided classes,
similar to Java `import foo.*;` or to keep a namespace for static
methods, e.g.
```golo
import java.util
import java.nio.file

Collections.singleton(Paths.get(...))
```
instead of
```golo
import java.util.Collections
import java.nio.file.Paths

singleton(get(...))
```
While the in the case of `Collections`, static methods can be imported
in the module scope, it's more readable to keep `get` prefixed.

In the first case, the resolution for `Paths.get` is done as:
- try to load class `Paths`: fails
- try to load class `java.util`: fails (it's not a class)
- try to load class `java.nio.file`: fails (it's not a class)
- try to load class `java.util.Paths`: fails
- try to load class `java.nio.file.Paths`: succeed
  - resolve the `get` method

With the actual implementation, a warning is printed for each failures
which can be misleading.

My bad, I was too hurry to merge the feature. A proper implementation is
on the go, but I think the feature should thus be off by default. It can
be activated manually to debug.