### PR TITLE
Fix a bug in function composition

### DIFF
--- a/src/main/java/gololang/FunctionReference.java
+++ b/src/main/java/gololang/FunctionReference.java
@@ -100,6 +100,9 @@ public class FunctionReference {
   }
 
   public FunctionReference asVarargsCollector(Class<?> arrayType) {
+    if (this.isVarargsCollector()) {
+      return this;
+    }
     return new FunctionReference(handle.asVarargsCollector(arrayType), this.parameterNames);
   }
 
@@ -108,7 +111,11 @@ public class FunctionReference {
   }
 
   public FunctionReference bindTo(Object x) {
-    return new FunctionReference(handle.bindTo(x), dropParameterNames(0, 1));
+    MethodHandle mh = this.handle.bindTo(x);
+    if (isVarargsCollector() && arity() > 1) {
+      mh = mh.asVarargsCollector(Object[].class);
+    }
+    return new FunctionReference(mh, dropParameterNames(0, 1));
   }
 
   public boolean isVarargsCollector() {
@@ -201,6 +208,12 @@ public class FunctionReference {
   /**
    * Compose a function with another function.
    *
+   * The {@code fun} function must accept 1 parameter that will be the value returned by this function, or no parameter, in
+   * which case the returned value will be ignored.
+   *
+   * The resulting function may throw a {@code ClassCastException} on invocation if the return type of this function
+   * does not match the type of the {@code fun} parameter.
+   *
    * @param fun the function that processes the results of {@code this} function.
    * @return a composed function.
    */
@@ -210,12 +223,20 @@ public class FunctionReference {
       other = fun.handle.asCollector(Object[].class, 1);
     } else if (fun.isVarargsCollector() && fun.arity() == 2) {
       other = MethodHandles.insertArguments(fun.handle, 1, new Object[]{new Object[0]});
+    } else if (fun.arity() == 0) {
+      other = MethodHandles.dropArguments(fun.handle, 0, Object.class);
     } else if (fun.arity() == 1) {
       other = fun.handle;
     } else {
-      throw new IllegalArgumentException("`andThen` requires a function that can be applied to 1 parameter");
+      throw new IllegalArgumentException("`andThen` requires a function that can be applied to 0 or 1 parameter");
     }
-    return new FunctionReference(filterReturnValue(this.handle, other), this.parameterNames);
+    MethodHandle mh = filterReturnValue(
+        this.handle.asType(this.handle.type().changeReturnType(Object.class)),
+        other.asType(other.type().changeParameterType(0, Object.class)));
+    if (isVarargsCollector()) {
+      mh = mh.asVarargsCollector(Object[].class);
+    }
+    return new FunctionReference(mh, this.parameterNames);
   }
 
   /*
@@ -227,8 +248,8 @@ public class FunctionReference {
    * @return a composed function.
    */
   public FunctionReference compose(FunctionReference fun) {
-    if (!acceptArity(1)) {
-      throw new UnsupportedOperationException("`compose` must be called on function accepting 1 parameter");
+    if (!acceptArity(1) && !acceptArity(0)) {
+      throw new UnsupportedOperationException("`compose` must be called on function accepting 0 or 1 parameter");
     }
     return fun.andThen(this);
   }
@@ -241,7 +262,11 @@ public class FunctionReference {
    * @return a partially applied function.
    */
   public FunctionReference bindAt(int position, Object value) {
-    return new FunctionReference(MethodHandles.insertArguments(this.handle, position, value), dropParameterNames(position, 1));
+    MethodHandle mh = MethodHandles.insertArguments(this.handle, position, value);
+    if (isVarargsCollector() && position < arity() - 1) {
+      mh = mh.asVarargsCollector(Object[].class);
+    }
+    return new FunctionReference(mh, dropParameterNames(position, 1));
   }
 
   /**
@@ -280,11 +305,11 @@ public class FunctionReference {
     if (values.length == 0) {
       return this;
     }
-    MethodHandle bounded = MethodHandles.insertArguments(handle, position, values);
-    if (handle.isVarargsCollector()) {
-      bounded = bounded.asVarargsCollector(Object[].class);
+    MethodHandle mh = MethodHandles.insertArguments(this.handle, position, values);
+    if (isVarargsCollector() && position < arity() - 1) {
+      mh = mh.asVarargsCollector(Object[].class);
     }
-    return new FunctionReference(bounded, dropParameterNames(position, values.length));
+    return new FunctionReference(mh, dropParameterNames(position, values.length));
   }
 
   /**

--- a/src/main/java/gololang/Predefined.java
+++ b/src/main/java/gololang/Predefined.java
@@ -449,7 +449,7 @@ public final class Predefined {
     return fun(caller, name, module, -1);
   }
 
-  private static FunctionReference toFunctionReference(Method targetMethod, int functionArity) throws Throwable {
+  public static FunctionReference toFunctionReference(Method targetMethod, int functionArity) throws Throwable {
     String[] parameterNames = Arrays.stream(targetMethod.getParameters())
         .map(Parameter::getName)
         .toArray(String[]::new);

--- a/src/test/java/gololang/FunctionReferenceTest.java
+++ b/src/test/java/gololang/FunctionReferenceTest.java
@@ -19,6 +19,9 @@ import java.util.stream.Collectors;
 import static java.lang.invoke.MethodType.genericMethodType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import gololang.Predefined;
 
 /*
  * Note: most tests are to be run from Golo code and CompileAndRunTest.
@@ -31,40 +34,39 @@ public class FunctionReferenceTest {
       return obj;
     }
 
+    public static Object noParam() {
+      return 42;
+    }
+
     public static Object collect(Object a, Object b, Object c) {
       return String.valueOf(a) + b + c;
     }
 
     public static Object collectN(Object a, Object... b) {
-      String head = (String) a;
-      String[] tail = new String[b.length];
-      for (int i = 0; i < b.length; i++) {
-        tail[i] = (String) b[i];
-      }
-      return head + Arrays.stream(tail).collect(Collectors.joining());
+      return a.toString() + Arrays.stream(b).map(Object::toString).collect(Collectors.joining());
     }
 
     public static Object collectAny(Object... a) {
-      String[] r = new String[a.length];
-      for (int i = 0; i < a.length; i++) {
-        r[i] = (String) a[i];
-      }
-      return Arrays.stream(r).collect(Collectors.joining());
+      return Arrays.stream(a).map(Object::toString).collect(Collectors.joining());
     }
+
+    public static void noReturn() {}
   }
 
-  private static final MethodHandle ping;
-  private static final MethodHandle collect;
-  private static final MethodHandle collectN;
-  private static final MethodHandle collectAny;
+  private static final FunctionReference ping;
+  private static final FunctionReference collect;
+  private static final FunctionReference collectN;
+  private static final FunctionReference collectAny;
+  private static final FunctionReference noParam;
 
   static {
     try {
       MethodHandles.Lookup lookup = MethodHandles.lookup();
-      ping = lookup.findStatic(Foo.class, "ping", genericMethodType(1));
-      collect = lookup.findStatic(Foo.class, "collect", genericMethodType(3));
-      collectN = lookup.findStatic(Foo.class, "collectN", genericMethodType(1, true));
-      collectAny = lookup.findStatic(Foo.class, "collectAny", genericMethodType(0, true));
+      ping = new FunctionReference(lookup.findStatic(Foo.class, "ping", genericMethodType(1)));
+      collect = new FunctionReference(lookup.findStatic(Foo.class, "collect", genericMethodType(3)));
+      collectN = new FunctionReference(lookup.findStatic(Foo.class, "collectN", genericMethodType(1, true)));
+      collectAny = new FunctionReference(lookup.findStatic(Foo.class, "collectAny", genericMethodType(0, true)));
+      noParam = new FunctionReference(lookup.findStatic(Foo.class, "noParam", genericMethodType(0)));
     } catch (NoSuchMethodException | IllegalAccessException e) {
       throw new IllegalStateException(e);
     }
@@ -72,9 +74,15 @@ public class FunctionReferenceTest {
 
   @Test
   public void sanity_check() throws Throwable {
-    FunctionReference fun = new FunctionReference(ping);
-    assertThat(fun.handle().invoke("Plop"), is("Plop"));
-    assertThat(fun.invoke("Plop"), is("Plop"));
+    assertThat(ping.handle().invoke("Plop"), is("Plop"));
+    assertThat(ping.invoke("Plop"), is("Plop"));
+
+    assertThat(collectAny.invoke(), is(""));
+    assertThat(collectAny.invoke("a"), is("a"));
+    assertThat(collectAny.invoke("a", "b", "c"), is("abc"));
+    assertThat(collectAny.invoke(new Object[]{"a", "b", "c"}), is("abc"));
+
+    assertThat(noParam.invoke(), is(42));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -84,32 +92,76 @@ public class FunctionReferenceTest {
 
   @Test
   public void spread() throws Throwable {
-    FunctionReference fun = new FunctionReference(collect);
-    assertThat(fun.handle().invoke(1, 2, 3), is("123"));
-    assertThat(fun.spread(1, 2, 3), is("123"));
+    assertThat(collect.handle().invoke(1, 2, 3), is("123"));
+    assertThat(collect.spread(1, 2, 3), is("123"));
   }
 
   @Test
   public void spread_varargs() throws Throwable {
-    FunctionReference fun = new FunctionReference(collectN);
-    assertThat(fun.handle().invoke("1", "2", "3"), is("123"));
-    assertThat(fun.spread("1", new Object[]{"2", "3"}), is("123"));
+    assertThat(collectN.handle().invoke("1", "2", "3"), is("123"));
+    assertThat(collectN.spread("1", new Object[]{"2", "3"}), is("123"));
   }
 
   @Test
   public void andThen() throws Throwable {
-    FunctionReference fun = new FunctionReference(ping).andThen(new FunctionReference(ping));
-    assertThat(fun.invoke("Plop"), is("Plop"));
+    assertThat(ping.andThen(ping).invoke("Plop"), is("Plop"));
+    assertThat(noParam.andThen(ping).invoke(), is(42));
+    assertThat(ping.andThen(collectN).invoke("Plop"), is("Plop"));
+    assertThat(ping.andThen(collectAny).invoke("Plop"), is("Plop"));
+  }
 
-    fun = new FunctionReference(ping).andThen(new FunctionReference(collectN));
-    assertThat(fun.invoke("Plop"), is("Plop"));
+  @Test
+  public void andThen_varargs() throws Throwable {
+    FunctionReference fun = collectAny.andThen(ping);
+    assertThat(fun.invoke(), is(""));
+    assertThat(fun.invoke("a"), is("a"));
+    assertThat(fun.invoke("a", "b", "c"), is("abc"));
+    assertThat(fun.invoke(new Object[]{"a", "b", "c"}), is("abc"));
+  }
 
-    fun = new FunctionReference(ping).andThen(new FunctionReference(collectAny));
-    assertThat(fun.invoke("Plop"), is("Plop"));
+  @Test
+  public void andThen_noargs() throws Throwable {
+    assertThat(noParam.andThen(ping).invoke(), is(42));
+    assertThat(ping.andThen(noParam).invoke("Plop"), is(42));
+  }
+
+  @Test
+  public void andThen_types() throws Throwable {
+    FunctionReference fun;
+    fun = Predefined.fun(null, "toString", Object.class)
+      .andThen(Predefined.fun(null, "length", String.class));
+    assertThat(fun.invoke("plop"), is(4));
+
+    fun = Predefined.fun(null, "toString", Object.class).andThen(ping);
+    assertThat(fun.invoke("plop"), is("plop"));
+
+    fun = ping.andThen(Predefined.fun(null, "length", String.class));
+    assertThat(fun.invoke("plop"), is(4));
+  }
+
+  @Test(expectedExceptions = ClassCastException.class)
+  public void andThen_bad_types() throws Throwable {
+    noParam.andThen(Predefined.fun(null, "length", String.class)).invoke();
+  }
+
+  @Test
+  public void andThen_void() throws Throwable {
+    FunctionReference noReturn = Predefined.fun(null, "noReturn", Foo.class);
+    assertThat(noReturn.andThen(noParam).invoke(), is(42));
+    assertThat(noParam.andThen(noReturn).invoke(), is(nullValue()));
+  }
+
+  @Test
+  public void bind() throws Throwable {
+    assertThat(ping.bindTo("Plop").invoke(), is("Plop"));
+    assertThat(collect.bindTo("a").invoke("b", "c"), is("abc"));
+    assertThat(collectN.bindTo("a").invoke("b", "c"), is("abc"));
+    assertThat(collect.bindAt(1, "b").invoke("a", "c"), is("abc"));
+    assertThat(collectN.bindAt(1, new Object[]{"b", "c"}).invoke("a"), is("abc"));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*1 parameter.*")
   public void andThen_bad_arity() throws Throwable {
-    new FunctionReference(ping).andThen(new FunctionReference(collect));
+    ping.andThen(collect);
   }
 }

--- a/src/test/resources/for-execution/augmentations-with-fallback.golo
+++ b/src/test/resources/for-execution/augmentations-with-fallback.golo
@@ -7,11 +7,9 @@ augment java.lang.String {
 }
 
 augmentation Fluent = {
-  function fallback = |this, functionName, args...| {
-    return match {
-      when args: length() is 1 then this: bindAt(functionName, args: get(0))
-      otherwise this: bindAt(functionName, args)
-    }
+  function fallback = |this, functionName, args...| -> match {
+    when args: length() is 1 then this: bindAt(functionName, args: get(0))
+    otherwise this: bindAt(functionName, args)
   }
 }
 


### PR DESCRIPTION
When composing a variadic function, the collector status is lost, thus
the resulting function can't be used as varargs.

For instance:

```golo
let f = (|a...| -> a: toString()): andThen(|a| -> a)

f("a", "b")
f: invoke("a", "b")
```

Both calls fail with a `WrongMethodTypeException`. A solution is to add
a `: asVarargsCollector()` call, but it is counter intuitive: the
composed function should directly accept the same arguments as the first
function and return the same type as the second one.

This is fixed by converting the composed function into a varargs
collector if the original one was.

The same issue occurred when binding parameters on varargs functions.

A last bug fixed here occurred when composing java functions whose types
do not match exactly even if compatible
(e.g. composing `A -> String` with `Object -> B` to get `A -> B`)
The types of both functions are now adapted to be `Object`. However, a
`ClassCastException` can be raised on invocation if types are not
actually compatible.

Another change introduced is to accept to compose with a parameterless
function, as in:

```golo
let f = (|a|{println("got " + a)}): andThen(-> 42)
println(f("answer"))
```

This used to raise an `IllegalArgumentException`. A solution was to use
`: andThen(|ignored| -> 42)` instead, which is cumbersome and prevents
to use existing functions.

The result of the first function is now ignored. This is useful to
sequence functions with side effects, that return null/void. The
previous example prints

    got answer
    42