### PR TITLE
Fix Gitter badge URL by encoding the space

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.16110.svg)](http://dx.doi.org/10.5281/zenodo.16110)
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/eclipse/golo-lang?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/eclipse/golo-lang?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/eclipse/golo-lang.svg?branch=master)](https://travis-ci.org/eclipse/golo-lang)
 [ ![Download](https://api.bintray.com/packages/golo-lang/downloads/distributions/images/download.svg) ](https://bintray.com/golo-lang/downloads/distributions/_latestVersion)
 


### PR DESCRIPTION
The current Gitter badge URL contains a space, which makes the
badge incorrectly display as a link (at least in GitHub's rendering).

Changing the space for '%20' fixes this.

Change preview:

## Before


<img width="830" alt="gitter-badge-before" src="https://user-images.githubusercontent.com/4542383/27844774-4dc68244-60f4-11e7-98d2-02c96e3b85d2.png">


## After

<img width="937" alt="gitter-badge-after" src="https://user-images.githubusercontent.com/4542383/27844760-2021132c-60f4-11e7-88c1-0c759b50cd30.png">
