### PR TITLE
FIX 496 : Add support for CodeSource URL for GoloClassLoader

### DIFF
--- a/src/main/java/org/eclipse/golo/cli/command/GoloGoloCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/GoloGoloCommand.java
@@ -78,7 +78,7 @@ public class GoloGoloCommand implements CliCommand {
       }
     } else if (file.getName().endsWith(".golo")) {
       try (FileInputStream in = new FileInputStream(file)) {
-        Class<?> loadedClass = loader.load(file.getName(), in);
+        Class<?> loadedClass = loader.load(file.getName(), in, file.toURI().toURL());
         if (module == null || loadedClass.getCanonicalName().equals(module)) {
           return loadedClass;
         }

--- a/src/main/java/org/eclipse/golo/cli/command/ShebangCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/ShebangCommand.java
@@ -78,7 +78,7 @@ public class ShebangCommand implements CliCommand {
     try (InputStream is = Files.newInputStream(path)) {
       Path filename = path.getFileName();
       if (filename != null) {
-        return loader.load(filename.toString(), is);
+        return loader.load(filename.toString(), is, path.toUri().toURL());
       } else {
         throw new RuntimeException(message("not_regular_file", path));
       }

--- a/src/main/java/org/eclipse/golo/compiler/GoloClassLoader.java
+++ b/src/main/java/org/eclipse/golo/compiler/GoloClassLoader.java
@@ -10,6 +10,10 @@
 package org.eclipse.golo.compiler;
 
 import java.io.InputStream;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.security.cert.Certificate;
 import java.util.List;
 
 /**
@@ -55,6 +59,27 @@ public class GoloClassLoader extends ClassLoader {
     for (CodeGenerationResult result : results) {
       byte[] bytecode = result.getBytecode();
       lastClassIsModule = defineClass(null, bytecode, 0, bytecode.length);
+    }
+    return lastClassIsModule;
+  }
+  
+  /**
+   * Compiles and loads the resulting JVM bytecode for a Golo source file.
+   * This method declares a URL for the CodeSource of this class, which
+   * is useful for retrieving the location at runtime.
+   *
+   * @param goloSourceFilename    the source file name.
+   * @param sourceCodeInputStream the source input stream.
+   * @param sourceCodeLocation    the source file location.
+   * @return the class matching the Golo module defined in the source.
+   * @throws GoloCompilationException if either of the compilation phase failed.
+   */
+  public synchronized Class<?> load(String goloSourceFilename, InputStream sourceCodeInputStream, URL sourceCodeLocation) throws GoloCompilationException {
+    List<CodeGenerationResult> results = compiler.compile(goloSourceFilename, sourceCodeInputStream);
+    Class<?> lastClassIsModule = null;
+    for (CodeGenerationResult result : results) {
+      byte[] bytecode = result.getBytecode();
+      lastClassIsModule = defineClass(null, bytecode, 0, bytecode.length, new ProtectionDomain(new CodeSource(sourceCodeLocation, (Certificate[])null), null));
     }
     return lastClassIsModule;
   }


### PR DESCRIPTION
This PR aims to fix #496 where it is impossible to get a .golo file's location at runtime. This uses the same mechanism as regular .jar and .classes in Java, which is registering a ProtectionDomain and CodeSource.

This PR adds a `load` method to `GoloClassLoader` that takes one argument more than the already present load method, which is a URL. This URL represents the original location of the .golo file.

Both the CLI "golo golo" and "golosh" were changed to use the new method. The old method was kept to ensure backwards-compatibility and still provide a way to load golo files without providing its source. This could also be useful in the future if you guys want to use Certificates or other security features of ProtectionDomain with GoloClassLoader.