### PR TITLE
Implicit import of the current package

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/PackageAndClass.java
+++ b/src/main/java/org/eclipse/golo/compiler/PackageAndClass.java
@@ -134,7 +134,7 @@ public final class PackageAndClass {
   }
 
   /**
-   * Create a class in another the same package as another one.
+   * Create a class in the same package as another one.
    * <p>
    * For instance:
    * <code><pre>
@@ -155,6 +155,20 @@ public final class PackageAndClass {
    */
   public String packageName() {
     return packageName;
+  }
+
+  /**
+   * Check if this {@code PackageAndClass} has a package component.
+   */
+  public boolean hasPackage() {
+    return !packageName.isEmpty();
+  }
+
+  /**
+   * @return the package as a {@code PackageAndClass}
+   */
+  public PackageAndClass parentPackage() {
+    return fromString(packageName);
   }
 
   /**

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
@@ -66,6 +66,9 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
       imp.add(new ModuleImport(this.getPackageAndClass().createSubPackage("types"), true));
     }
     imp.addAll(imports);
+    if (this.packageAndClass.hasPackage()) {
+      imp.add(new ModuleImport(this.packageAndClass.parentPackage(), true));
+    }
     imp.addAll(DEFAULT_IMPORTS);
     return imp;
   }

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -55,7 +55,7 @@ public class CompileAndRunTest {
     assertThat(isStatic($imports.getModifiers()), is(true));
 
     List<String> imports = asList((String[]) $imports.invoke(null));
-    assertThat(imports.size(), is(8));
+    assertThat(imports.size(), is(9));
     assertThat(imports, hasItem("gololang.Predefined"));
     assertThat(imports, hasItem("gololang.StandardAugmentations"));
     assertThat(imports, hasItem("gololang"));
@@ -64,6 +64,7 @@ public class CompileAndRunTest {
     assertThat(imports, hasItem("java.lang.System"));
     assertThat(imports, hasItem("java.lang"));
     assertThat(imports, hasItem("golotest.execution.ImportsMetaData.types"));
+    assertThat(imports, hasItem("golotest.execution"));
     assertThat(imports.get(0), is ("golotest.execution.ImportsMetaData.types"));
   }
 


### PR DESCRIPTION
In a module `foo.bar.Baz`, we add an implicit `import foo.bar`, such
that modules in the same package are directly visible.
This mimic the Java behavior in which classes in the same package are
directly visible without importing them.

For instance, given

    module foo.bar.Plop

    function daPlop = -> "Plop"

the module `foo.bar.Baz` can directly call `Plop.daPlop()`.