### PR TITLE
Multiple imports

### DIFF
--- a/doc/functions.adoc
+++ b/doc/functions.adoc
@@ -229,6 +229,14 @@ import foo.bar.baz.Egg
 
 Note that only modules in the same package or in a sub-package can be imported using relative name. In the previous example, to import the module `foo.Plop`, its full name must be specified.
 
+[[multi_import]]
+Moreover, it is possible to import several modules from the same package with a single `import` statement, as in;
+
+[source,golo]
+----
+import java.util.{Collections, Objects, stream.Collectors}
+----
+
 [[implicit_imports]]
 Golo modules have a set of implicit imports:
 

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -210,12 +210,18 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   @Override
   public Object visit(ASTImportDeclaration node, Object data) {
     Context context = (Context) data;
+    PackageAndClass name;
     if (node.isRelative()) {
-      context.module.addImport(moduleImport(
-            context.module.getPackageAndClass().createSiblingClass(node.getName()))
-          .ofAST(node));
+      name = context.module.getPackageAndClass().createSiblingClass(node.getName());
     } else {
-      context.module.addImport(moduleImport(node.getName()).ofAST(node));
+      name = PackageAndClass.fromString(node.getName());
+    }
+    if (node.getMultiple().isEmpty()) {
+      context.module.addImport(moduleImport(name).ofAST(node));
+    } else {
+      for (String sub : node.getMultiple()) {
+        context.module.addImport(moduleImport(name.createSubPackage(sub)).ofAST(node));
+      }
     }
     return node.childrenAccept(this, data);
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
@@ -31,7 +31,7 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
   private GoloFunction moduleStateInitializer = null;
   private boolean hasMain = false;
 
-  public static final Set<ModuleImport> DEFAULT_IMPORTS = unmodifiableSet(new HashSet<>(Arrays.asList(
+  public static final Set<ModuleImport> DEFAULT_IMPORTS = unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
     new ModuleImport(PackageAndClass.fromString("gololang.Predefined"), true),
     new ModuleImport(PackageAndClass.fromString("gololang.StandardAugmentations"), true),
     new ModuleImport(PackageAndClass.fromString("gololang"), true),

--- a/src/main/java/org/eclipse/golo/compiler/parser/ASTImportDeclaration.java
+++ b/src/main/java/org/eclipse/golo/compiler/parser/ASTImportDeclaration.java
@@ -9,10 +9,14 @@
 
 package org.eclipse.golo.compiler.parser;
 
+import java.util.List;
+import java.util.Collections;
+
 public class ASTImportDeclaration extends GoloASTNode implements NamedNode {
 
   private String name;
   private boolean relative;
+  private List<String> multi = Collections.emptyList();
 
   public ASTImportDeclaration(int i) {
     super(i);
@@ -38,6 +42,14 @@ public class ASTImportDeclaration extends GoloASTNode implements NamedNode {
 
   public boolean isRelative() {
     return this.relative;
+  }
+
+  public List<String> getMultiple() {
+    return multi;
+  }
+
+  public void setMultiple(List<String> names) {
+    multi = names;
   }
 
   @Override

--- a/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
+++ b/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
@@ -765,18 +765,46 @@ void ModuleDeclaration():
   }
 }
 
+List<String> MultiImport() #void: {
+  List<String> modules = new LinkedList<String>();
+  String rootName;
+  String nextName;
+}
+{
+  ".{" (BlankLine())?
+    rootName=QualifiedName()
+    {
+      modules.add(rootName);
+    }
+    (
+      "," (BlankLine())? nextName=QualifiedName()
+      {
+        modules.add(nextName);
+      }
+    )+
+    (BlankLine())?
+  "}"
+  {
+    return modules;
+  }
+}
+
 void ImportDeclaration():
 {
   String name;
   Token relative = null;
+  List<String> multiples = null;
 }
 {
   try {
-    <IMPORT> (relative=".")? name=QualifiedName()
+    <IMPORT> (relative=".")? name=QualifiedName() (multiples=MultiImport())?
     {
       jjtThis.setName(name);
       if (relative != null) {
         jjtThis.setRelative(true);
+      }
+      if (multiples != null) {
+        jjtThis.setMultiple(multiples);
       }
     }
   }

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -57,19 +57,23 @@ public class CompileAndRunTest {
     assertThat(isStatic($imports.getModifiers()), is(true));
 
     List<String> imports = asList((String[]) $imports.invoke(null));
-    assertThat(imports.size(), is(11));
-    assertThat(imports, hasItem("gololang.Predefined"));
-    assertThat(imports, hasItem("gololang.StandardAugmentations"));
-    assertThat(imports, hasItem("gololang"));
-    assertThat(imports, hasItem("java.util.List"));
-    assertThat(imports, hasItem("java.util.LinkedList"));
-    assertThat(imports, hasItem("java.lang.System"));
-    assertThat(imports, hasItem("java.lang"));
-    assertThat(imports, hasItem("golotest.execution.ImportsMetaData.types"));
-    assertThat(imports, hasItem("golotest.execution"));
-    assertThat(imports, hasItem("golotest.execution.Bar"));
-    assertThat(imports, hasItem("golotest.execution.plop.Daplop"));
-    assertThat(imports.get(0), is ("golotest.execution.ImportsMetaData.types"));
+    assertThat(imports, contains(
+      "golotest.execution.ImportsMetaData.types",
+      "java.util.List",
+      "java.util.LinkedList",
+      "java.lang.System",
+      "golotest.execution.Bar",
+      "golotest.execution.plop.Daplop",
+      "java.util.Set",
+      "java.util.stream",
+      "java.util.regex.Pattern",
+      "golotest.execution.foo.Baz",
+      "golotest.execution.foo.spam.Egg",
+      "golotest.execution",
+      "gololang.Predefined",
+      "gololang.StandardAugmentations",
+      "gololang",
+      "java.lang"));
   }
 
   @Test

--- a/src/test/resources/for-execution/imports-metadata.golo
+++ b/src/test/resources/for-execution/imports-metadata.golo
@@ -7,4 +7,12 @@ import java.lang.System
 import .Bar
 import .plop.Daplop
 
+import java.util.{
+  Set,
+  stream,
+  regex.Pattern
+}
+
+import .foo.{Baz, spam.Egg}
+
 struct Foo = {x}


### PR DESCRIPTION
Allows to import several modules from the same package at once.

For instance:

```golo

import foo.{
  bar.Baz,
  Plop
}
```

is equivalent to

```golo
import foo.bar.Baz
import foo.Plop
```