### PR TITLE
Fix the 509 issue

### DIFF
--- a/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
+++ b/src/main/jjtree/org/eclipse/golo/compiler/parser/Golo.jjt
@@ -1573,7 +1573,7 @@ void Assignment():
 
 void Return(): {}
 {
-  <RETURN> (LOOKAHEAD(2) (BlankLine())? ExpressionStatement())?
+  <RETURN> (LOOKAHEAD(2) BlankLines() ExpressionStatement())?
 }
 
 void Argument():

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -132,6 +132,9 @@ public class CompileAndRunTest {
     assertThat(main, notNullValue());
     assertThat(main.getReturnType().toString(), is("void"));
     assertThat(main.invoke(null, (Object[]) new String[1]), nullValue());
+
+    Method issue509 = moduleClass.getMethod("issue509");
+    assertThat((Integer) issue509.invoke(null), is(42));
   }
 
   @Test

--- a/src/test/resources/for-execution/returns.golo
+++ b/src/test/resources/for-execution/returns.golo
@@ -36,3 +36,9 @@ function raw_code = {
 }
 
 function main = |args| {}
+
+function issue509 = {
+  return # comment 1
+  # comment 2
+  42
+}


### PR DESCRIPTION
Add the ability to put some comments between
the `return` keyword and the returned statment.