### PR TITLE
Relative import

### DIFF
--- a/doc/functions.adoc
+++ b/doc/functions.adoc
@@ -190,7 +190,7 @@ subsequently tries to resolve `f` from each `import` statement. Also, note that 
 `import` statements is important, as the resolution stops at the first module having the `f`
 function.
 
-Last but not least, you may prepend the last piece of the module name. The following invocations are
+You may prepend the *last* piece of the module name. The following invocations are
 equivalent:
 
 [source,golo]
@@ -206,6 +206,28 @@ function plop = {
   return result
 }
 ----
+
+[[relative_import]]
+To help maintaining packages of several modules, and to avoid repeating the fully qualified name of the package when importing “local” modules,
+`import` can also be made relative to the package of the importing module. For instance, the following code:
+
+[source,golo]
+----
+module foo.bar.Spam
+
+import .baz.Egg
+----
+
+is equivalent to
+
+[source,golo]
+----
+module foo.bar.Spam
+
+import foo.bar.baz.Egg
+----
+
+Note that only modules in the same package or in a sub-package can be imported using relative name. In the previous example, to import the module `foo.Plop`, its full name must be specified.
 
 [[implicit_imports]]
 Golo modules have a set of implicit imports:

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -210,7 +210,13 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   @Override
   public Object visit(ASTImportDeclaration node, Object data) {
     Context context = (Context) data;
-    context.module.addImport(moduleImport(node.getName()).ofAST(node));
+    if (node.isRelative()) {
+      context.module.addImport(moduleImport(
+            context.module.getPackageAndClass().createSiblingClass(node.getName()))
+          .ofAST(node));
+    } else {
+      context.module.addImport(moduleImport(node.getName()).ofAST(node));
+    }
     return node.childrenAccept(this, data);
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/parser/ASTImportDeclaration.java
+++ b/src/main/java/org/eclipse/golo/compiler/parser/ASTImportDeclaration.java
@@ -12,6 +12,7 @@ package org.eclipse.golo.compiler.parser;
 public class ASTImportDeclaration extends GoloASTNode implements NamedNode {
 
   private String name;
+  private boolean relative;
 
   public ASTImportDeclaration(int i) {
     super(i);
@@ -29,6 +30,14 @@ public class ASTImportDeclaration extends GoloASTNode implements NamedNode {
   @Override
   public void setName(String name) {
     this.name = name;
+  }
+
+  public void setRelative(boolean b) {
+    this.relative = b;
+  }
+
+  public boolean isRelative() {
+    return this.relative;
   }
 
   @Override

--- a/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
+++ b/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
@@ -768,12 +768,16 @@ void ModuleDeclaration():
 void ImportDeclaration():
 {
   String name;
+  Token relative = null;
 }
 {
   try {
-    <IMPORT> name=QualifiedName()
+    <IMPORT> (relative=".")? name=QualifiedName()
     {
       jjtThis.setName(name);
+      if (relative != null) {
+        jjtThis.setRelative(true);
+      }
     }
   }
   catch (ParseException e) {

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -57,7 +57,7 @@ public class CompileAndRunTest {
     assertThat(isStatic($imports.getModifiers()), is(true));
 
     List<String> imports = asList((String[]) $imports.invoke(null));
-    assertThat(imports.size(), is(9));
+    assertThat(imports.size(), is(11));
     assertThat(imports, hasItem("gololang.Predefined"));
     assertThat(imports, hasItem("gololang.StandardAugmentations"));
     assertThat(imports, hasItem("gololang"));
@@ -67,6 +67,8 @@ public class CompileAndRunTest {
     assertThat(imports, hasItem("java.lang"));
     assertThat(imports, hasItem("golotest.execution.ImportsMetaData.types"));
     assertThat(imports, hasItem("golotest.execution"));
+    assertThat(imports, hasItem("golotest.execution.Bar"));
+    assertThat(imports, hasItem("golotest.execution.plop.Daplop"));
     assertThat(imports.get(0), is ("golotest.execution.ImportsMetaData.types"));
   }
 

--- a/src/test/resources/for-execution/imports-metadata.golo
+++ b/src/test/resources/for-execution/imports-metadata.golo
@@ -4,4 +4,7 @@ import java.util.List
 import java.util.LinkedList
 import java.lang.System
 
+import .Bar
+import .plop.Daplop
+
 struct Foo = {x}


### PR DESCRIPTION
FIX #322

A module can be imported without specifying its fully qualified name in
a module of *the same package or sub-package* by prefixing its name with a `.`

For instance

```golo
module a.b.C

import .d.E
import .F
```

is the same as

```golo
module a.b.C

import a.b.d.E
import a.b.F
```