### PR TITLE
Generate doc from IR instead of AST

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/GoloCompiler.java
+++ b/src/main/java/org/eclipse/golo/compiler/GoloCompiler.java
@@ -210,21 +210,21 @@ public class GoloCompiler {
    */
   public final GoloModule check(ASTCompilationUnit compilationUnit) {
     GoloModule goloModule = transform(compilationUnit);
-    refine(goloModule);
-    return goloModule;
+    return refine(goloModule);
   }
 
   public final GoloModule transform(ASTCompilationUnit compilationUnit) {
     return new ParseTreeToGoloIrVisitor().transform(compilationUnit, exceptionBuilder);
   }
 
-  public final void refine(GoloModule goloModule) {
+  public final GoloModule refine(GoloModule goloModule) {
     if (goloModule != null) {
       goloModule.accept(new SugarExpansionVisitor());
       goloModule.accept(new ClosureCaptureGoloIrVisitor());
       goloModule.accept(new LocalReferenceAssignmentAndVerificationVisitor(exceptionBuilder));
     }
     throwIfErrorEncountered();
+    return goloModule;
   }
 
 

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -150,7 +150,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
 
     private LocalReference getOrCreateReference(ASTLetOrVar.Type type, String name, boolean module, GoloASTNode node) {
       if (type != null) {
-        LocalReference val = localRef(name).kind(referenceKindOf(type, module));
+        LocalReference val = localRef(name).kind(referenceKindOf(type, module)).ofAST(node);
         referenceTableStack.peek().add(val);
         return val;
       }

--- a/src/main/java/org/eclipse/golo/compiler/ir/AbstractGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/AbstractGoloIrVisitor.java
@@ -234,6 +234,10 @@ public abstract class AbstractGoloIrVisitor implements GoloIrVisitor {
   public void visitTryCatchFinally(TryCatchFinally tryCatchFinally) {
     tryCatchFinally.walk(this);
   }
+
+  /**
+   * @inheritDoc
+   */
   @Override
   public void visitClosureReference(ClosureReference closureReference) {
     closureReference.walk(this);

--- a/src/main/java/org/eclipse/golo/doc/AbstractProcessor.java
+++ b/src/main/java/org/eclipse/golo/doc/AbstractProcessor.java
@@ -9,8 +9,6 @@
 
 package org.eclipse.golo.doc;
 
-import org.eclipse.golo.compiler.parser.ASTCompilationUnit;
-import org.eclipse.golo.compiler.parser.ASTModuleDeclaration;
 import gololang.FunctionReference;
 import gololang.TemplateEngine;
 import gololang.Predefined;
@@ -27,9 +25,9 @@ import java.util.TreeSet;
 
 public abstract class AbstractProcessor {
 
-  public abstract String render(ASTCompilationUnit compilationUnit) throws Throwable;
+  public abstract String render(ModuleDocumentation module) throws Throwable;
 
-  public abstract void process(Map<String, ASTCompilationUnit> units, Path targetFolder) throws Throwable;
+  public abstract void process(Map<String, ModuleDocumentation> modules, Path targetFolder) throws Throwable;
 
   private TemplateEngine templateEngine = new TemplateEngine();
   private HashMap<String, FunctionReference> templateCache = new HashMap<>();
@@ -118,10 +116,6 @@ public abstract class AbstractProcessor {
       out = out.getParent();
     }
     return out.relativize(outputFile(dst)).toString();
-  }
-
-  protected String moduleName(ASTCompilationUnit unit) {
-    return ((ASTModuleDeclaration) unit.jjtGetChild(0)).getName();
   }
 
   protected void renderIndex(String templateName) throws Throwable {

--- a/src/main/java/org/eclipse/golo/doc/AugmentationDocumentation.java
+++ b/src/main/java/org/eclipse/golo/doc/AugmentationDocumentation.java
@@ -85,7 +85,7 @@ class AugmentationDocumentation extends AbstractSet<FunctionDocumentation> imple
   }
 
   public AugmentationDocumentation documentation(String documentation) {
-    if (documentation != null) {
+    if (documentation != null && !documentation.isEmpty()) {
       this.documentation = documentation;
     }
     return this;

--- a/src/main/java/org/eclipse/golo/doc/CtagsProcessor.java
+++ b/src/main/java/org/eclipse/golo/doc/CtagsProcessor.java
@@ -140,8 +140,7 @@ public class CtagsProcessor extends AbstractProcessor {
   }
 
   @Override
-  public String render(ASTCompilationUnit compilationUnit) throws Throwable {
-    ModuleDocumentation documentation = new ModuleDocumentation(compilationUnit);
+  public String render(ModuleDocumentation documentation) throws Throwable {
     ctagsModule(documentation);
     for (Map.Entry<String, Integer> imp : documentation.imports().entrySet()) {
       ctagsImport(imp.getKey(), imp.getValue());
@@ -177,7 +176,7 @@ public class CtagsProcessor extends AbstractProcessor {
   }
 
   @Override
-  public void process(Map<String, ASTCompilationUnit> units, Path targetFolder) throws Throwable {
+  public void process(Map<String, ModuleDocumentation> modules, Path targetFolder) throws Throwable {
     Path targetFile = null;
     if (targetFolder.toString().equals("-")) {
       targetFile = targetFolder;
@@ -185,7 +184,7 @@ public class CtagsProcessor extends AbstractProcessor {
       targetFile = targetFolder.resolve("tags");
     }
     ctags.clear();
-    for (Map.Entry<String, ASTCompilationUnit> src : units.entrySet()) {
+    for (Map.Entry<String, ModuleDocumentation> src : modules.entrySet()) {
       file = src.getKey();
       render(src.getValue());
     }

--- a/src/main/java/org/eclipse/golo/doc/FunctionDocumentation.java
+++ b/src/main/java/org/eclipse/golo/doc/FunctionDocumentation.java
@@ -191,4 +191,8 @@ class FunctionDocumentation implements DocumentationElement {
     return -1 * other.compareTo(this);
   }
 
+  @Override
+  public String toString() {
+    return (local ? "-" : "+") + label();
+  }
 }

--- a/src/main/java/org/eclipse/golo/doc/HtmlProcessor.java
+++ b/src/main/java/org/eclipse/golo/doc/HtmlProcessor.java
@@ -50,9 +50,8 @@ public class HtmlProcessor extends AbstractProcessor {
   }
 
   @Override
-  public String render(ASTCompilationUnit compilationUnit) throws Throwable {
+  public String render(ModuleDocumentation documentation) throws Throwable {
     FunctionReference template = template("template", fileExtension());
-    ModuleDocumentation documentation = new ModuleDocumentation(compilationUnit);
     globalIndex.update(documentation);
     addModule(documentation);
     Path doc = docFile(documentation);
@@ -63,20 +62,20 @@ public class HtmlProcessor extends AbstractProcessor {
   }
 
   @Override
-  public void process(Map<String, ASTCompilationUnit> units, Path targetFolder) throws Throwable {
+  public void process(Map<String, ModuleDocumentation> docs, Path targetFolder) throws Throwable {
     setTargetFolder(targetFolder);
-    for (Map.Entry<String, ASTCompilationUnit> unit : units.entrySet()) {
-      renderModule(unit.getKey(), unit.getValue());
+    for (Map.Entry<String, ModuleDocumentation> doc : docs.entrySet()) {
+      renderModule(doc.getKey(), doc.getValue());
     }
     renderIndex("index");
     renderIndex("index-all");
   }
 
-  private void renderModule(String sourceFile, ASTCompilationUnit unit) throws Throwable {
-    String moduleName = moduleName(unit);
+  private void renderModule(String sourceFile, ModuleDocumentation doc) throws Throwable {
+    String moduleName = doc.moduleName();
     srcFile = outputFile(moduleName + "-src");
     Predefined.textToFile(renderSource(moduleName, sourceFile), srcFile);
-    Predefined.textToFile(render(unit), outputFile(moduleName));
+    Predefined.textToFile(render(doc), outputFile(moduleName));
   }
 
   private String renderSource(String moduleName, String filename) throws Throwable {

--- a/src/main/java/org/eclipse/golo/doc/MarkdownProcessor.java
+++ b/src/main/java/org/eclipse/golo/doc/MarkdownProcessor.java
@@ -9,7 +9,6 @@
 
 package org.eclipse.golo.doc;
 
-import org.eclipse.golo.compiler.parser.ASTCompilationUnit;
 import gololang.FunctionReference;
 import gololang.Predefined;
 
@@ -24,18 +23,17 @@ public class MarkdownProcessor extends AbstractProcessor {
   }
 
   @Override
-  public String render(ASTCompilationUnit compilationUnit) throws Throwable {
+  public String render(ModuleDocumentation documentation) throws Throwable {
     FunctionReference template = template("template", fileExtension());
-    ModuleDocumentation documentation = new ModuleDocumentation(compilationUnit);
     addModule(documentation);
     return (String) template.invoke(documentation);
   }
 
   @Override
-  public void process(Map<String, ASTCompilationUnit> units, Path targetFolder) throws Throwable {
+  public void process(Map<String, ModuleDocumentation> modules, Path targetFolder) throws Throwable {
     setTargetFolder(targetFolder);
-    for (ASTCompilationUnit unit : units.values()) {
-      Predefined.textToFile(render(unit), outputFile(moduleName(unit)));
+    for (ModuleDocumentation doc : modules.values()) {
+      Predefined.textToFile(render(doc), outputFile(doc.moduleName()));
     }
     renderIndex("index");
   }

--- a/src/test/java/org/eclipse/golo/doc/ModuleDocumentationTest.java
+++ b/src/test/java/org/eclipse/golo/doc/ModuleDocumentationTest.java
@@ -9,9 +9,8 @@
 
 package org.eclipse.golo.doc;
 
-import org.eclipse.golo.compiler.parser.ASTCompilationUnit;
-import org.eclipse.golo.compiler.parser.GoloOffsetParser;
-import org.eclipse.golo.compiler.parser.GoloParser;
+import org.eclipse.golo.compiler.GoloCompiler;
+import org.eclipse.golo.compiler.ir.GoloModule;
 
 import org.testng.annotations.Test;
 import org.testng.annotations.BeforeTest;
@@ -29,9 +28,7 @@ public class ModuleDocumentationTest {
 
   @BeforeTest
   public void setUp() throws Throwable {
-    GoloParser parser = new GoloOffsetParser(new FileInputStream(SRC + "doc.golo"));
-    ASTCompilationUnit compilationUnit = parser.CompilationUnit();
-    doc = new ModuleDocumentation(compilationUnit);
+    doc = ModuleDocumentation.load(SRC + "doc.golo", new GoloCompiler());
   }
 
   @Test


### PR DESCRIPTION
In the prevision of introducing macros, the golodoc should be generated from the IR instead of the AST, since macros can inject new public types and functions in a module that should be documented.
This refactor also loosen the coupling between the AST and the rest of the code base, being even less dependent on the parser.