### PR TITLE
Fix #380 on variable scope

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
@@ -140,16 +140,16 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
   public void visitAssignmentStatement(AssignmentStatement assignmentStatement) {
     LocalReference reference = assignmentStatement.getLocalReference();
     Set<LocalReference> assignedReferences = assignmentStack.peek();
-    if (assigningConstant(reference, assignedReferences)) {
-      getExceptionBuilder().report(ASSIGN_CONSTANT, assignmentStatement.getASTNode(),
-          "Assigning `" + reference.getName() +
-              "` at " + assignmentStatement.getPositionInSourceCode() +
-              " but it is a constant reference"
-      );
-    } else if (redeclaringReferenceInBlock(assignmentStatement, reference, assignedReferences)) {
+    if (redeclaringReferenceInBlock(assignmentStatement, reference, assignedReferences)) {
       getExceptionBuilder().report(REFERENCE_ALREADY_DECLARED_IN_BLOCK, assignmentStatement.getASTNode(),
-          "Declaring a duplicate reference `" + reference.getName() +
-              "` at " + assignmentStatement.getPositionInSourceCode()
+          "Declaring a duplicate reference `" + reference.getName()
+          + "` at " + assignmentStatement.getPositionInSourceCode()
+      );
+    } else if (assigningConstant(reference, assignedReferences)) {
+      getExceptionBuilder().report(ASSIGN_CONSTANT, assignmentStatement.getASTNode(),
+          "Assigning `" + reference.getName()
+          + "` at " + assignmentStatement.getPositionInSourceCode()
+          + " but it is a constant reference"
       );
     }
     bindReference(reference);
@@ -178,8 +178,8 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
 
   private boolean assigningConstant(LocalReference reference, Set<LocalReference> assignedReferences) {
     return reference.isConstant() && (
-        assignedReferences.contains(reference) ||
-        (reference.isModuleState() && !functionStack.peek().isModuleInit()));
+        assignedReferences.contains(reference)
+        || (reference.isModuleState() && !functionStack.peek().isModuleInit()));
   }
 
   private boolean referenceNameExists(LocalReference reference, Set<LocalReference> referencesInBlock) {


### PR DESCRIPTION
As discussed in the #380 issue thread, the expected behavior is not that
clear. The current one mimic the java one, it is indeed a realy bad idea
to redefine/shadow an existing variable in a more local scope.

This fix just display the correct error message that we are redefining a
variable.