### PR TITLE
Struct improvement

### DIFF
--- a/src/main/java/gololang/GoloStruct.java
+++ b/src/main/java/gololang/GoloStruct.java
@@ -51,7 +51,9 @@ public abstract class GoloStruct implements Iterable<Tuple>, Comparable<GoloStru
    *
    * @return a tuple with the current values.
    */
-  public abstract Tuple values();
+  public Tuple values() {
+    return Tuple.fromArray(toArray());
+  }
 
   /**
    * Destructuration helper.
@@ -59,7 +61,7 @@ public abstract class GoloStruct implements Iterable<Tuple>, Comparable<GoloStru
    * @return a tuple with the current values.
    */
   public Tuple destruct() {
-    return values();
+    return Tuple.fromArray(toArray());
   }
 
   /**
@@ -67,9 +69,7 @@ public abstract class GoloStruct implements Iterable<Tuple>, Comparable<GoloStru
    *
    * @return an array containing the values (in member orders)
    */
-  public Object[] toArray() {
-    return values().toArray();
-  }
+  public abstract Object[] toArray();
 
   /**
    * Compares this structure with the specified structure for order.

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeStructGenerator.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeStructGenerator.java
@@ -41,7 +41,7 @@ class JavaBytecodeStructGenerator {
     makeCopy(classWriter, struct, true);
     makeHashCode(classWriter, struct);
     makeEquals(classWriter, struct);
-    makeValuesMethod(classWriter, struct);
+    makeToArrayMethod(classWriter, struct);
     makeGetMethod(classWriter, struct);
     makeSetMethod(classWriter, struct);
     classWriter.visitEnd();
@@ -117,9 +117,9 @@ class JavaBytecodeStructGenerator {
     visitor.visitInsn(ATHROW);
   }
 
-  private void makeValuesMethod(ClassWriter classWriter, Struct struct) {
+  private void makeToArrayMethod(ClassWriter classWriter, Struct struct) {
     String owner = struct.getPackageAndClass().toJVMType();
-    MethodVisitor visitor = classWriter.visitMethod(ACC_PUBLIC, "values", "()Lgololang/Tuple;", null, null);
+    MethodVisitor visitor = classWriter.visitMethod(ACC_PUBLIC, "toArray", "()[Ljava/lang/Object;", null, null);
     visitor.visitCode();
     loadInteger(visitor, struct.getPublicMembers().size());
     visitor.visitTypeInsn(ANEWARRAY, "java/lang/Object");
@@ -132,7 +132,6 @@ class JavaBytecodeStructGenerator {
       visitor.visitInsn(AASTORE);
       index = index + 1;
     }
-    visitor.visitMethodInsn(INVOKESTATIC, "gololang/Tuple", "fromArray", "([Ljava/lang/Object;)Lgololang/Tuple;", false);
     visitor.visitInsn(ARETURN);
     visitor.visitMaxs(0, 0);
     visitor.visitEnd();

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -50,6 +50,9 @@ handle_conversion_failed = Could not convert `{0}` to a functional interface of 
 invalid_argument_name = Argument name `{0}` not in parameter names used in declaration: {1}
 invalid_unary_operator = Operator `{0}` is not supported for type {1}
 invalid_binary_operator = Operator `{0}` is not supported for types {1} and {2}
+frozen_struct = This `{0}` struct instance is frozen
+unknown_struct_member = Unknown member in struct `{0}`
+struct_private_member = Private member of `{0}`
 
 # Runtime warnings ============================================================
 no_parameter_names = The function `{0}` has no parameter names but is called with {1} as argument names.\n\tSee <{2}#warning-no-parameter-names> for more information.

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -50,6 +50,9 @@ handle_conversion_failed = Impossible de convertir `{0}` en une interface foncti
 invalid_argument_name = Le nom d\u2019argument `{0}` n\u2019est pas un param\u00e8tre de la d\u00e9claration\u00a0: {1}
 invalid_unary_operator = L\u2019operateur `{0}` n\u2019est pas support\u00e9 pour le type {1}
 invalid_binary_operator = L\u2019operateur `{0}` n\u2019est pas support\u00e9 pour les types {1} et {2}
+frozen_struct = Cette instance de structure `{0}` est fig\u00e9e
+unknown_struct_member = Membre inconnu pour structure `{0}`
+struct_private_member = Membre priv\u00e9 de `{0}`
 
 
 # Runtime warnings ============================================================


### PR DESCRIPTION
Misc improvements of the struct generated classes:

 - make `toArray` abstract and generated instead of using `values`; make `values` use `toArray` instead of being generated,
- l10n of runtime exceptions (trying to access a private field, etc.)
- make returned type of setters and copy the struct itself instead of `GoloStruct`