### PR TITLE
Refactor ast/ir link

### DIFF
--- a/src/main/java/gololang/AdapterFabric.java
+++ b/src/main/java/gololang/AdapterFabric.java
@@ -77,8 +77,8 @@ public final class AdapterFabric {
       Object[] cargs = new Object[args.length + 1];
       cargs[0] = adapterDefinition;
       System.arraycopy(args, 0, cargs, 1, args.length);
-      for (Constructor constructor : adapterClass.getConstructors()) {
-        Class[] parameterTypes = constructor.getParameterTypes();
+      for (Constructor<?> constructor : adapterClass.getConstructors()) {
+        Class<?>[] parameterTypes = constructor.getParameterTypes();
         if ((cargs.length == parameterTypes.length) || (constructor.isVarArgs() && (cargs.length >= parameterTypes.length))) {
           if (TypeMatching.canAssign(parameterTypes, cargs, constructor.isVarArgs())) {
             return constructor.newInstance(cargs);

--- a/src/main/java/org/eclipse/golo/compiler/GoloCompilationException.java
+++ b/src/main/java/org/eclipse/golo/compiler/GoloCompilationException.java
@@ -12,7 +12,6 @@ package org.eclipse.golo.compiler;
 
 import org.eclipse.golo.compiler.parser.GoloASTNode;
 import org.eclipse.golo.compiler.parser.ParseException;
-import org.eclipse.golo.compiler.parser.Token;
 import org.eclipse.golo.compiler.ir.PositionInSourceCode;
 import org.eclipse.golo.compiler.ir.GoloElement;
 
@@ -136,7 +135,7 @@ public class GoloCompilationException extends RuntimeException {
      * @param description the problem description.
      * @return the same builder object.
      */
-    public Builder report(Problem.Type type, GoloElement source, String description) {
+    public Builder report(Problem.Type type, GoloElement<?> source, String description) {
       exception.report(new Problem(type,
             source != null ? source.positionInSourceCode() : null,
             description,

--- a/src/main/java/org/eclipse/golo/compiler/GoloCompilationException.java
+++ b/src/main/java/org/eclipse/golo/compiler/GoloCompilationException.java
@@ -54,56 +54,12 @@ public class GoloCompilationException extends RuntimeException {
 
     private final String description;
 
-    /**
-     * Constructs a new problem to report.
-     *
-     * @param type        the problem type.
-     * @param source      the problem source, which may be of any meaningful type.
-     * @param description the problem description in a human-readable form.
-     */
-    public Problem(Type type, GoloASTNode source, String description) {
-      this.type = type;
-      this.description = description;
-      this.source = source;
-      if (source != null) {
-        this.firstToken = source.jjtGetFirstToken();
-        this.lastToken = source.jjtGetLastToken();
-      } else {
-        this.firstToken = null;
-        this.lastToken = null;
-      }
-    }
-
-    /**
-     * Constructs a new problem to report.
-     *
-     * @param type        the problem type.
-     * @param source      the problem source, which may be of any meaningful type.
-     * @param token       the precise source token, where the problem is located.
-     * @param description the problem description in a human-readable form.
-     */
-    public Problem(Type type, GoloASTNode source, Token token, String description) {
+    private Problem(Type type, GoloASTNode source, Token firstToken, Token lastToken, String description) {
       this.type = type;
       this.source = source;
-      this.firstToken = token;
-      this.lastToken = token;
+      this.firstToken = firstToken;
+      this.lastToken = lastToken;
       this.description = description;
-    }
-
-    public Problem(ParseException pe, GoloASTNode source) {
-      this.type = Type.PARSING;
-      this.source = source;
-      this.firstToken = pe.currentToken;
-      this.lastToken = pe.currentToken;
-      this.description = pe.getMessage();
-    }
-
-    public Problem(UnsupportedCharsetException uce) {
-      this.type = Type.INVALID_ENCODING;
-      this.source = null;
-      this.firstToken = null;
-      this.lastToken = null;
-      this.description = uce.getMessage();
     }
 
     /**
@@ -177,7 +133,10 @@ public class GoloCompilationException extends RuntimeException {
      * @return the same builder object.
      */
     public Builder report(Problem.Type type, GoloASTNode source, String description) {
-      exception.report(new Problem(type, source, description));
+      exception.report(new Problem(type, source,
+            source != null ? source.jjtGetFirstToken() : null,
+            source != null ? source.jjtGetLastToken() : null,
+            description));
       return this;
     }
 
@@ -189,7 +148,7 @@ public class GoloCompilationException extends RuntimeException {
      * @return the same builder object.
      */
     public Builder report(ParseException pe, GoloASTNode source) {
-      exception.report(new Problem(pe, source));
+      exception.report(new Problem(Problem.Type.PARSING, source, pe.currentToken, pe.currentToken, pe.getMessage()));
       return this;
     }
 
@@ -200,7 +159,7 @@ public class GoloCompilationException extends RuntimeException {
      * @return the same builder object.
      */
     public Builder report(UnsupportedCharsetException uce) {
-      exception.report(new Problem(uce));
+      exception.report(new Problem(Problem.Type.INVALID_ENCODING, null, null, null, uce.getMessage()));
       return this;
     }
 

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeGenerationGoloIrVisitor.java
@@ -74,7 +74,7 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
       + description + ")Ljava/lang/invoke/CallSite;", false);
   }
 
-  private static RuntimeException invalidElement(GoloElement element) {
+  private static RuntimeException invalidElement(GoloElement<?> element) {
     return new IllegalStateException(prefixed("bug", message("no_element_remains", element.getClass())));
   }
 
@@ -376,7 +376,7 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
     Label blockStart = new Label();
     Label blockEnd = new Label();
     currentMethodVisitor.visitLabel(blockStart);
-    for (GoloStatement statement : block.getStatements()) {
+    for (GoloStatement<?> statement : block.getStatements()) {
       visitLine(statement, currentMethodVisitor);
       statement.accept(this);
       insertMissingPop(statement);
@@ -392,8 +392,8 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
     context.referenceTableStack.pop();
   }
 
-  private void insertMissingPop(GoloStatement statement) {
-    Class<? extends GoloStatement> statementClass = statement.getClass();
+  private void insertMissingPop(GoloStatement<?> statement) {
+    Class<?> statementClass = statement.getClass();
     if (statementClass == FunctionInvocation.class) {
       currentMethodVisitor.visitInsn(POP);
     } else if (statementClass == BinaryOperation.class) {
@@ -490,9 +490,9 @@ class JavaBytecodeGenerationGoloIrVisitor implements GoloIrVisitor {
     currentMethodVisitor.visitInsn(ATHROW);
   }
 
-  private List<String> visitInvocationArguments(AbstractInvocation invocation) {
+  private List<String> visitInvocationArguments(AbstractInvocation<?> invocation) {
     List<String> argumentNames = new ArrayList<>();
-    for (ExpressionStatement argument : invocation.getArguments()) {
+    for (ExpressionStatement<?> argument : invocation.getArguments()) {
       if (invocation.usesNamedArguments()) {
         NamedArgument namedArgument = (NamedArgument) argument;
         argumentNames.add(namedArgument.getName());

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
@@ -58,7 +58,7 @@ final class JavaBytecodeUtils {
     if (element.hasPosition()) {
       Label label = new Label();
       visitor.visitLabel(label);
-      visitor.visitLineNumber(element.positionInSourceCode().getLine(), label);
+      visitor.visitLineNumber(element.positionInSourceCode().getStartLine(), label);
     }
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
@@ -58,7 +58,7 @@ final class JavaBytecodeUtils {
     if (element.hasPosition()) {
       Label label = new Label();
       visitor.visitLabel(label);
-      visitor.visitLineNumber(element.getPositionInSourceCode().getLine(), label);
+      visitor.visitLineNumber(element.positionInSourceCode().getLine(), label);
     }
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
@@ -54,7 +54,7 @@ final class JavaBytecodeUtils {
     }
   }
 
-  static void visitLine(GoloElement element, MethodVisitor visitor) {
+  static void visitLine(GoloElement<?> element, MethodVisitor visitor) {
     if (element.hasPosition()) {
       Label label = new Label();
       visitor.visitLabel(label);

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
@@ -55,7 +55,7 @@ final class JavaBytecodeUtils {
   }
 
   static void visitLine(GoloElement element, MethodVisitor visitor) {
-    if (element.hasASTNode()) {
+    if (element.hasPosition()) {
       Label label = new Label();
       visitor.visitLabel(label);
       visitor.visitLineNumber(element.getPositionInSourceCode().getLine(), label);

--- a/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
@@ -11,7 +11,6 @@
 package org.eclipse.golo.compiler;
 
 import org.eclipse.golo.compiler.ir.*;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
 import java.util.Deque;
 import java.util.HashSet;
@@ -65,7 +64,7 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
     return exceptionBuilder;
   }
 
-  private void errorMessage(GoloCompilationException.Problem.Type type, GoloElement node, String message) {
+  private void errorMessage(GoloCompilationException.Problem.Type type, GoloElement<?> node, String message) {
     PositionInSourceCode position = node.positionInSourceCode();
     String errorMessage = message + ' ' + (
         (position != null || position.isUndefined())

--- a/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
@@ -69,8 +69,8 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
       String message) {
     PositionInSourceCode position = node.getPositionInSourceCode();
     String errorMessage = message + ' ' + (
-        position != null
-        ? message("source_position", position.getLine(), position.getColumn())
+        (position != null || position.isUndefined())
+        ? message("source_position", position.getStartLine(), position.getStartColumn())
         : message("generated_code")) + ".";
 
     getExceptionBuilder().report(type, node, errorMessage);

--- a/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/LocalReferenceAssignmentAndVerificationVisitor.java
@@ -65,9 +65,8 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
     return exceptionBuilder;
   }
 
-  private void errorMessage(GoloCompilationException.Problem.Type type, GoloASTNode node,
-      String message) {
-    PositionInSourceCode position = node.getPositionInSourceCode();
+  private void errorMessage(GoloCompilationException.Problem.Type type, GoloElement node, String message) {
+    PositionInSourceCode position = node.positionInSourceCode();
     String errorMessage = message + ' ' + (
         (position != null || position.isUndefined())
         ? message("source_position", position.getStartLine(), position.getStartColumn())
@@ -155,10 +154,10 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
     LocalReference reference = assignmentStatement.getLocalReference();
     Set<LocalReference> assignedReferences = assignmentStack.peek();
     if (redeclaringReferenceInBlock(assignmentStatement, reference, assignedReferences)) {
-      errorMessage(REFERENCE_ALREADY_DECLARED_IN_BLOCK, assignmentStatement.getASTNode(),
+      errorMessage(REFERENCE_ALREADY_DECLARED_IN_BLOCK, assignmentStatement,
           message("reference_already_declared", reference.getName()));
     } else if (assigningConstant(reference, assignedReferences)) {
-      errorMessage(ASSIGN_CONSTANT, assignmentStatement.getASTNode(),
+      errorMessage(ASSIGN_CONSTANT, assignmentStatement,
           message("assign_constant", reference.getName()));
     }
     bindReference(reference);
@@ -205,7 +204,7 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
     ReferenceTable table = tableStack.peek();
     if (table == null) { return; }
     if (!table.hasReferenceFor(referenceLookup.getName())) {
-      errorMessage(UNDECLARED_REFERENCE, referenceLookup.getASTNode(),
+      errorMessage(UNDECLARED_REFERENCE, referenceLookup,
           message("undeclared_reference", referenceLookup.getName(),
           !functionStack.isEmpty()
             ? message("in_function", functionStack.peek().getName())
@@ -213,7 +212,7 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
     }
     LocalReference ref = referenceLookup.resolveIn(table);
     if (isUninitialized(ref)) {
-      errorMessage(UNINITIALIZED_REFERENCE_ACCESS, referenceLookup.getASTNode(),
+      errorMessage(UNINITIALIZED_REFERENCE_ACCESS, referenceLookup,
           message("uninitialized_reference_access", ref.getName()));
     }
   }
@@ -237,7 +236,7 @@ class LocalReferenceAssignmentAndVerificationVisitor extends AbstractGoloIrVisit
   @Override
   public void visitLoopBreakFlowStatement(LoopBreakFlowStatement loopBreakFlowStatement) {
     if (loopStack.isEmpty()) {
-      errorMessage(BREAK_OR_CONTINUE_OUTSIDE_LOOP, loopBreakFlowStatement.getASTNode(),
+      errorMessage(BREAK_OR_CONTINUE_OUTSIDE_LOOP, loopBreakFlowStatement,
           message("break_or_continue_outside_loop"));
     } else {
       loopBreakFlowStatement.setEnclosingLoop(loopStack.peek());

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -332,8 +332,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   @Override
   public Object visit(ASTContinue node, Object data) {
     Context context = (Context) data;
-    LoopBreakFlowStatement statement = LoopBreakFlowStatement.newContinue();
-    node.setIrElement(statement);
+    LoopBreakFlowStatement statement = LoopBreakFlowStatement.newContinue().ofAST(node);
     context.push(statement);
     return data;
   }
@@ -341,8 +340,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   @Override
   public Object visit(ASTBreak node, Object data) {
     Context context = (Context) data;
-    LoopBreakFlowStatement statement = LoopBreakFlowStatement.newBreak();
-    node.setIrElement(statement);
+    LoopBreakFlowStatement statement = LoopBreakFlowStatement.newBreak().ofAST(node);
     context.push(statement);
     return data;
   }
@@ -395,9 +393,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   @Override
   public Object visit(ASTLiteral node, Object data) {
     Context context = (Context) data;
-    ConstantStatement constantStatement = constant(node.getLiteralValue());
+    ConstantStatement constantStatement = constant(node.getLiteralValue()).ofAST(node);
     context.push(constantStatement);
-    node.setIrElement(constantStatement);
     return data;
   }
 
@@ -521,8 +518,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   @Override
   public Object visit(ASTBlock node, Object data) {
     Context context = (Context) data;
-    Block block = context.enterScope();
-    node.setIrElement(block);
+    Block block = context.enterScope().ofAST(node);
     if (context.peek() instanceof GoloFunction) {
       GoloFunction function = (GoloFunction) context.peek();
       function.block(block);
@@ -781,10 +777,9 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
         ((MethodInvocation) rOp.getLeftExpression()).setNullSafeGuarded(true);
       }
       left = (ExpressionStatement) context.pop();
-      right = current = binaryOperation(operator, left, right);
+      right = current = binaryOperation(operator, left, right).ofAST(node);
     }
     context.push(current);
-    node.setIrElement(current);
     return data;
   }
 
@@ -819,9 +814,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
         .map(OperatorType::fromString)
         .collect(Collectors.toList());
     List<ExpressionStatement> statements = operatorStatements(context, operators.size());
-    ExpressionStatement operation = assembleBinaryOperation(statements, operators);
+    ExpressionStatement operation = assembleBinaryOperation(statements, operators).ofAST(node);
     context.push(operation);
-    node.setIrElement(operation);
     return data;
   }
 
@@ -834,9 +828,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
         .map(OperatorType::fromString)
         .collect(Collectors.toList());
     List<ExpressionStatement> statements = operatorStatements(context, operators.size());
-    ExpressionStatement operation = assembleBinaryOperation(statements, operators);
+    ExpressionStatement operation = assembleBinaryOperation(statements, operators).ofAST(node);
     context.push(operation);
-    node.setIrElement(operation);
     return data;
   }
 
@@ -846,9 +839,9 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     node.childrenAccept(this, data);
     BinaryOperation operation = binaryOperation(node.getOperator())
       .right(context.pop())
-      .left(context.pop());
+      .left(context.pop())
+      .ofAST(node);
     context.push(operation);
-    node.setIrElement(operation);
     return data;
   }
 
@@ -858,9 +851,9 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     node.childrenAccept(this, data);
     BinaryOperation operation = binaryOperation(node.getOperator())
       .right(context.pop())
-      .left(context.pop());
+      .left(context.pop())
+      .ofAST(node);
     context.push(operation);
-    node.setIrElement(operation);
     return data;
   }
 
@@ -869,9 +862,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     Context context = (Context) data;
     node.childrenAccept(this, context);
     List<ExpressionStatement> statements = operatorStatements(context, node.count());
-    BinaryOperation operation = assembleBinaryOperation(statements, nCopies(node.count(), OperatorType.AND));
+    BinaryOperation operation = assembleBinaryOperation(statements, nCopies(node.count(), OperatorType.AND)).ofAST(node);
     context.push(operation);
-    node.setIrElement(operation);
     return data;
   }
 
@@ -880,9 +872,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     Context context = (Context) data;
     node.childrenAccept(this, context);
     List<ExpressionStatement> statements = operatorStatements(context, node.count());
-    BinaryOperation operation = assembleBinaryOperation(statements, nCopies(node.count(), OperatorType.OR));
+    BinaryOperation operation = assembleBinaryOperation(statements, nCopies(node.count(), OperatorType.OR)).ofAST(node);
     context.push(operation);
-    node.setIrElement(operation);
     return data;
   }
 
@@ -891,9 +882,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     Context context = (Context) data;
     node.childrenAccept(this, context);
     List<ExpressionStatement> statements = operatorStatements(context, node.count());
-    BinaryOperation operation = assembleBinaryOperation(statements, nCopies(node.count(), OperatorType.ORIFNULL));
+    BinaryOperation operation = assembleBinaryOperation(statements, nCopies(node.count(), OperatorType.ORIFNULL)).ofAST(node);
     context.push(operation);
-    node.setIrElement(operation);
     return data;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -109,7 +109,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     }
 
     public boolean checkExistingSubtype(GoloASTNode node, String name) {
-      GoloElement existing = module.getSubtypeByName(name);
+      GoloElement<?> existing = module.getSubtypeByName(name);
       if (existing != null) {
         errorMessage(AMBIGUOUS_DECLARATION, node,
             message("ambiguous_type_declaration",
@@ -183,7 +183,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
       getOrCreateExceptionBuilder().report(type, node, errorDescription(node.getPositionInSourceCode(), message));
     }
 
-    public void errorMessage(GoloCompilationException.Problem.Type type, GoloElement node, String message) {
+    public void errorMessage(GoloCompilationException.Problem.Type type, GoloElement<?> node, String message) {
       getOrCreateExceptionBuilder().report(type, node, errorDescription(node.positionInSourceCode(), message));
     }
   }
@@ -532,7 +532,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     for (int i = 0; i < node.jjtGetNumChildren(); i++) {
       GoloASTNode child = (GoloASTNode) node.jjtGetChild(i);
       child.jjtAccept(this, data);
-      GoloStatement statement = (GoloStatement) context.pop();
+      GoloStatement<?> statement = (GoloStatement) context.pop();
       block.addStatement(statement);
     }
     context.leaveScope();
@@ -556,7 +556,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   @Override
   public Object visit(ASTAnonymousFunctionInvocation node, Object data) {
     Context context = (Context) data;
-    ExpressionStatement result = visitAbstractInvocation(data, node, functionInvocation().constant(node.isConstant()));
+    ExpressionStatement<?> result = visitAbstractInvocation(data, node, functionInvocation().constant(node.isConstant()));
     if (node.isOnExpression()) {
       context.push(anonCall(context.pop(), result));
     } else {
@@ -565,7 +565,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     return data;
   }
 
-  private void checkNamedArgument(Context context, GoloASTNode node, AbstractInvocation invocation, ExpressionStatement statement) {
+  private void checkNamedArgument(Context context, GoloASTNode node, AbstractInvocation<?> invocation, ExpressionStatement<?> statement) {
     if (statement instanceof NamedArgument) {
       if (!invocation.namedArgumentsComplete()) {
         context.errorMessage(INCOMPLETE_NAMED_ARGUMENTS_USAGE, node,
@@ -576,7 +576,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     }
   }
 
-  private ExpressionStatement visitAbstractInvocation(Object data, GoloASTNode node, AbstractInvocation invocation) {
+  private ExpressionStatement<?> visitAbstractInvocation(Object data, GoloASTNode node, AbstractInvocation<?> invocation) {
     Context context = (Context) data;
     invocation.ofAST(node);
     int i = 0;
@@ -591,7 +591,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
       checkNamedArgument(context, node, invocation, statement);
       invocation.withArgs(statement);
     }
-    ExpressionStatement result = invocation;
+    ExpressionStatement<?> result = invocation;
     if (i < numChildren) {
       for (; i < numChildren; i++) {
         node.jjtGetChild(i).jjtAccept(this, context);
@@ -763,8 +763,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     Context context = (Context) data;
     node.childrenAccept(this, context);
     BinaryOperation current = null;
-    ExpressionStatement left;
-    ExpressionStatement right = null;
+    ExpressionStatement<?> left;
+    ExpressionStatement<?> right = null;
     List<String> operators = node.getOperators();
     Collections.reverse(operators);
     for (String symbol : operators) {
@@ -785,7 +785,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     return data;
   }
 
-  private BinaryOperation assembleBinaryOperation(List<ExpressionStatement> statements, List<OperatorType> operators) {
+  private BinaryOperation assembleBinaryOperation(List<ExpressionStatement<?>> statements, List<OperatorType> operators) {
     BinaryOperation current = null;
     int i = 2;
     for (OperatorType operator : operators) {
@@ -799,8 +799,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     return current;
   }
 
-  private List<ExpressionStatement> operatorStatements(Context context, int operatorsCount) {
-    LinkedList<ExpressionStatement> statements = new LinkedList<>();
+  private List<ExpressionStatement<?>> operatorStatements(Context context, int operatorsCount) {
+    LinkedList<ExpressionStatement<?>> statements = new LinkedList<>();
     for (int i = 0; i < operatorsCount + 1; i++) {
       statements.addFirst((ExpressionStatement) context.pop());
     }
@@ -815,8 +815,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
         .stream()
         .map(OperatorType::fromString)
         .collect(Collectors.toList());
-    List<ExpressionStatement> statements = operatorStatements(context, operators.size());
-    ExpressionStatement operation = assembleBinaryOperation(statements, operators).ofAST(node);
+    List<ExpressionStatement<?>> statements = operatorStatements(context, operators.size());
+    ExpressionStatement<?> operation = assembleBinaryOperation(statements, operators).ofAST(node);
     context.push(operation);
     return data;
   }
@@ -829,8 +829,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
         .stream()
         .map(OperatorType::fromString)
         .collect(Collectors.toList());
-    List<ExpressionStatement> statements = operatorStatements(context, operators.size());
-    ExpressionStatement operation = assembleBinaryOperation(statements, operators).ofAST(node);
+    List<ExpressionStatement<?>> statements = operatorStatements(context, operators.size());
+    ExpressionStatement<?> operation = assembleBinaryOperation(statements, operators).ofAST(node);
     context.push(operation);
     return data;
   }
@@ -863,7 +863,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   public Object visit(ASTAndExpression node, Object data) {
     Context context = (Context) data;
     node.childrenAccept(this, context);
-    List<ExpressionStatement> statements = operatorStatements(context, node.count());
+    List<ExpressionStatement<?>> statements = operatorStatements(context, node.count());
     BinaryOperation operation = assembleBinaryOperation(statements, nCopies(node.count(), OperatorType.AND)).ofAST(node);
     context.push(operation);
     return data;
@@ -873,7 +873,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   public Object visit(ASTOrExpression node, Object data) {
     Context context = (Context) data;
     node.childrenAccept(this, context);
-    List<ExpressionStatement> statements = operatorStatements(context, node.count());
+    List<ExpressionStatement<?>> statements = operatorStatements(context, node.count());
     BinaryOperation operation = assembleBinaryOperation(statements, nCopies(node.count(), OperatorType.OR)).ofAST(node);
     context.push(operation);
     return data;
@@ -883,7 +883,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   public Object visit(ASTOrIfNullExpression node, Object data) {
     Context context = (Context) data;
     node.childrenAccept(this, context);
-    List<ExpressionStatement> statements = operatorStatements(context, node.count());
+    List<ExpressionStatement<?>> statements = operatorStatements(context, node.count());
     BinaryOperation operation = assembleBinaryOperation(statements, nCopies(node.count(), OperatorType.ORIFNULL)).ofAST(node);
     context.push(operation);
     return data;

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -179,8 +179,8 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
                               GoloASTNode node,
                               String message) {
       String errorMessage = message + ' ' + message("source_position",
-          node.getPositionInSourceCode().getLine(),
-          node.getPositionInSourceCode().getColumn());
+          node.getPositionInSourceCode().getStartLine(),
+          node.getPositionInSourceCode().getStartColumn());
       getOrCreateExceptionBuilder().report(type, node, errorMessage);
     }
 

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -587,7 +587,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
         break;
       }
       argumentNode.jjtAccept(this, context);
-      ExpressionStatement statement = (ExpressionStatement) context.pop();
+      ExpressionStatement<?> statement = ExpressionStatement.of(context.pop());
       checkNamedArgument(context, node, invocation, statement);
       invocation.withArgs(statement);
     }
@@ -770,7 +770,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     for (String symbol : operators) {
       OperatorType operator = OperatorType.fromString(symbol);
       if (right == null) {
-        right = (ExpressionStatement) context.pop();
+        right = ExpressionStatement.of(context.pop());
         if (operator == OperatorType.ELVIS_METHOD_CALL) {
           ((MethodInvocation) right).setNullSafeGuarded(true);
         }
@@ -802,7 +802,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
   private List<ExpressionStatement<?>> operatorStatements(Context context, int operatorsCount) {
     LinkedList<ExpressionStatement<?>> statements = new LinkedList<>();
     for (int i = 0; i < operatorsCount + 1; i++) {
-      statements.addFirst((ExpressionStatement) context.pop());
+      statements.addFirst(ExpressionStatement.of(context.pop()));
     }
     return statements;
   }

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -651,7 +651,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
     node.jjtGetChild(0).jjtAccept(this, data);
     context.push(
       whileLoop(context.pop()).ofAST(node)
-        .block((Block) context.pop()));
+        .block(Block.of(context.pop())));
     return data;
   }
 
@@ -671,7 +671,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
 
     if (node.jjtGetNumChildren() == 4) {
       node.jjtGetChild(3).jjtAccept(this, data);
-      loopStatement.block((Block) context.pop());
+      loopStatement.block(Block.of(context.pop()));
     }
     context.push(block.add(loopStatement));
     context.leaveScope();

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -100,10 +100,10 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
             firstDeclaration = f;
           }
         }
-        errorMessage(AMBIGUOUS_DECLARATION, function.getASTNode(),
+        errorMessage(AMBIGUOUS_DECLARATION, function,
             message("ambiguous_function_declaration",
                 function.getName(),
-                firstDeclaration == null ? "unknown" : firstDeclaration.getASTNode().getPositionInSourceCode()));
+                firstDeclaration == null ? "unknown" : firstDeclaration.positionInSourceCode()));
       }
       container.addFunction(function);
     }
@@ -113,7 +113,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
       if (existing != null) {
         errorMessage(AMBIGUOUS_DECLARATION, node,
             message("ambiguous_type_declaration",
-                name, existing.getASTNode().getPositionInSourceCode()));
+                name, existing.positionInSourceCode()));
         return true;
       }
       return false;
@@ -175,15 +175,17 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
       return exceptionBuilder;
     }
 
-    public void errorMessage(GoloCompilationException.Problem.Type type,
-                              GoloASTNode node,
-                              String message) {
-      String errorMessage = message + ' ' + message("source_position",
-          node.getPositionInSourceCode().getStartLine(),
-          node.getPositionInSourceCode().getStartColumn());
-      getOrCreateExceptionBuilder().report(type, node, errorMessage);
+    private String errorDescription(PositionInSourceCode position, String message) {
+      return message + ' ' + message("source_position", position.getStartLine(), position.getStartColumn());
     }
 
+    public void errorMessage(GoloCompilationException.Problem.Type type, GoloASTNode node, String message) {
+      getOrCreateExceptionBuilder().report(type, node, errorDescription(node.getPositionInSourceCode(), message));
+    }
+
+    public void errorMessage(GoloCompilationException.Problem.Type type, GoloElement node, String message) {
+      getOrCreateExceptionBuilder().report(type, node, errorDescription(node.positionInSourceCode(), message));
+    }
   }
 
   public GoloModule transform(ASTCompilationUnit compilationUnit, GoloCompilationException.Builder builder) {

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -127,8 +127,13 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
     LocalReference tempVar = localRef(symbols.next("match"))
       .variable()
       .synthetic();
-    CaseStatement caseStatement = cases().ofAST(matchExpression.getASTNode())
-      .otherwise(block(assign(matchExpression.getOtherwise()).to(tempVar)));
+    CaseStatement caseStatement = cases()
+      .documentation(matchExpression.documentation())
+      .positionInSourceCode(matchExpression.positionInSourceCode())
+      .otherwise(block(
+            assign(matchExpression.getOtherwise())
+            .to(tempVar)
+            .positionInSourceCode(matchExpression.getOtherwise().positionInSourceCode())));
 
     for (WhenClause<ExpressionStatement> c : matchExpression.getClauses()) {
       caseStatement.when(c.condition())

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -50,8 +50,8 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
     function.insertMissingReturnStatement();
     if (!expressionToBlock(function)) {
       function.walk(this);
-      if (function.hasDecorators() && function.getParentNode().isPresent()) {
-        FunctionContainer parent = (FunctionContainer) function.getParentNode().get();
+      if (function.hasDecorators() && function.hasParent()) {
+        FunctionContainer parent = (FunctionContainer) function.parent();
         GoloFunction decorator = function.createDecorator();
         parent.addFunction(decorator);
         decorator.accept(this);
@@ -145,7 +145,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
         .positionInSourceCode(c.positionInSourceCode());
     }
     Block block = block();
-    for (GoloAssignment a : matchExpression.declarations()) {
+    for (GoloAssignment<?> a : matchExpression.declarations()) {
       block.add(a);
     }
     matchExpression.clearDeclarations();
@@ -218,7 +218,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
       .variable()
       .synthetic();
     Block mainBlock = block();
-    for (GoloAssignment a : collection.declarations()) {
+    for (GoloAssignment<?> a : collection.declarations()) {
       mainBlock.add(a);
     }
     collection.clearDeclarations();
@@ -397,7 +397,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
     Block b = Builders.block((Object[]) expr.declarations());
     expr.replaceInParentBy(b);
     expr.clearDeclarations();
-    LocalReference  r = Builders.localRef(symbols.next("localdec")).synthetic();
+    LocalReference r = Builders.localRef(symbols.next("localdec")).synthetic();
     b.add(Builders.define(r).as(expr));
     b.add(r.lookup());
     b.accept(this);

--- a/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/SugarExpansionVisitor.java
@@ -135,7 +135,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
             .to(tempVar)
             .positionInSourceCode(matchExpression.getOtherwise().positionInSourceCode())));
 
-    for (WhenClause<ExpressionStatement> c : matchExpression.getClauses()) {
+    for (WhenClause<ExpressionStatement<?>> c : matchExpression.getClauses()) {
       caseStatement.when(c.condition())
         .then(block(assign(c.action()).to(tempVar)));
     }
@@ -160,7 +160,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
   public void visitCollectionLiteral(CollectionLiteral collection) {
     if (!expressionToBlock(collection)) {
       collection.walk(this);
-      AbstractInvocation construct = call("gololang.Predefined." + collection.getType().toString())
+      AbstractInvocation<?> construct = call("gololang.Predefined." + collection.getType().toString())
         .withArgs(collection.getExpressions().toArray());
       collection.replaceInParentBy(construct);
       construct.accept(this);
@@ -173,7 +173,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
     Object value = constantStatement.getValue();
     if (value instanceof GoloParser.FunctionRef) {
       GoloParser.FunctionRef ref = (GoloParser.FunctionRef) value;
-      AbstractInvocation fun = call("gololang.Predefined.fun").constant()
+      AbstractInvocation<?> fun = call("gololang.Predefined.fun").constant()
         .withArgs(
             constant(ref.name),
             classRef(ref.module == null
@@ -221,7 +221,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
     Block innerBlock = mainBlock;
     for (Block loop : collection.getLoopBlocks()) {
       innerBlock.addStatement(loop);
-      GoloStatement loopStatement = loop.getStatements().get(0);
+      GoloStatement<?> loopStatement = loop.getStatements().get(0);
       innerBlock = ((BlockContainer) loopStatement).getBlock();
     }
     innerBlock.addStatement(
@@ -374,7 +374,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
     visitExpression(invoke);
   }
 
-  private void visitExpression(ExpressionStatement expr) {
+  private void visitExpression(ExpressionStatement<?> expr) {
     if (!expressionToBlock(expr)) {
       expr.walk(this);
     }
@@ -383,7 +383,7 @@ class SugarExpansionVisitor extends AbstractGoloIrVisitor {
   /**
    * Convert an expression with local declarations into a block.
    */
-  private boolean expressionToBlock(ExpressionStatement expr) {
+  private boolean expressionToBlock(ExpressionStatement<?> expr) {
     // TODO: make TCO aware expansion? (or wait for a more general optimization pass)
     if (!expr.hasLocalDeclarations()) {
       return false;

--- a/src/main/java/org/eclipse/golo/compiler/ir/AbstractInvocation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/AbstractInvocation.java
@@ -14,10 +14,10 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-public abstract class AbstractInvocation extends ExpressionStatement {
+public abstract class AbstractInvocation<T extends AbstractInvocation<T>> extends ExpressionStatement<T> {
 
   private final String name;
-  private final List<ExpressionStatement> arguments = new LinkedList<>();
+  private final List<ExpressionStatement<?>> arguments = new LinkedList<>();
   protected boolean usesNamedArguments = false;
 
   AbstractInvocation(String name) {
@@ -29,19 +29,19 @@ public abstract class AbstractInvocation extends ExpressionStatement {
     return name;
   }
 
-  private void addArgument(ExpressionStatement argument) {
+  private void addArgument(ExpressionStatement<?> argument) {
     arguments.add(argument);
     makeParentOf(argument);
   }
 
-  public AbstractInvocation withArgs(Object... arguments) {
+  public T withArgs(Object... arguments) {
     for (Object argument : arguments) {
       addArgument(ExpressionStatement.of(argument));
     }
-    return this;
+    return self();
   }
 
-  public List<ExpressionStatement> getArguments() {
+  public List<ExpressionStatement<?>> getArguments() {
     return Collections.unmodifiableList(arguments);
   }
 
@@ -57,9 +57,9 @@ public abstract class AbstractInvocation extends ExpressionStatement {
     return this.arguments.isEmpty() || this.usesNamedArguments;
   }
 
-  public AbstractInvocation withNamedArguments() {
+  public T withNamedArguments() {
     setUsesNamedArguments(true);
-    return this;
+    return self();
   }
 
   private void setUsesNamedArguments(boolean usesNamedArguments) {
@@ -68,13 +68,13 @@ public abstract class AbstractInvocation extends ExpressionStatement {
 
   @Override
   public void walk(GoloIrVisitor visitor) {
-    for (ExpressionStatement arg : arguments) {
+    for (ExpressionStatement<?> arg : arguments) {
       arg.accept(visitor);
     }
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (newElement instanceof ExpressionStatement && arguments.contains(original)) {
       this.arguments.set(arguments.indexOf((ExpressionStatement) original),
           (ExpressionStatement) newElement);

--- a/src/main/java/org/eclipse/golo/compiler/ir/AbstractInvocation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/AbstractInvocation.java
@@ -76,8 +76,8 @@ public abstract class AbstractInvocation<T extends AbstractInvocation<T>> extend
   @Override
   protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (newElement instanceof ExpressionStatement && arguments.contains(original)) {
-      this.arguments.set(arguments.indexOf((ExpressionStatement) original),
-          (ExpressionStatement) newElement);
+      this.arguments.set(arguments.indexOf(ExpressionStatement.of(original)),
+          ExpressionStatement.of(newElement));
     } else {
       throw cantReplace(original, newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/AbstractInvocation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/AbstractInvocation.java
@@ -30,8 +30,7 @@ public abstract class AbstractInvocation<T extends AbstractInvocation<T>> extend
   }
 
   private void addArgument(ExpressionStatement<?> argument) {
-    arguments.add(argument);
-    makeParentOf(argument);
+    arguments.add(makeParentOf(argument));
   }
 
   public T withArgs(Object... arguments) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/Alternatives.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Alternatives.java
@@ -12,7 +12,7 @@ package org.eclipse.golo.compiler.ir;
 
 import java.util.List;
 
-public interface Alternatives<T extends GoloElement> {
+public interface Alternatives<T extends GoloElement<?>> {
   Alternatives<T> when(Object cond);
 
   Alternatives<T> then(Object action);

--- a/src/main/java/org/eclipse/golo/compiler/ir/AssignmentStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/AssignmentStatement.java
@@ -49,8 +49,7 @@ public final class AssignmentStatement extends GoloAssignment<AssignmentStatemen
     if (refs.length != 1 || refs[0] == null) {
       throw new IllegalArgumentException("Must assign to one reference");
     }
-    localReference = (LocalReference) refs[0];
-    makeParentOf(localReference);
+    this.localReference = makeParentOf((LocalReference) refs[0]);
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/AssignmentStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/AssignmentStatement.java
@@ -10,33 +10,13 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
-
-public final class AssignmentStatement extends GoloAssignment {
+public final class AssignmentStatement extends GoloAssignment<AssignmentStatement> {
 
   private LocalReference localReference;
 
   AssignmentStatement() { super(); }
 
-  /**
-   * @inheritDoc
-   */
-  @Override
-  public AssignmentStatement ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
-
-  @Override
-  public AssignmentStatement declaring() {
-    return this.declaring(true);
-  }
-
-  @Override
-  public AssignmentStatement declaring(boolean isDeclaring) {
-    super.declaring(isDeclaring);
-    return this;
-  }
+  protected AssignmentStatement self() { return this; }
 
   public LocalReference getLocalReference() {
     return localReference;
@@ -74,15 +54,6 @@ public final class AssignmentStatement extends GoloAssignment {
     return this;
   }
 
-  /**
-   * @inheritDoc
-   */
-  @Override
-  public AssignmentStatement as(Object expr) {
-    super.as(expr);
-    return this;
-  }
-
   @Override
   public String toString() {
     return String.format("%s = %s", localReference, getExpressionStatement().toString());
@@ -94,14 +65,6 @@ public final class AssignmentStatement extends GoloAssignment {
   @Override
   public void accept(GoloIrVisitor visitor) {
     visitor.visitAssignmentStatement(this);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  @Override
-  public void walk(GoloIrVisitor visitor) {
-    super.walk(visitor);
   }
 
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/Augmentation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Augmentation.java
@@ -16,7 +16,6 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 
 import org.eclipse.golo.compiler.PackageAndClass;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
 import static java.util.Collections.unmodifiableSet;
 
@@ -37,7 +36,7 @@ import static java.util.Collections.unmodifiableSet;
  * augment MyType with MyAugmentation
  * </code></pre>
  */
-public final class Augmentation extends GoloElement implements FunctionContainer {
+public final class Augmentation extends GoloElement<Augmentation> implements FunctionContainer {
   private PackageAndClass target;
   private final Set<GoloFunction> functions = new LinkedHashSet<>();
   private final Set<String> names = new LinkedHashSet<>();
@@ -47,11 +46,7 @@ public final class Augmentation extends GoloElement implements FunctionContainer
     this.target = target;
   }
 
-  @Override
-  public Augmentation ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected Augmentation self() { return this; }
 
   public PackageAndClass getTarget() {
     return target;
@@ -127,7 +122,7 @@ public final class Augmentation extends GoloElement implements FunctionContainer
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (functions.contains(original) && newElement instanceof GoloFunction) {
       functions.remove((GoloFunction) original);
       functions.add((GoloFunction) newElement);

--- a/src/main/java/org/eclipse/golo/compiler/ir/Augmentation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Augmentation.java
@@ -67,8 +67,7 @@ public final class Augmentation extends GoloElement<Augmentation> implements Fun
 
   @Override
   public void addFunction(GoloFunction func) {
-    functions.add(func);
-    makeParentOf(func);
+    functions.add(makeParentOf(func));
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
@@ -44,13 +44,13 @@ public final class BinaryOperation extends ExpressionStatement<BinaryOperation> 
   }
 
   public BinaryOperation left(Object expr) {
-    leftExpression = (ExpressionStatement) expr;
+    leftExpression = ExpressionStatement.of(expr);
     makeParentOf(leftExpression);
     return this;
   }
 
   public BinaryOperation right(Object expr) {
-    rightExpression = (ExpressionStatement) expr;
+    rightExpression = ExpressionStatement.of(expr);
     makeParentOf(rightExpression);
     return this;
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
@@ -11,12 +11,12 @@
 package org.eclipse.golo.compiler.ir;
 
 import org.eclipse.golo.runtime.OperatorType;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
-public final class BinaryOperation extends ExpressionStatement {
+public final class BinaryOperation extends ExpressionStatement<BinaryOperation> {
+
   private final OperatorType type;
-  private ExpressionStatement leftExpression;
-  private ExpressionStatement rightExpression;
+  private ExpressionStatement<?> leftExpression;
+  private ExpressionStatement<?> rightExpression;
 
   BinaryOperation(OperatorType type) {
     super();
@@ -33,17 +33,13 @@ public final class BinaryOperation extends ExpressionStatement {
     throw cantConvert("BinaryOperation", type);
   }
 
-  @Override
-  public BinaryOperation ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected BinaryOperation self() { return this; }
 
   public OperatorType getType() {
     return type;
   }
 
-  public ExpressionStatement getLeftExpression() {
+  public ExpressionStatement<?> getLeftExpression() {
     return leftExpression;
   }
 
@@ -59,7 +55,7 @@ public final class BinaryOperation extends ExpressionStatement {
     return this;
   }
 
-  public ExpressionStatement getRightExpression() {
+  public ExpressionStatement<?> getRightExpression() {
     return rightExpression;
   }
 
@@ -86,7 +82,7 @@ public final class BinaryOperation extends ExpressionStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (!(newElement instanceof ExpressionStatement)) {
       throw cantConvert("ExpressionStatement", newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
@@ -11,6 +11,7 @@
 package org.eclipse.golo.compiler.ir;
 
 import org.eclipse.golo.runtime.OperatorType;
+import org.eclipse.golo.compiler.parser.GoloASTNode;
 
 public final class BinaryOperation extends ExpressionStatement {
   private final OperatorType type;
@@ -30,6 +31,12 @@ public final class BinaryOperation extends ExpressionStatement {
       return new BinaryOperation(OperatorType.fromString((String) type));
     }
     throw cantConvert("BinaryOperation", type);
+  }
+
+  @Override
+  public BinaryOperation ofAST(GoloASTNode node) {
+    super.ofAST(node);
+    return this;
   }
 
   public OperatorType getType() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
@@ -44,14 +44,12 @@ public final class BinaryOperation extends ExpressionStatement<BinaryOperation> 
   }
 
   public BinaryOperation left(Object expr) {
-    leftExpression = ExpressionStatement.of(expr);
-    makeParentOf(leftExpression);
+    this.leftExpression = makeParentOf(ExpressionStatement.of(expr));
     return this;
   }
 
   public BinaryOperation right(Object expr) {
-    rightExpression = ExpressionStatement.of(expr);
-    makeParentOf(rightExpression);
+    this.rightExpression = makeParentOf(ExpressionStatement.of(expr));
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/Block.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Block.java
@@ -42,6 +42,9 @@ public final class Block extends ExpressionStatement<Block> {
     if (block instanceof Block) {
       return (Block) block;
     }
+    if (block instanceof GoloStatement<?>) {
+      return emptyBlock().add(block);
+    }
     throw cantConvert("Block", block);
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
@@ -307,14 +307,6 @@ public final class Builders {
     throw cantConvert(statement, "GoloStatement");
   }
 
-  public static Block toBlock(Object block) {
-    if (block == null) { return Block.emptyBlock(); }
-    if (block instanceof Block) {
-      return (Block) block;
-    }
-    throw cantConvert(block, "Block");
-  }
-
   private static IllegalArgumentException cantConvert(Object value, String target) {
     return new IllegalArgumentException(
         String.format("%s is not a %s, but a %s",

--- a/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
@@ -98,7 +98,7 @@ public final class Builders {
   }
 
   public static Decorator decorator(Object expr) {
-    return new Decorator((ExpressionStatement) expr);
+    return new Decorator(ExpressionStatement.of(expr));
   }
 
   public static GoloFunction functionDeclaration() {
@@ -129,7 +129,7 @@ public final class Builders {
   public static BinaryOperation anonCall(Object receiver, Object invocation) {
     return binaryOperation(
         OperatorType.ANON_CALL,
-        (ExpressionStatement) receiver,
+        ExpressionStatement.of(receiver),
         (FunctionInvocation) invocation);
   }
 
@@ -196,11 +196,11 @@ public final class Builders {
   }
 
   public static ReturnStatement returns(Object expr) {
-    return new ReturnStatement((ExpressionStatement) expr);
+    return new ReturnStatement(ExpressionStatement.of(expr));
   }
 
   public static ThrowStatement raise(Object expression) {
-    return new ThrowStatement((ExpressionStatement) expression);
+    return new ThrowStatement(ExpressionStatement.of(expression));
   }
 
   public static LocalReference localRef(Object name) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Builders.java
@@ -85,7 +85,7 @@ public final class Builders {
     return new DestructuringAssignment();
   }
 
-  public static UnaryOperation not(ExpressionStatement expression) {
+  public static UnaryOperation not(ExpressionStatement<?> expression) {
     return new UnaryOperation(OperatorType.NOT, expression);
   }
 
@@ -299,10 +299,10 @@ public final class Builders {
     return new TryCatchFinally(exceptionId);
   }
 
-  public static GoloStatement toGoloStatement(Object statement) {
+  public static GoloStatement<?> toGoloStatement(Object statement) {
     if (statement == null) { return null; }
     if (statement instanceof GoloStatement) {
-      return (GoloStatement) statement;
+      return (GoloStatement<?>) statement;
     }
     throw cantConvert(statement, "GoloStatement");
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
@@ -32,12 +32,12 @@ public final class CaseStatement extends GoloStatement<CaseStatement> implements
   }
 
   public CaseStatement then(Object action) {
-    this.clauses.getLast().setAction((Block) action);
+    this.clauses.getLast().setAction(Block.of(action));
     return this;
   }
 
   public CaseStatement otherwise(Object action) {
-    this.otherwise = makeParentOf((Block) action);
+    this.otherwise = makeParentOf(Block.of(action));
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
@@ -27,7 +27,7 @@ public final class CaseStatement extends GoloStatement<CaseStatement> implements
   protected CaseStatement self() { return this; }
 
   public CaseStatement when(Object cond) {
-    WhenClause<Block> clause = new WhenClause<Block>((ExpressionStatement) cond, null);
+    WhenClause<Block> clause = new WhenClause<Block>(ExpressionStatement.of(cond), null);
     this.clauses.add(clause);
     makeParentOf(clause);
     return this;

--- a/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
@@ -27,9 +27,7 @@ public final class CaseStatement extends GoloStatement<CaseStatement> implements
   protected CaseStatement self() { return this; }
 
   public CaseStatement when(Object cond) {
-    WhenClause<Block> clause = new WhenClause<Block>(ExpressionStatement.of(cond), null);
-    this.clauses.add(clause);
-    makeParentOf(clause);
+    this.clauses.add(makeParentOf(new WhenClause<Block>(ExpressionStatement.of(cond), null)));
     return this;
   }
 
@@ -39,8 +37,7 @@ public final class CaseStatement extends GoloStatement<CaseStatement> implements
   }
 
   public CaseStatement otherwise(Object action) {
-    otherwise = (Block) action;
-    makeParentOf(otherwise);
+    this.otherwise = makeParentOf((Block) action);
     return this;
   }
 
@@ -77,8 +74,7 @@ public final class CaseStatement extends GoloStatement<CaseStatement> implements
     if (clauses.contains(original)) {
       @SuppressWarnings("unchecked")
       WhenClause<Block> when = (WhenClause<Block>) newElement;
-      clauses.set(clauses.indexOf(original), when);
-      makeParentOf(when);
+      clauses.set(clauses.indexOf(original), makeParentOf(when));
       return;
     }
     throw doesNotContain(original);

--- a/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
@@ -14,9 +14,8 @@ import java.util.List;
 import java.util.LinkedList;
 
 import static java.util.Collections.unmodifiableList;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
-public final class CaseStatement extends GoloStatement implements Alternatives<Block> {
+public final class CaseStatement extends GoloStatement<CaseStatement> implements Alternatives<Block> {
 
   private Block otherwise;
   private final LinkedList<WhenClause<Block>> clauses = new LinkedList<>();
@@ -24,6 +23,8 @@ public final class CaseStatement extends GoloStatement implements Alternatives<B
   CaseStatement() {
     super();
   }
+
+  protected CaseStatement self() { return this; }
 
   public CaseStatement when(Object cond) {
     WhenClause<Block> clause = new WhenClause<Block>((ExpressionStatement) cond, null);
@@ -52,24 +53,6 @@ public final class CaseStatement extends GoloStatement implements Alternatives<B
   }
 
   @Override
-  public CaseStatement documentation(String doc) {
-    super.documentation(doc);
-    return this;
-  }
-
-  @Override
-  public CaseStatement positionInSourceCode(PositionInSourceCode pos) {
-    super.positionInSourceCode(pos);
-    return this;
-  }
-
-  @Override
-  public CaseStatement ofAST(GoloASTNode n) {
-    super.ofAST(n);
-    return this;
-  }
-
-  @Override
   public void accept(GoloIrVisitor visitor) {
     visitor.visitCaseStatement(this);
   }
@@ -83,7 +66,7 @@ public final class CaseStatement extends GoloStatement implements Alternatives<B
   }
 
   @Override
-  public void replaceElement(GoloElement original, GoloElement newElement) {
+  public void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (!(newElement instanceof Block || newElement instanceof WhenClause)) {
       throw cantConvert("Block or WhenClause", newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CaseStatement.java
@@ -52,6 +52,18 @@ public final class CaseStatement extends GoloStatement implements Alternatives<B
   }
 
   @Override
+  public CaseStatement documentation(String doc) {
+    super.documentation(doc);
+    return this;
+  }
+
+  @Override
+  public CaseStatement positionInSourceCode(PositionInSourceCode pos) {
+    super.positionInSourceCode(pos);
+    return this;
+  }
+
+  @Override
   public CaseStatement ofAST(GoloASTNode n) {
     super.ofAST(n);
     return this;

--- a/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
@@ -31,7 +31,7 @@ public class ClosureReference extends ExpressionStatement {
   private void setTarget(GoloFunction target) {
     this.target = target;
     makeParentOf(target);
-    this.setASTNode(target.getASTNode());
+    this.ofAST(target.getASTNode());
     updateCapturedReferenceNames();
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
@@ -31,7 +31,8 @@ public class ClosureReference extends ExpressionStatement {
   private void setTarget(GoloFunction target) {
     this.target = target;
     makeParentOf(target);
-    this.ofAST(target.getASTNode());
+    this.positionInSourceCode(target.positionInSourceCode());
+    this.documentation(target.documentation());
     updateCapturedReferenceNames();
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
@@ -14,7 +14,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.Collections;
 
-public class ClosureReference extends ExpressionStatement {
+public class ClosureReference extends ExpressionStatement<ClosureReference> {
 
   private GoloFunction target;
   private final Set<String> capturedReferenceNames = new LinkedHashSet<>();
@@ -23,6 +23,8 @@ public class ClosureReference extends ExpressionStatement {
     super();
     setTarget(target);
   }
+
+  protected ClosureReference self() { return this; }
 
   public GoloFunction getTarget() {
     return target;
@@ -67,7 +69,7 @@ public class ClosureReference extends ExpressionStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (newElement instanceof GoloFunction && target.equals(original)) {
       setTarget((GoloFunction) newElement);
     } else {

--- a/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ClosureReference.java
@@ -31,8 +31,7 @@ public class ClosureReference extends ExpressionStatement<ClosureReference> {
   }
 
   private void setTarget(GoloFunction target) {
-    this.target = target;
-    makeParentOf(target);
+    this.target = makeParentOf(target);
     this.positionInSourceCode(target.positionInSourceCode());
     this.documentation(target.documentation());
     updateCapturedReferenceNames();

--- a/src/main/java/org/eclipse/golo/compiler/ir/CollectionComprehension.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CollectionComprehension.java
@@ -12,14 +12,13 @@ package org.eclipse.golo.compiler.ir;
 
 import java.util.List;
 import java.util.LinkedList;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
 import static java.util.Collections.unmodifiableList;
 
-public class CollectionComprehension extends ExpressionStatement {
+public class CollectionComprehension extends ExpressionStatement<CollectionComprehension> {
 
   private final CollectionLiteral.Type type;
-  private ExpressionStatement expression;
+  private ExpressionStatement<?> expression;
   private final List<Block> loopBlocks = new LinkedList<>();
 
   CollectionComprehension(CollectionLiteral.Type type) {
@@ -27,11 +26,7 @@ public class CollectionComprehension extends ExpressionStatement {
     this.type = type;
   }
 
-  @Override
-  public CollectionComprehension ofAST(GoloASTNode n) {
-    super.ofAST(n);
-    return this;
-  }
+  protected CollectionComprehension self() { return this; }
 
   public CollectionComprehension expression(Object expression) {
     this.expression = (ExpressionStatement) expression;
@@ -46,7 +41,7 @@ public class CollectionComprehension extends ExpressionStatement {
     return this;
   }
 
-  public ExpressionStatement getExpression() {
+  public ExpressionStatement<?> getExpression() {
     return this.expression;
   }
 
@@ -79,7 +74,7 @@ public class CollectionComprehension extends ExpressionStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (expression == original && newElement instanceof ExpressionStatement) {
       expression(newElement);
     } else if (newElement instanceof Block && loopBlocks.contains(original)) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/CollectionComprehension.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CollectionComprehension.java
@@ -29,7 +29,7 @@ public class CollectionComprehension extends ExpressionStatement<CollectionCompr
   protected CollectionComprehension self() { return this; }
 
   public CollectionComprehension expression(Object expression) {
-    this.expression = (ExpressionStatement) expression;
+    this.expression = ExpressionStatement.of(expression);
     makeParentOf(this.expression);
     return this;
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/CollectionComprehension.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CollectionComprehension.java
@@ -75,7 +75,7 @@ public class CollectionComprehension extends ExpressionStatement<CollectionCompr
     if (expression == original && newElement instanceof ExpressionStatement) {
       expression(newElement);
     } else if (newElement instanceof Block && loopBlocks.contains(original)) {
-      loopBlocks.set(loopBlocks.indexOf(original), (Block) newElement);
+      loopBlocks.set(loopBlocks.indexOf(original), Block.of(newElement));
     } else {
       throw cantReplace(original, newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/CollectionComprehension.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CollectionComprehension.java
@@ -29,15 +29,12 @@ public class CollectionComprehension extends ExpressionStatement<CollectionCompr
   protected CollectionComprehension self() { return this; }
 
   public CollectionComprehension expression(Object expression) {
-    this.expression = ExpressionStatement.of(expression);
-    makeParentOf(this.expression);
+    this.expression = makeParentOf(ExpressionStatement.of(expression));
     return this;
   }
 
   public CollectionComprehension loop(Object b) {
-    Block theBlock = Block.of(b);
-    this.loopBlocks.add(theBlock);
-    makeParentOf(theBlock);
+    this.loopBlocks.add(makeParentOf(Block.of(b)));
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/CollectionLiteral.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CollectionLiteral.java
@@ -30,9 +30,7 @@ public final class CollectionLiteral extends ExpressionStatement<CollectionLiter
   protected CollectionLiteral self() { return this; }
 
   public CollectionLiteral add(Object expression) {
-    ExpressionStatement<?> expr = ExpressionStatement.of(expression);
-    this.expressions.add(expr);
-    makeParentOf(expr);
+    this.expressions.add(makeParentOf(ExpressionStatement.of(expression)));
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/CollectionLiteral.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CollectionLiteral.java
@@ -12,30 +12,25 @@ package org.eclipse.golo.compiler.ir;
 
 import java.util.List;
 import java.util.LinkedList;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
-public final class CollectionLiteral extends ExpressionStatement {
+public final class CollectionLiteral extends ExpressionStatement<CollectionLiteral> {
 
   public static enum Type {
     array, list, set, map, tuple, vector, range
   }
 
   private final Type type;
-  private final List<ExpressionStatement> expressions = new LinkedList<>();
+  private final List<ExpressionStatement<?>> expressions = new LinkedList<>();
 
   CollectionLiteral(Type type) {
     super();
     this.type = type;
   }
 
-  @Override
-  public CollectionLiteral ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected CollectionLiteral self() { return this; }
 
   public CollectionLiteral add(Object expression) {
-    ExpressionStatement expr = ExpressionStatement.of(expression);
+    ExpressionStatement<?> expr = ExpressionStatement.of(expression);
     this.expressions.add(expr);
     makeParentOf(expr);
     return this;
@@ -45,7 +40,7 @@ public final class CollectionLiteral extends ExpressionStatement {
     return type;
   }
 
-  public List<ExpressionStatement> getExpressions() {
+  public List<ExpressionStatement<?>> getExpressions() {
     return expressions;
   }
 
@@ -61,13 +56,13 @@ public final class CollectionLiteral extends ExpressionStatement {
 
   @Override
   public void walk(GoloIrVisitor visitor) {
-    for (ExpressionStatement expression : expressions) {
+    for (ExpressionStatement<?> expression : expressions) {
       expression.accept(visitor);
     }
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (expressions.contains(original) && newElement instanceof ExpressionStatement) {
       expressions.set(expressions.indexOf(original), (ExpressionStatement) newElement);
     } else {

--- a/src/main/java/org/eclipse/golo/compiler/ir/CollectionLiteral.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CollectionLiteral.java
@@ -15,7 +15,7 @@ import java.util.LinkedList;
 
 public final class CollectionLiteral extends ExpressionStatement<CollectionLiteral> {
 
-  public static enum Type {
+  public enum Type {
     array, list, set, map, tuple, vector, range
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/CollectionLiteral.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/CollectionLiteral.java
@@ -64,7 +64,7 @@ public final class CollectionLiteral extends ExpressionStatement<CollectionLiter
   @Override
   protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (expressions.contains(original) && newElement instanceof ExpressionStatement) {
-      expressions.set(expressions.indexOf(original), (ExpressionStatement) newElement);
+      expressions.set(expressions.indexOf(original), ExpressionStatement.of(newElement));
     } else {
       throw cantReplace(original, newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/ConditionalBranching.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ConditionalBranching.java
@@ -33,12 +33,12 @@ public final class ConditionalBranching extends GoloStatement<ConditionalBranchi
   }
 
   public ConditionalBranching whenTrue(Object block) {
-    setTrueBlock(Builders.toBlock(block));
+    setTrueBlock(Block.of(block));
     return this;
   }
 
   public ConditionalBranching whenFalse(Object block) {
-    setFalseBlock(block == null ? null : Builders.toBlock(block));
+    setFalseBlock(block == null ? null : Block.of(block));
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/ConditionalBranching.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ConditionalBranching.java
@@ -10,11 +10,9 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
+public final class ConditionalBranching extends GoloStatement<ConditionalBranching> {
 
-public final class ConditionalBranching extends GoloStatement {
-
-  private ExpressionStatement condition;
+  private ExpressionStatement<?> condition;
   private Block trueBlock;
   private ConditionalBranching elseConditionalBranching;
   private Block falseBlock;
@@ -23,11 +21,13 @@ public final class ConditionalBranching extends GoloStatement {
     super();
   }
 
+  protected ConditionalBranching self() { return this; }
+
   public ConditionalBranching condition(Object cond) {
     if (cond == null) {
       setCondition(Builders.constant(false));
     } else {
-      setCondition((ExpressionStatement) cond);
+      setCondition(ExpressionStatement.of(cond));
     }
     return this;
   }
@@ -55,17 +55,11 @@ public final class ConditionalBranching extends GoloStatement {
     return whenFalse(alternative);
   }
 
-  @Override
-  public ConditionalBranching ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
-
-  public ExpressionStatement getCondition() {
+  public ExpressionStatement<?> getCondition() {
     return condition;
   }
 
-  public void setCondition(ExpressionStatement condition) {
+  public void setCondition(ExpressionStatement<?> condition) {
     this.condition = condition;
     makeParentOf(condition);
   }
@@ -143,7 +137,7 @@ public final class ConditionalBranching extends GoloStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (condition == original && newElement instanceof ExpressionStatement) {
       condition(newElement);
     } else if (elseConditionalBranching == original && newElement instanceof ConditionalBranching) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/ConditionalBranching.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ConditionalBranching.java
@@ -43,8 +43,7 @@ public final class ConditionalBranching extends GoloStatement<ConditionalBranchi
   }
 
   public ConditionalBranching elseBranch(Object elseBranch) {
-    this.elseConditionalBranching = (ConditionalBranching) elseBranch;
-    makeParentOf(elseConditionalBranching);
+    this.elseConditionalBranching = makeParentOf((ConditionalBranching) elseBranch);
     return this;
   }
 
@@ -60,8 +59,7 @@ public final class ConditionalBranching extends GoloStatement<ConditionalBranchi
   }
 
   public void setCondition(ExpressionStatement<?> condition) {
-    this.condition = condition;
-    makeParentOf(condition);
+    this.condition = makeParentOf(condition);
   }
 
   public Block getTrueBlock() {
@@ -69,8 +67,7 @@ public final class ConditionalBranching extends GoloStatement<ConditionalBranchi
   }
 
   public void setTrueBlock(Block block) {
-    this.trueBlock = block;
-    makeParentOf(block);
+    this.trueBlock = makeParentOf(block);
   }
 
   public Block getFalseBlock() {
@@ -78,10 +75,7 @@ public final class ConditionalBranching extends GoloStatement<ConditionalBranchi
   }
 
   public void setFalseBlock(Block block) {
-    this.falseBlock = block;
-    if (block != null) {
-      makeParentOf(block);
-    }
+    this.falseBlock = makeParentOf(block);
   }
 
   public boolean hasFalseBlock() {
@@ -93,8 +87,7 @@ public final class ConditionalBranching extends GoloStatement<ConditionalBranchi
   }
 
   public void setElseConditionalBranching(ConditionalBranching elseBranch) {
-    this.elseConditionalBranching = elseBranch;
-    makeParentOf(elseBranch);
+    this.elseConditionalBranching = makeParentOf(elseBranch);
   }
 
   public boolean hasElseConditionalBranching() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/ConstantStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ConstantStatement.java
@@ -12,6 +12,8 @@ package org.eclipse.golo.compiler.ir;
 
 import static gololang.Messages.message;
 
+import org.eclipse.golo.compiler.parser.GoloASTNode;
+
 public class ConstantStatement extends ExpressionStatement {
 
   private Object value;
@@ -42,6 +44,12 @@ public class ConstantStatement extends ExpressionStatement {
   @Override
   public boolean hasLocalDeclarations() {
     return false;
+  }
+
+  @Override
+  public ConstantStatement ofAST(GoloASTNode node) {
+    super.ofAST(node);
+    return this;
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/compiler/ir/ConstantStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ConstantStatement.java
@@ -12,9 +12,7 @@ package org.eclipse.golo.compiler.ir;
 
 import static gololang.Messages.message;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
-
-public class ConstantStatement extends ExpressionStatement {
+public final class ConstantStatement extends ExpressionStatement<ConstantStatement> {
 
   private Object value;
 
@@ -31,25 +29,21 @@ public class ConstantStatement extends ExpressionStatement {
     value = v;
   }
 
+  protected ConstantStatement self() { return this; }
+
   /**
    * {@inheritDoc}
    *
    * <p>Always throws an exception since {@link NamedArgument} can't have a local declaration.
    */
   @Override
-  public ExpressionStatement with(Object a) {
+  public ConstantStatement with(Object a) {
     throw new UnsupportedOperationException(message("invalid_local_definition", this.getClass().getName()));
   }
 
   @Override
   public boolean hasLocalDeclarations() {
     return false;
-  }
-
-  @Override
-  public ConstantStatement ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
   }
 
   @Override
@@ -68,7 +62,7 @@ public class ConstantStatement extends ExpressionStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     throw cantReplace();
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/Decorator.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Decorator.java
@@ -42,8 +42,7 @@ public final class Decorator extends GoloElement<Decorator> {
       throw new IllegalArgumentException("Decorator expression must be a reference or an invocation, got a "
           + expr.getClass().getSimpleName());
     }
-    this.expressionStatement = expr;
-    makeParentOf(expr);
+    this.expressionStatement = makeParentOf(expr);
   }
 
   public boolean isConstant() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/Decorator.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Decorator.java
@@ -12,22 +12,24 @@ package org.eclipse.golo.compiler.ir;
 
 import org.eclipse.golo.runtime.OperatorType;
 
-public final class Decorator extends  GoloElement {
+public final class Decorator extends GoloElement<Decorator> {
 
-  private ExpressionStatement expressionStatement;
+  private ExpressionStatement<?> expressionStatement;
 
   private boolean constant = false;
 
-  Decorator(ExpressionStatement expressionStatement) {
+  Decorator(ExpressionStatement<?> expressionStatement) {
     super();
     setExpressionStatement(expressionStatement);
   }
 
-  public ExpressionStatement getExpressionStatement() {
+  protected Decorator self() { return this; }
+
+  public ExpressionStatement<?> getExpressionStatement() {
     return expressionStatement;
   }
 
-  private boolean isValidDecoratorExpressoin(ExpressionStatement expr) {
+  private boolean isValidDecoratorExpressoin(ExpressionStatement<?> expr) {
     return expr instanceof ReferenceLookup
           || expr instanceof FunctionInvocation
           || expr instanceof ClosureReference
@@ -35,7 +37,7 @@ public final class Decorator extends  GoloElement {
             && OperatorType.ANON_CALL.equals(((BinaryOperation) expr).getType()));
   }
 
-  public void setExpressionStatement(ExpressionStatement expr) {
+  public void setExpressionStatement(ExpressionStatement<?> expr) {
     if (!isValidDecoratorExpressoin(expr)) {
       throw new IllegalArgumentException("Decorator expression must be a reference or an invocation, got a "
           + expr.getClass().getSimpleName());
@@ -61,22 +63,22 @@ public final class Decorator extends  GoloElement {
     return constant(true);
   }
 
-  private ExpressionStatement wrapLookup(ReferenceLookup reference, ExpressionStatement expression) {
+  private ExpressionStatement<?> wrapLookup(ReferenceLookup reference, ExpressionStatement<?> expression) {
     return Builders.call(reference.getName())
       .constant(this.isConstant())
       .withArgs(expression);
   }
 
-  private ExpressionStatement wrapInvocation(FunctionInvocation invocation, ExpressionStatement expression) {
+  private ExpressionStatement<?> wrapInvocation(FunctionInvocation invocation, ExpressionStatement<?> expression) {
     return Builders.anonCall(invocation, Builders.functionInvocation()
         .constant(this.isConstant())
         .withArgs(expression));
   }
-  private ExpressionStatement wrapAnonymousCall(ExpressionStatement call, ExpressionStatement expression) {
+  private ExpressionStatement<?> wrapAnonymousCall(ExpressionStatement<?> call, ExpressionStatement<?> expression) {
     return Builders.anonCall(call, Builders.functionInvocation().constant(this.isConstant()).withArgs(expression));
   }
 
-  public ExpressionStatement wrapExpression(ExpressionStatement expression) {
+  public ExpressionStatement<?> wrapExpression(ExpressionStatement<?> expression) {
     if (expressionStatement instanceof ReferenceLookup) {
       return wrapLookup((ReferenceLookup) expressionStatement, expression);
     }
@@ -97,7 +99,7 @@ public final class Decorator extends  GoloElement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (expressionStatement.equals(original) && newElement instanceof ExpressionStatement) {
       setExpressionStatement((ExpressionStatement) newElement);
     } else {

--- a/src/main/java/org/eclipse/golo/compiler/ir/Decorator.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Decorator.java
@@ -85,7 +85,7 @@ public final class Decorator extends GoloElement<Decorator> {
     if (expressionStatement instanceof FunctionInvocation) {
       return wrapInvocation((FunctionInvocation) expressionStatement, expression);
     }
-    return wrapAnonymousCall((ExpressionStatement) expressionStatement, expression);
+    return wrapAnonymousCall(ExpressionStatement.of(expressionStatement), expression);
   }
 
   @Override
@@ -101,7 +101,7 @@ public final class Decorator extends GoloElement<Decorator> {
   @Override
   protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (expressionStatement.equals(original) && newElement instanceof ExpressionStatement) {
-      setExpressionStatement((ExpressionStatement) newElement);
+      setExpressionStatement(ExpressionStatement.of(newElement));
     } else {
       throw cantReplace(original, newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/DestructuringAssignment.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/DestructuringAssignment.java
@@ -39,7 +39,6 @@ public final class DestructuringAssignment extends GoloAssignment<DestructuringA
     return varargs(true);
   }
 
-
   /**
    * {@inheritDoc}
    */

--- a/src/main/java/org/eclipse/golo/compiler/ir/DestructuringAssignment.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/DestructuringAssignment.java
@@ -10,14 +10,12 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
-
 import java.util.List;
 import java.util.LinkedList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
-public final class DestructuringAssignment extends GoloAssignment {
+public final class DestructuringAssignment extends GoloAssignment<DestructuringAssignment> {
 
   private final List<LocalReference> references = new LinkedList<>();
   private boolean isVarargs = false;
@@ -26,11 +24,7 @@ public final class DestructuringAssignment extends GoloAssignment {
     super();
   }
 
-  @Override
-  public DestructuringAssignment ofAST(GoloASTNode n) {
-    super.ofAST(n);
-    return this;
-  }
+  protected DestructuringAssignment self() { return this; }
 
   public boolean isVarargs() {
     return this.isVarargs;
@@ -45,25 +39,6 @@ public final class DestructuringAssignment extends GoloAssignment {
     return varargs(true);
   }
 
-  @Override
-  public DestructuringAssignment declaring() {
-    return this.declaring(true);
-  }
-
-  @Override
-  public DestructuringAssignment declaring(boolean d) {
-    super.declaring(d);
-    return this;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  @Override
-  public DestructuringAssignment as(Object expr) {
-    super.as(expr);
-    return this;
-  }
 
   /**
    * {@inheritDoc}

--- a/src/main/java/org/eclipse/golo/compiler/ir/ExpressionStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ExpressionStatement.java
@@ -54,6 +54,9 @@ public abstract class ExpressionStatement<T extends ExpressionStatement<T>> exte
     if (expr instanceof ExpressionStatement) {
       return (ExpressionStatement<?>) expr;
     }
+    if (expr == null) {
+      return null;
+    }
     throw cantConvert("ExpressionStatement", expr);
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/ExpressionStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ExpressionStatement.java
@@ -12,21 +12,21 @@ package org.eclipse.golo.compiler.ir;
 
 import java.util.LinkedList;
 
-public abstract class ExpressionStatement extends GoloStatement {
+public abstract class ExpressionStatement<T extends ExpressionStatement<T>> extends GoloStatement<T> {
 
-  private final LinkedList<GoloAssignment> declarations = new LinkedList<>();
+  private final LinkedList<GoloAssignment<?>> declarations = new LinkedList<>();
 
   /**
    * Defines a variable declaration (assignment) local to this expression.
    */
-  public ExpressionStatement with(Object a) {
+  public T with(Object a) {
     if (!(a instanceof GoloAssignment)) {
       throw new IllegalArgumentException(("Must be an assignment, got " + a));
     }
-    GoloAssignment declaration = (GoloAssignment) a;
+    GoloAssignment<?> declaration = (GoloAssignment<?>) a;
     declarations.add(declaration.declaring());
     makeParentOf(declaration);
-    return this;
+    return self();
   }
 
   /**
@@ -50,9 +50,9 @@ public abstract class ExpressionStatement extends GoloStatement {
     declarations.clear();
   }
 
-  public static ExpressionStatement of(Object expr) {
+  public static ExpressionStatement<?> of(Object expr) {
     if (expr instanceof ExpressionStatement) {
-      return (ExpressionStatement) expr;
+      return (ExpressionStatement<?>) expr;
     }
     throw cantConvert("ExpressionStatement", expr);
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/ForEachLoopStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ForEachLoopStatement.java
@@ -13,15 +13,14 @@ package org.eclipse.golo.compiler.ir;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
 import static java.util.Collections.unmodifiableList;
 
-public final class ForEachLoopStatement extends GoloStatement implements BlockContainer, ReferencesHolder {
+public final class ForEachLoopStatement extends GoloStatement<ForEachLoopStatement> implements BlockContainer, ReferencesHolder {
   private Block block = Block.emptyBlock();
-  private ExpressionStatement iterable;
+  private ExpressionStatement<?> iterable;
   private final List<LocalReference> valueRefs = new LinkedList<>();
-  private ExpressionStatement whenClause;
+  private ExpressionStatement<?> whenClause;
   private boolean isVarargs = false;
 
   ForEachLoopStatement() {
@@ -33,11 +32,7 @@ public final class ForEachLoopStatement extends GoloStatement implements BlockCo
     return this;
   }
 
-  @Override
-  public ForEachLoopStatement ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected ForEachLoopStatement self() { return this; }
 
   public ForEachLoopStatement on(Object iterable) {
     this.iterable = ExpressionStatement.of(iterable);
@@ -67,7 +62,7 @@ public final class ForEachLoopStatement extends GoloStatement implements BlockCo
     return this;
   }
 
-  public ExpressionStatement getIterable() {
+  public ExpressionStatement<?> getIterable() {
     return iterable;
   }
 
@@ -107,7 +102,7 @@ public final class ForEachLoopStatement extends GoloStatement implements BlockCo
     return whenClause != null;
   }
 
-  public ExpressionStatement getWhenClause() {
+  public ExpressionStatement<?> getWhenClause() {
     return whenClause;
   }
 
@@ -129,7 +124,7 @@ public final class ForEachLoopStatement extends GoloStatement implements BlockCo
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (Objects.equals(iterable, original)) {
       on(newElement);
     } else if (Objects.equals(whenClause, original)) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/ForEachLoopStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ForEachLoopStatement.java
@@ -35,7 +35,7 @@ public final class ForEachLoopStatement extends GoloStatement implements BlockCo
 
   @Override
   public ForEachLoopStatement ofAST(GoloASTNode node) {
-    node.setIrElement(this);
+    super.ofAST(node);
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/ForEachLoopStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ForEachLoopStatement.java
@@ -28,7 +28,7 @@ public final class ForEachLoopStatement extends GoloStatement<ForEachLoopStateme
   }
 
   public ForEachLoopStatement block(Object block) {
-    this.block = Builders.toBlock(block);
+    this.block = Block.of(block);
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/FunctionInvocation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/FunctionInvocation.java
@@ -10,9 +10,7 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
-
-public class FunctionInvocation extends AbstractInvocation {
+public final class FunctionInvocation extends AbstractInvocation<FunctionInvocation> {
 
   private boolean onReference = false;
   private boolean onModuleState = false;
@@ -28,11 +26,7 @@ public class FunctionInvocation extends AbstractInvocation {
     super(name);
   }
 
-  @Override
-  public FunctionInvocation ofAST(GoloASTNode n) {
-    super.ofAST(n);
-    return this;
-  }
+  protected FunctionInvocation self() { return this; }
 
   public FunctionInvocation onReference(boolean isOnReference) {
     this.onReference = isOnReference;

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloAssignment.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloAssignment.java
@@ -38,8 +38,7 @@ public abstract class GoloAssignment<T extends GoloAssignment<T>> extends GoloSt
    * Defines the value to be assigned.
    */
   public final T as(Object expr) {
-    this.expressionStatement = ExpressionStatement.of(expr);
-    makeParentOf(expressionStatement);
+    this.expressionStatement = makeParentOf(ExpressionStatement.of(expr));
     return self();
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloAssignment.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloAssignment.java
@@ -10,43 +10,43 @@
 
 package org.eclipse.golo.compiler.ir;
 
-public abstract class GoloAssignment extends GoloStatement implements ReferencesHolder {
+public abstract class GoloAssignment<T extends GoloAssignment<T>> extends GoloStatement<T> implements ReferencesHolder {
 
   private boolean declaring = false;
-  private ExpressionStatement expressionStatement;
+  private ExpressionStatement<?> expressionStatement;
 
   GoloAssignment() { super(); }
 
-  public boolean isDeclaring() {
+  public final boolean isDeclaring() {
     return declaring;
   }
 
-  public GoloAssignment declaring(boolean isDeclaring) {
+  public final T declaring(boolean isDeclaring) {
     this.declaring = isDeclaring;
-    return this;
+    return self();
   }
 
-  public GoloAssignment declaring() {
-    return declaring(true);
+  public final T declaring() {
+    return this.declaring(true);
   }
 
-  public ExpressionStatement getExpressionStatement() {
-    return expressionStatement;
+  public final ExpressionStatement<?> getExpressionStatement() {
+    return this.expressionStatement;
   }
 
   /**
    * Defines the value to be assigned.
    */
-  public GoloAssignment as(Object expr) {
-    expressionStatement = ExpressionStatement.of(expr);
+  public final T as(Object expr) {
+    this.expressionStatement = ExpressionStatement.of(expr);
     makeParentOf(expressionStatement);
-    return this;
+    return self();
   }
 
   /**
    * Defines the reference to assign to.
    */
-  public abstract GoloAssignment to(Object... refs);
+  public abstract T to(Object... refs);
 
 
   /**
@@ -64,7 +64,7 @@ public abstract class GoloAssignment extends GoloStatement implements References
    * @inheritDoc
    */
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (original.equals(getExpressionStatement()) && newElement instanceof ExpressionStatement) {
       as(newElement);
     } else {
@@ -79,6 +79,4 @@ public abstract class GoloAssignment extends GoloStatement implements References
   public void walk(GoloIrVisitor visitor) {
     expressionStatement.accept(visitor);
   }
-
-
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -22,7 +22,6 @@ public abstract class GoloElement {
 
   public GoloElement ofAST(GoloASTNode node) {
     if (node != null) {
-      node.setIrElement(this);
       this.documentation(node.getDocumentation());
       this.positionInSourceCode(node.getPositionInSourceCode());
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -87,12 +87,17 @@ public abstract class GoloElement<T extends GoloElement<T>> {
    * @param newElement the element to replace this one with.
    * @throws IllegalStateException if this element has no parent.
    */
-  public void replaceInParentBy(GoloElement<?> newElement) {
+  public final void replaceInParentBy(GoloElement<?> newElement) {
     if (newElement == this) { return; }
     if (this.parent != null) {
       this.parent.replaceElement(this, newElement);
       this.parent.makeParentOf(newElement);
-      newElement.position = this.position;
+      if (newElement.position == null) {
+        newElement.position = this.position;
+      }
+      if (newElement.documentation == null || newElement.documentation.isEmpty()) {
+        newElement.documentation = this.documentation;
+      }
       this.setParentNode(null);
     } else {
       throw new IllegalStateException("This node has no parent");
@@ -111,7 +116,10 @@ public abstract class GoloElement<T extends GoloElement<T>> {
   }
 
   public PositionInSourceCode positionInSourceCode() {
-    return position;
+    if (this.position == null && this.parent != null) {
+      return this.parent.positionInSourceCode();
+    }
+    return PositionInSourceCode.of(this.position);
   }
 
   public T positionInSourceCode(PositionInSourceCode pos) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -38,11 +38,12 @@ public abstract class GoloElement<T extends GoloElement<T>> {
     return Optional.ofNullable(this.parent);
   }
 
-  public void makeParentOf(GoloElement<?> childElement) {
+  public <C extends GoloElement<?>> C makeParentOf(C childElement) {
     if (childElement != null) {
       childElement.setParentNode(this);
       relinkChild(childElement);
     }
+    return childElement;
   }
 
   private void relinkChild(GoloElement child) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -12,28 +12,16 @@ package org.eclipse.golo.compiler.ir;
 
 import org.eclipse.golo.compiler.parser.GoloASTNode;
 
-import java.lang.ref.WeakReference;
 import java.util.Optional;
 import java.util.NoSuchElementException;
 
 public abstract class GoloElement {
-  private WeakReference<GoloASTNode> nodeRef;
   private GoloElement parent;
   private String documentation;
   private PositionInSourceCode position = PositionInSourceCode.undefined();
 
-  public GoloASTNode getASTNode() {
-    if (nodeRef == null) { return null; }
-    return nodeRef.get();
-  }
-
-  private boolean hasASTNode() {
-    return nodeRef != null && nodeRef.get() != null;
-  }
-
   public GoloElement ofAST(GoloASTNode node) {
     if (node != null) {
-      nodeRef = new WeakReference<>(node);
       node.setIrElement(this);
       this.documentation(node.getDocumentation());
       this.positionInSourceCode(node.getPositionInSourceCode());

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -18,7 +18,7 @@ import java.util.NoSuchElementException;
 
 public abstract class GoloElement {
   private WeakReference<GoloASTNode> nodeRef;
-  private Optional<GoloElement> parent = Optional.empty();
+  private GoloElement parent;
   private String documentation;
 
   public void setASTNode(GoloASTNode node) {
@@ -52,11 +52,11 @@ public abstract class GoloElement {
   }
 
   protected void setParentNode(GoloElement parentElement) {
-    this.parent = Optional.ofNullable(parentElement);
+    this.parent = parentElement;
   }
 
   public Optional<GoloElement> getParentNode() {
-    return this.parent;
+    return Optional.ofNullable(this.parent);
   }
 
   public void makeParentOf(GoloElement childElement) {
@@ -100,9 +100,9 @@ public abstract class GoloElement {
 
   public void replaceInParentBy(GoloElement newElement) {
     if (newElement == this) { return; }
-    if (this.parent.isPresent()) {
-      this.parent.get().replaceElement(this, newElement);
-      this.parent.get().makeParentOf(newElement);
+    if (this.parent != null) {
+      this.parent.replaceElement(this, newElement);
+      this.parent.makeParentOf(newElement);
       if (hasASTNode()) {
         getASTNode().setIrElement(newElement);
       }
@@ -122,8 +122,8 @@ public abstract class GoloElement {
   }
 
   public Optional<ReferenceTable> getLocalReferenceTable() {
-    if (parent.isPresent()) {
-      return parent.get().getLocalReferenceTable();
+    if (this.parent != null) {
+      return parent.getLocalReferenceTable();
     }
     return Optional.empty();
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -22,7 +22,7 @@ public abstract class GoloElement<T extends GoloElement<T>> {
 
   protected abstract T self();
 
-  public T ofAST(GoloASTNode node) {
+  public final T ofAST(GoloASTNode node) {
     if (node != null) {
       this.documentation(node.getDocumentation());
       this.positionInSourceCode(node.getPositionInSourceCode());
@@ -30,21 +30,21 @@ public abstract class GoloElement<T extends GoloElement<T>> {
     return self();
   }
 
-  protected void setParentNode(GoloElement<?> parentElement) {
+  private void setParentNode(GoloElement<?> parentElement) {
     this.parent = parentElement;
   }
 
-  public boolean hasParent() {
+  public final boolean hasParent() {
     return this.parent != null;
   }
 
-  public GoloElement<?> parent() {
+  public final GoloElement<?> parent() {
     return this.parent;
   }
 
-  public <C extends GoloElement<?>> C makeParentOf(C childElement) {
-    if (childElement != null) {
-      childElement.setParentNode(this);
+  protected final <C extends GoloElement<?>> C makeParentOf(C childElement) {
+    if (childElement != null && childElement.parent() != this) {
+      ((GoloElement<?>) childElement).setParentNode(this);
       relinkChild(childElement);
     }
     return childElement;
@@ -66,19 +66,19 @@ public abstract class GoloElement<T extends GoloElement<T>> {
     }));
   }
 
-  protected RuntimeException cantReplace() {
+  protected final RuntimeException cantReplace() {
     return new UnsupportedOperationException(getClass().getName() + " can't replace elements");
   }
 
-  protected RuntimeException cantReplace(GoloElement<?> original, GoloElement<?> replacement) {
+  protected final RuntimeException cantReplace(GoloElement<?> original, GoloElement<?> replacement) {
     return new IllegalArgumentException(this + " can't replace " + original + " with " + replacement);
   }
 
-  protected RuntimeException doesNotContain(GoloElement<?> element) {
+  protected final RuntimeException doesNotContain(GoloElement<?> element) {
     return new NoSuchElementException(element + " not in " + this);
   }
 
-  protected static RuntimeException cantConvert(String expected, Object value) {
+  protected static final RuntimeException cantConvert(String expected, Object value) {
     return new ClassCastException(String.format(
           "expecting a %s but got a %s",
           expected,
@@ -108,25 +108,25 @@ public abstract class GoloElement<T extends GoloElement<T>> {
     }
   }
 
-  public String documentation() {
+  public final String documentation() {
     return this.documentation;
   }
 
-  public T documentation(String doc) {
+  public final T documentation(String doc) {
     if (doc != null) {
       this.documentation = doc;
     }
     return self();
   }
 
-  public PositionInSourceCode positionInSourceCode() {
+  public final PositionInSourceCode positionInSourceCode() {
     if (this.position == null && this.parent != null) {
       return this.parent.positionInSourceCode();
     }
     return PositionInSourceCode.of(this.position);
   }
 
-  public T positionInSourceCode(PositionInSourceCode pos) {
+  public final T positionInSourceCode(PositionInSourceCode pos) {
     if (pos != null && pos.isUndefined()) {
       this.position = null;
     } else {
@@ -135,12 +135,12 @@ public abstract class GoloElement<T extends GoloElement<T>> {
     return self();
   }
 
-  public boolean hasPosition() {
-    return position != null && !position.isUndefined();
+  public final boolean hasPosition() {
+    return position != null || (this.parent != null && this.parent != this && this.parent.hasPosition());
   }
 
   public Optional<ReferenceTable> getLocalReferenceTable() {
-    if (this.parent != null) {
+    if (this.parent != null && this.parent != this) {
       return parent.getLocalReferenceTable();
     }
     return Optional.empty();

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -20,7 +20,7 @@ public abstract class GoloElement {
   private WeakReference<GoloASTNode> nodeRef;
   private GoloElement parent;
   private String documentation;
-  private PositionInSourceCode position = PositionInSourceCode.UNDEFINED;
+  private PositionInSourceCode position = PositionInSourceCode.undefined();
 
   public GoloASTNode getASTNode() {
     if (nodeRef == null) { return null; }
@@ -122,23 +122,12 @@ public abstract class GoloElement {
   }
 
   public GoloElement positionInSourceCode(PositionInSourceCode pos) {
-    if (pos == null) {
-      this.position = PositionInSourceCode.UNDEFINED;
-    } else {
-      this.position = pos;
-    }
+    this.position = PositionInSourceCode.of(pos);
     return this;
   }
 
-  public GoloElement positionInSourceCode(int line, int column) {
-    if (line <= 0 && column <= 0) {
-      return positionInSourceCode(null);
-    }
-    return positionInSourceCode(new PositionInSourceCode(line, column));
-  }
-
   public boolean hasPosition() {
-    return !PositionInSourceCode.UNDEFINED.equals(position);
+    return !position.isUndefined();
   }
 
   public Optional<ReferenceTable> getLocalReferenceTable() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -20,35 +20,29 @@ public abstract class GoloElement {
   private WeakReference<GoloASTNode> nodeRef;
   private GoloElement parent;
   private String documentation;
-
-  public void setASTNode(GoloASTNode node) {
-    if (node != null) {
-      nodeRef = new WeakReference<>(node);
-      setDocumentationFrom(node);
-    }
-  }
+  private PositionInSourceCode position = PositionInSourceCode.UNDEFINED;
 
   public GoloASTNode getASTNode() {
     if (nodeRef == null) { return null; }
     return nodeRef.get();
   }
 
-  public boolean hasASTNode() {
+  private boolean hasASTNode() {
     return nodeRef != null && nodeRef.get() != null;
   }
 
   public GoloElement ofAST(GoloASTNode node) {
     if (node != null) {
+      nodeRef = new WeakReference<>(node);
       node.setIrElement(this);
-      setDocumentationFrom(node);
+      setDocumentationAndPositionFrom(node);
     }
     return this;
   }
 
-  private void setDocumentationFrom(GoloASTNode node) {
-    if (node != null && node.getDocumentation() != null) {
-      documentation = node.getDocumentation();
-    }
+  private void setDocumentationAndPositionFrom(GoloASTNode node) {
+    setDocumentation(node.getDocumentation());
+    setPositionInSourceCode(node.getPositionInSourceCode());
   }
 
   protected void setParentNode(GoloElement parentElement) {
@@ -114,11 +108,37 @@ public abstract class GoloElement {
     return documentation;
   }
 
-  public PositionInSourceCode getPositionInSourceCode() {
-    if (hasASTNode()) {
-      return getASTNode().getPositionInSourceCode();
+  public void setDocumentation(String doc) {
+    if (doc != null) {
+      this.documentation = doc;
     }
-    return new PositionInSourceCode(0, 0);
+  }
+
+  public PositionInSourceCode getPositionInSourceCode() {
+    if (position != null) {
+      return position;
+    }
+    return PositionInSourceCode.UNDEFINED;
+  }
+
+  public void setPositionInSourceCode(PositionInSourceCode pos) {
+    if (PositionInSourceCode.UNDEFINED.equals(pos)) {
+      this.position = null;
+    } else {
+      this.position = pos;
+    }
+  }
+
+  public void setPositionInSourceCode(int line, int column) {
+    if (line == 0 && column == 0) {
+      position = null;
+    } else {
+      position = new PositionInSourceCode(line, column);
+    }
+  }
+
+  public boolean hasPosition() {
+    return position != null && !PositionInSourceCode.UNDEFINED.equals(position);
   }
 
   public Optional<ReferenceTable> getLocalReferenceTable() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloElement.java
@@ -34,8 +34,12 @@ public abstract class GoloElement<T extends GoloElement<T>> {
     this.parent = parentElement;
   }
 
-  public Optional<GoloElement<?>> getParentNode() {
-    return Optional.ofNullable(this.parent);
+  public boolean hasParent() {
+    return this.parent != null;
+  }
+
+  public GoloElement<?> parent() {
+    return this.parent;
   }
 
   public <C extends GoloElement<?>> C makeParentOf(C childElement) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
@@ -40,7 +40,7 @@ public final class GoloFunction extends ExpressionStatement<GoloFunction> {
   private String decoratorRef = null;
   private final LinkedList<Decorator> decorators = new LinkedList<>();
 
-  public static enum Scope {
+  public enum Scope {
     MODULE, AUGMENT, CLOSURE
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
@@ -16,15 +16,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.Collection;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
-
 import static java.util.Collections.unmodifiableList;
 import static java.util.Arrays.asList;
 import java.util.Objects;
 import static org.eclipse.golo.compiler.ir.Builders.*;
 import static java.util.Objects.requireNonNull;
 
-public final class GoloFunction extends ExpressionStatement {
+public final class GoloFunction extends ExpressionStatement<GoloFunction> {
 
   private static final SymbolGenerator SYMBOLS = new SymbolGenerator("function");
 
@@ -52,11 +50,7 @@ public final class GoloFunction extends ExpressionStatement {
     makeParentOf(block);
   }
 
-  @Override
-  public GoloFunction ofAST(GoloASTNode n) {
-    super.ofAST(n);
-    return this;
-  }
+  protected GoloFunction self() { return this; }
 
   // name -----------------------------------------------------------------------------------------
   public GoloFunction name(String n) {
@@ -291,7 +285,7 @@ public final class GoloFunction extends ExpressionStatement {
   }
 
   public GoloFunction createDecorator() {
-    ExpressionStatement expr = refLookup("__$$_original");
+    ExpressionStatement<?> expr = refLookup("__$$_original");
     for (Decorator decorator : this.getDecorators()) {
       expr = decorator.wrapExpression(expr);
     }
@@ -335,7 +329,7 @@ public final class GoloFunction extends ExpressionStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     throw cantReplace();
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloFunction.java
@@ -46,8 +46,7 @@ public final class GoloFunction extends ExpressionStatement<GoloFunction> {
 
   GoloFunction() {
     super();
-    block = Builders.block();
-    makeParentOf(block);
+    this.block = makeParentOf(Builders.block());
   }
 
   protected GoloFunction self() { return this; }
@@ -144,11 +143,10 @@ public final class GoloFunction extends ExpressionStatement<GoloFunction> {
   }
 
   public GoloFunction block(Block block) {
-    this.block = requireNonNull(block);
+    this.block = makeParentOf(requireNonNull(block));
     for (String param : parameterNames) {
       addParameterToBlockReferences(param);
     }
-    makeParentOf(this.block);
     return this;
   }
 
@@ -272,8 +270,7 @@ public final class GoloFunction extends ExpressionStatement<GoloFunction> {
   }
 
   public void addDecorator(Decorator decorator) {
-    this.decorators.add(decorator);
-    makeParentOf(decorator);
+    this.decorators.add(makeParentOf(decorator));
   }
 
   public List<Decorator> getDecorators() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
@@ -88,8 +88,7 @@ public final class GoloModule extends GoloElement<GoloModule> implements Functio
   }
 
   public void addImport(ModuleImport moduleImport) {
-    imports.add(moduleImport);
-    makeParentOf(moduleImport);
+    imports.add(makeParentOf(moduleImport));
   }
 
   @Override
@@ -124,8 +123,7 @@ public final class GoloModule extends GoloElement<GoloModule> implements Functio
   }
 
   public void addNamedAugmentation(NamedAugmentation augment) {
-    namedAugmentations.add(augment);
-    makeParentOf(augment);
+    namedAugmentations.add(makeParentOf(augment));
   }
 
   // TODO: refactor to not return the value...
@@ -143,8 +141,7 @@ public final class GoloModule extends GoloElement<GoloModule> implements Functio
   }
 
   public void addStruct(Struct struct) {
-    structs.add(struct);
-    makeParentOf(struct);
+    structs.add(makeParentOf(struct));
     struct.setModuleName(getPackageAndClass());
   }
 
@@ -163,8 +160,7 @@ public final class GoloModule extends GoloElement<GoloModule> implements Functio
   }
 
   public void addUnion(Union union) {
-    unions.add(union);
-    makeParentOf(union);
+    unions.add(makeParentOf(union));
     union.setModuleName(this.getPackageAndClass());
     this.addImport(new ModuleImport(union.getPackageAndClass(), true));
   }
@@ -181,8 +177,7 @@ public final class GoloModule extends GoloElement<GoloModule> implements Functio
   }
 
   private void addLocalState(LocalReference reference) {
-    moduleState.add(reference);
-    makeParentOf(reference);
+    moduleState.add(makeParentOf(reference));
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
@@ -191,6 +191,11 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
   }
 
   @Override
+  public String toString() {
+    return String.format("GoloModule{name=%s, src=%s}", this.packageAndClass, this.sourceFile);
+  }
+
+  @Override
   public void accept(GoloIrVisitor visitor) {
     visitor.visitModule(this);
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloModule.java
@@ -11,14 +11,13 @@
 package org.eclipse.golo.compiler.ir;
 
 import org.eclipse.golo.compiler.PackageAndClass;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
 import java.util.*;
 
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Collections.unmodifiableCollection;
 
-public final class GoloModule extends GoloElement implements FunctionContainer {
+public final class GoloModule extends GoloElement<GoloModule> implements FunctionContainer {
 
   private String sourceFile;
   private final PackageAndClass packageAndClass;
@@ -52,11 +51,7 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
     this.globalReferences = references;
   }
 
-  @Override
-  public GoloModule ofAST(GoloASTNode n) {
-    super.ofAST(n);
-    return this;
-  }
+  protected GoloModule self() { return this; }
 
   public PackageAndClass getPackageAndClass() {
     return packageAndClass;
@@ -153,7 +148,7 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
     struct.setModuleName(getPackageAndClass());
   }
 
-  public GoloElement getSubtypeByName(String name) {
+  public GoloElement<?> getSubtypeByName(String name) {
     for (Struct s : structs) {
       if (s.getName().equals(name)) {
         return s;
@@ -226,7 +221,7 @@ public final class GoloModule extends GoloElement implements FunctionContainer {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     throw cantReplace();
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/GoloStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/GoloStatement.java
@@ -10,4 +10,4 @@
 
 package org.eclipse.golo.compiler.ir;
 
-public abstract class GoloStatement extends GoloElement { }
+public abstract class GoloStatement<T extends GoloStatement<T>> extends GoloElement<T> { }

--- a/src/main/java/org/eclipse/golo/compiler/ir/IrTreeDumper.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/IrTreeDumper.java
@@ -452,7 +452,7 @@ public class IrTreeDumper implements GoloIrVisitor {
     System.out.println();
   }
 
-  private void printLocalDeclarations(ExpressionStatement expr) {
+  private void printLocalDeclarations(ExpressionStatement<?> expr) {
     if (expr.hasLocalDeclarations()) {
       incr();
       space();

--- a/src/main/java/org/eclipse/golo/compiler/ir/LocalReference.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/LocalReference.java
@@ -10,9 +10,8 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
-public final class LocalReference extends GoloElement {
+public final class LocalReference extends GoloElement<LocalReference> {
 
   public static enum Kind {
     CONSTANT, VARIABLE, MODULE_CONSTANT, MODULE_VARIABLE
@@ -28,11 +27,7 @@ public final class LocalReference extends GoloElement {
     this.name = name;
   }
 
-  @Override
-  public LocalReference ofAST(GoloASTNode n) {
-    super.ofAST(n);
-    return this;
-  }
+  protected LocalReference self() { return this; }
 
   public Kind getKind() {
     return kind;
@@ -134,7 +129,7 @@ public final class LocalReference extends GoloElement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     throw cantReplace();
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/LocalReference.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/LocalReference.java
@@ -13,7 +13,7 @@ package org.eclipse.golo.compiler.ir;
 
 public final class LocalReference extends GoloElement<LocalReference> {
 
-  public static enum Kind {
+  public enum Kind {
     CONSTANT, VARIABLE, MODULE_CONSTANT, MODULE_VARIABLE
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/LoopBreakFlowStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/LoopBreakFlowStatement.java
@@ -10,9 +10,7 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
-
-public final class LoopBreakFlowStatement extends GoloStatement {
+public final class LoopBreakFlowStatement extends GoloStatement<LoopBreakFlowStatement> {
 
   public static enum Type {
     BREAK, CONTINUE
@@ -34,6 +32,8 @@ public final class LoopBreakFlowStatement extends GoloStatement {
     return new LoopBreakFlowStatement(Type.BREAK);
   }
 
+  protected LoopBreakFlowStatement self() { return this; }
+
   public Type getType() {
     return type;
   }
@@ -47,12 +47,6 @@ public final class LoopBreakFlowStatement extends GoloStatement {
   }
 
   @Override
-  public LoopBreakFlowStatement ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
-
-  @Override
   public void accept(GoloIrVisitor visitor) {
     visitor.visitLoopBreakFlowStatement(this);
   }
@@ -63,7 +57,7 @@ public final class LoopBreakFlowStatement extends GoloStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     throw cantReplace();
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/LoopBreakFlowStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/LoopBreakFlowStatement.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.golo.compiler.ir;
 
+import org.eclipse.golo.compiler.parser.GoloASTNode;
+
 public final class LoopBreakFlowStatement extends GoloStatement {
 
   public static enum Type {
@@ -42,6 +44,12 @@ public final class LoopBreakFlowStatement extends GoloStatement {
 
   public void setEnclosingLoop(LoopStatement enclosingLoop) {
     this.enclosingLoop = enclosingLoop;
+  }
+
+  @Override
+  public LoopBreakFlowStatement ofAST(GoloASTNode node) {
+    super.ofAST(node);
+    return this;
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/compiler/ir/LoopBreakFlowStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/LoopBreakFlowStatement.java
@@ -12,7 +12,7 @@ package org.eclipse.golo.compiler.ir;
 
 public final class LoopBreakFlowStatement extends GoloStatement<LoopBreakFlowStatement> {
 
-  public static enum Type {
+  public enum Type {
     BREAK, CONTINUE
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/LoopStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/LoopStatement.java
@@ -148,7 +148,7 @@ public final class LoopStatement extends GoloStatement<LoopStatement> implements
     } else if (Objects.equals(postStatement, original)) {
       post(newElement);
     } else if (Objects.equals(block, original)) {
-      block((Block) newElement);
+      block(Block.of(newElement));
     } else {
       throw cantReplace(original, newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/LoopStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/LoopStatement.java
@@ -70,8 +70,7 @@ public final class LoopStatement extends GoloStatement<LoopStatement> implements
   }
 
   public void setInitStatement(AssignmentStatement init) {
-    this.initStatement = init;
-    makeParentOf(init);
+    this.initStatement = makeParentOf(init);
   }
 
   public ExpressionStatement<?> getConditionStatement() {
@@ -79,8 +78,8 @@ public final class LoopStatement extends GoloStatement<LoopStatement> implements
   }
 
   public void setConditionStatement(ExpressionStatement<?> cond) {
-    conditionStatement = (cond == null ? constant(false) : cond);
-    makeParentOf(conditionStatement);
+    this.conditionStatement = (cond == null ? constant(false) : cond);
+    makeParentOf(this.conditionStatement);
   }
 
   public Block getBlock() {
@@ -97,8 +96,7 @@ public final class LoopStatement extends GoloStatement<LoopStatement> implements
   }
 
   public void setPostStatement(GoloStatement<?> stat) {
-    postStatement = stat;
-    makeParentOf(postStatement);
+    this.postStatement = makeParentOf(stat);
   }
 
   public boolean hasPostStatement() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/LoopStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/LoopStatement.java
@@ -10,27 +10,23 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 import java.util.Objects;
 
 import static org.eclipse.golo.compiler.ir.Builders.*;
 
-public final class LoopStatement extends GoloStatement implements BlockContainer, ReferencesHolder {
+public final class LoopStatement extends GoloStatement<LoopStatement> implements BlockContainer, ReferencesHolder {
 
   private AssignmentStatement initStatement = null;
-  private ExpressionStatement conditionStatement = constant(false);
-  private GoloStatement postStatement = null;
+  private ExpressionStatement<?> conditionStatement;
+  private GoloStatement<?> postStatement = null;
   private Block block = Block.emptyBlock();;
 
   LoopStatement() {
     super();
+    this.setConditionStatement(constant(false));
   }
 
-  @Override
-  public LoopStatement ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected LoopStatement self() { return this; }
 
   public LoopStatement init(Object assignment) {
     if (assignment instanceof AssignmentStatement) {
@@ -78,11 +74,11 @@ public final class LoopStatement extends GoloStatement implements BlockContainer
     makeParentOf(init);
   }
 
-  public ExpressionStatement getConditionStatement() {
+  public ExpressionStatement<?> getConditionStatement() {
     return conditionStatement;
   }
 
-  public void setConditionStatement(ExpressionStatement cond) {
+  public void setConditionStatement(ExpressionStatement<?> cond) {
     conditionStatement = (cond == null ? constant(false) : cond);
     makeParentOf(conditionStatement);
   }
@@ -96,11 +92,11 @@ public final class LoopStatement extends GoloStatement implements BlockContainer
     makeParentOf(this.block);
   }
 
-  public GoloStatement getPostStatement() {
+  public GoloStatement<?> getPostStatement() {
     return postStatement;
   }
 
-  public void setPostStatement(GoloStatement stat) {
+  public void setPostStatement(GoloStatement<?> stat) {
     postStatement = stat;
     makeParentOf(postStatement);
   }
@@ -146,7 +142,7 @@ public final class LoopStatement extends GoloStatement implements BlockContainer
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (Objects.equals(initStatement, original)) {
       init(newElement);
     } else if (Objects.equals(conditionStatement, original)) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/MatchExpression.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/MatchExpression.java
@@ -34,12 +34,12 @@ public final class MatchExpression extends ExpressionStatement<MatchExpression> 
   }
 
   public MatchExpression then(Object action) {
-    this.clauses.getLast().setAction((ExpressionStatement) action);
+    this.clauses.getLast().setAction(ExpressionStatement.of(action));
     return this;
   }
 
   public MatchExpression otherwise(Object action) {
-    otherwise = (ExpressionStatement) action;
+    this.otherwise = ExpressionStatement.of(action);
     makeParentOf(otherwise);
     return this;
   }

--- a/src/main/java/org/eclipse/golo/compiler/ir/MatchExpression.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/MatchExpression.java
@@ -27,9 +27,7 @@ public final class MatchExpression extends ExpressionStatement<MatchExpression> 
   protected MatchExpression self() { return this; }
 
   public MatchExpression when(Object cond) {
-    WhenClause<ExpressionStatement<?>> clause = new WhenClause<ExpressionStatement<?>>(ExpressionStatement.of(cond), null);
-    this.clauses.add(clause);
-    makeParentOf(clause);
+    this.clauses.add(makeParentOf(new WhenClause<ExpressionStatement<?>>(ExpressionStatement.of(cond), null)));
     return this;
   }
 
@@ -39,8 +37,7 @@ public final class MatchExpression extends ExpressionStatement<MatchExpression> 
   }
 
   public MatchExpression otherwise(Object action) {
-    this.otherwise = ExpressionStatement.of(action);
-    makeParentOf(otherwise);
+    this.otherwise = makeParentOf(ExpressionStatement.of(action));
     return this;
   }
 
@@ -77,8 +74,7 @@ public final class MatchExpression extends ExpressionStatement<MatchExpression> 
     if (clauses.contains(original)) {
       @SuppressWarnings("unchecked")
       WhenClause<ExpressionStatement<?>> when = (WhenClause<ExpressionStatement<?>>) newElement;
-      clauses.set(clauses.indexOf(original), when);
-      makeParentOf(when);
+      clauses.set(clauses.indexOf(original), makeParentOf(when));
       return;
     }
     throw doesNotContain(original);

--- a/src/main/java/org/eclipse/golo/compiler/ir/MatchExpression.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/MatchExpression.java
@@ -13,21 +13,21 @@ package org.eclipse.golo.compiler.ir;
 import java.util.List;
 import java.util.LinkedList;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
-
 import static java.util.Collections.unmodifiableList;
 
-public final class MatchExpression extends ExpressionStatement implements Alternatives<ExpressionStatement> {
+public final class MatchExpression extends ExpressionStatement<MatchExpression> implements Alternatives<ExpressionStatement<?>> {
 
-  private ExpressionStatement otherwise;
-  private final LinkedList<WhenClause<ExpressionStatement>> clauses = new LinkedList<>();
+  private ExpressionStatement<?> otherwise;
+  private final LinkedList<WhenClause<ExpressionStatement<?>>> clauses = new LinkedList<>();
 
   MatchExpression() {
     super();
   }
 
+  protected MatchExpression self() { return this; }
+
   public MatchExpression when(Object cond) {
-    WhenClause<ExpressionStatement> clause = new WhenClause<ExpressionStatement>(ExpressionStatement.of(cond), null);
+    WhenClause<ExpressionStatement<?>> clause = new WhenClause<ExpressionStatement<?>>(ExpressionStatement.of(cond), null);
     this.clauses.add(clause);
     makeParentOf(clause);
     return this;
@@ -44,18 +44,12 @@ public final class MatchExpression extends ExpressionStatement implements Altern
     return this;
   }
 
-  public List<WhenClause<ExpressionStatement>> getClauses() {
+  public List<WhenClause<ExpressionStatement<?>>> getClauses() {
     return unmodifiableList(this.clauses);
   }
 
-  public ExpressionStatement getOtherwise() {
+  public ExpressionStatement<?> getOtherwise() {
     return this.otherwise;
-  }
-
-  @Override
-  public MatchExpression ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
   }
 
   @Override
@@ -65,14 +59,14 @@ public final class MatchExpression extends ExpressionStatement implements Altern
 
   @Override
   public void walk(GoloIrVisitor visitor) {
-    for (WhenClause<ExpressionStatement> clause : clauses) {
+    for (WhenClause<ExpressionStatement<?>> clause : clauses) {
       clause.accept(visitor);
     }
     otherwise.accept(visitor);
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (!(newElement instanceof ExpressionStatement || newElement instanceof WhenClause)) {
       throw cantConvert("ExpressionStatement or WhenClause", newElement);
     }
@@ -82,7 +76,7 @@ public final class MatchExpression extends ExpressionStatement implements Altern
     }
     if (clauses.contains(original)) {
       @SuppressWarnings("unchecked")
-      WhenClause<ExpressionStatement> when = (WhenClause<ExpressionStatement>) newElement;
+      WhenClause<ExpressionStatement<?>> when = (WhenClause<ExpressionStatement<?>>) newElement;
       clauses.set(clauses.indexOf(original), when);
       makeParentOf(when);
       return;

--- a/src/main/java/org/eclipse/golo/compiler/ir/Member.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Member.java
@@ -10,11 +10,10 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
-
 import static java.util.Objects.requireNonNull;
 
-public final class Member extends GoloElement {
+public final class Member extends GoloElement<Member> {
+
   private final String name;
 
   Member(String name) {
@@ -22,21 +21,14 @@ public final class Member extends GoloElement {
     this.name = requireNonNull(name);
   }
 
+  protected Member self() { return this; }
+
   public String getName() {
     return name;
   }
 
   public boolean isPublic() {
     return !name.startsWith("_");
-  }
-
-  /**
-   * @inheritDoc
-   */
-  @Override
-  public Member ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
   }
 
   /**
@@ -60,7 +52,7 @@ public final class Member extends GoloElement {
    * @inheritDoc
    */
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     throw cantReplace(original, newElement);
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/MethodInvocation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/MethodInvocation.java
@@ -11,9 +11,8 @@
 package org.eclipse.golo.compiler.ir;
 
 import org.eclipse.golo.runtime.OperatorType;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
-public class MethodInvocation extends AbstractInvocation {
+public final class MethodInvocation extends AbstractInvocation<MethodInvocation> {
 
   private boolean nullSafeGuarded = false;
 
@@ -21,11 +20,7 @@ public class MethodInvocation extends AbstractInvocation {
     super(name);
   }
 
-  @Override
-  public MethodInvocation ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected MethodInvocation self() { return this; }
 
   public void setNullSafeGuarded(boolean nullSafeGuarded) {
     this.nullSafeGuarded = nullSafeGuarded;

--- a/src/main/java/org/eclipse/golo/compiler/ir/ModuleImport.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ModuleImport.java
@@ -10,10 +10,9 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 import org.eclipse.golo.compiler.PackageAndClass;
 
-public final class ModuleImport extends GoloElement {
+public final class ModuleImport extends GoloElement<ModuleImport> {
 
   private final PackageAndClass packageAndClass;
   private final boolean implicit;
@@ -28,11 +27,7 @@ public final class ModuleImport extends GoloElement {
     this(packageAndClass, false);
   }
 
-  @Override
-  public ModuleImport ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected ModuleImport self() { return this; }
 
   public PackageAndClass getPackageAndClass() {
     return packageAndClass;
@@ -75,7 +70,7 @@ public final class ModuleImport extends GoloElement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     throw cantReplace();
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/NamedArgument.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/NamedArgument.java
@@ -33,7 +33,7 @@ public final class NamedArgument extends ExpressionStatement<NamedArgument> {
   }
 
   public NamedArgument value(Object value) {
-    expression = (ExpressionStatement) value;
+    expression = ExpressionStatement.of(value);
     makeParentOf(expression);
     return this;
   }
@@ -69,6 +69,6 @@ public final class NamedArgument extends ExpressionStatement<NamedArgument> {
     if (expression != original) {
       throw doesNotContain(original);
     }
-    value((ExpressionStatement) newElement);
+    value(newElement);
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/NamedArgument.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/NamedArgument.java
@@ -12,21 +12,23 @@ package org.eclipse.golo.compiler.ir;
 
 import static gololang.Messages.message;
 
-public final class NamedArgument extends ExpressionStatement {
+public final class NamedArgument extends ExpressionStatement<NamedArgument> {
 
   private String name;
-  private ExpressionStatement expression;
+  private ExpressionStatement<?> expression;
 
   NamedArgument(String name) {
     super();
     this.name = name;
   }
 
+  protected NamedArgument self() { return this; }
+
   public String getName() {
     return name;
   }
 
-  public ExpressionStatement getExpression() {
+  public ExpressionStatement<?> getExpression() {
     return expression;
   }
 
@@ -42,7 +44,7 @@ public final class NamedArgument extends ExpressionStatement {
    * <p>Always throws an exception since {@link NamedArgument} can't have a local declaration.
    */
   @Override
-  public ExpressionStatement with(Object a) {
+  public NamedArgument with(Object a) {
     throw new UnsupportedOperationException(message("invalid_local_definition", this.getClass().getName()));
   }
 
@@ -63,7 +65,7 @@ public final class NamedArgument extends ExpressionStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (expression != original) {
       throw doesNotContain(original);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/NamedArgument.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/NamedArgument.java
@@ -33,8 +33,7 @@ public final class NamedArgument extends ExpressionStatement<NamedArgument> {
   }
 
   public NamedArgument value(Object value) {
-    expression = ExpressionStatement.of(value);
-    makeParentOf(expression);
+    this.expression = makeParentOf(ExpressionStatement.of(value));
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/NamedAugmentation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/NamedAugmentation.java
@@ -15,13 +15,12 @@ import java.util.Set;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import org.eclipse.golo.compiler.PackageAndClass;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 import static java.util.Collections.unmodifiableSet;
 
 /**
  * Named augmentation definition
  */
-public final class NamedAugmentation extends GoloElement implements FunctionContainer {
+public final class NamedAugmentation extends GoloElement<NamedAugmentation> implements FunctionContainer {
   private final PackageAndClass name;
   private final Set<GoloFunction> functions = new LinkedHashSet<>();
 
@@ -38,11 +37,7 @@ public final class NamedAugmentation extends GoloElement implements FunctionCont
     return this.name;
   }
 
-  @Override
-  public NamedAugmentation ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected NamedAugmentation self() { return this; }
 
   @Override
   public Set<GoloFunction> getFunctions() {
@@ -85,7 +80,7 @@ public final class NamedAugmentation extends GoloElement implements FunctionCont
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (functions.contains(original)) {
       functions.remove(original);
       add(newElement);

--- a/src/main/java/org/eclipse/golo/compiler/ir/NamedAugmentation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/NamedAugmentation.java
@@ -46,8 +46,7 @@ public final class NamedAugmentation extends GoloElement<NamedAugmentation> impl
 
   @Override
   public void addFunction(GoloFunction func) {
-    functions.add(func);
-    makeParentOf(func);
+    functions.add(makeParentOf(func));
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/compiler/ir/PositionInSourceCode.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/PositionInSourceCode.java
@@ -15,6 +15,8 @@ public final class PositionInSourceCode {
   private final int line;
   private final int column;
 
+  public static final PositionInSourceCode UNDEFINED = new PositionInSourceCode(0, 0);
+
   public PositionInSourceCode(int line, int column) {
     this.line = line;
     this.column = column;

--- a/src/main/java/org/eclipse/golo/compiler/ir/PositionInSourceCode.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/PositionInSourceCode.java
@@ -10,48 +10,95 @@
 
 package org.eclipse.golo.compiler.ir;
 
-public final class PositionInSourceCode {
+public class PositionInSourceCode {
 
-  private final int line;
-  private final int column;
+  private final int startLine;
+  private final int startColumn;
+  private final int endLine;
+  private final int endColumn;
 
-  public static final PositionInSourceCode UNDEFINED = new PositionInSourceCode(0, 0);
+  private static final PositionInSourceCode UNDEFINED = new PositionInSourceCode(0, 0, 0, 0) {
+    @Override
+    public boolean isUndefined() {
+      return true;
+    }
 
-  public PositionInSourceCode(int line, int column) {
-    this.line = line;
-    this.column = column;
+    @Override
+    public String toString() {
+      return "undefined";
+    }
+  };
+
+  private PositionInSourceCode(int startLine, int startColumn, int endLine, int endColumn) {
+    this.startLine = startLine;
+    this.endLine = endLine;
+    this.startColumn = startColumn;
+    this.endColumn = endColumn;
   }
 
-  public int getLine() {
-    return line;
+  public static PositionInSourceCode undefined() {
+    return UNDEFINED;
   }
 
-  public int getColumn() {
-    return column;
+  public static PositionInSourceCode of(PositionInSourceCode pos) {
+    if (pos == null) {
+      return UNDEFINED;
+    }
+    return pos;
   }
 
-  public boolean isNull() {
-    return line == 0 && column == 0;
+  public static PositionInSourceCode of(int line, int column) {
+    return of(line, column, line, column);
+  }
+
+  public static PositionInSourceCode of(int startLine, int startColumn, int endLine, int endColumn) {
+    if (startLine <= 0 && endLine <= 0 && startColumn <= 0 && endColumn <= 0) {
+      return UNDEFINED;
+    }
+    return new PositionInSourceCode(startLine, startColumn, endLine, endColumn);
+  }
+
+  public int getStartLine() {
+    return startLine;
+  }
+
+  public int getStartColumn() {
+    return startColumn;
+  }
+
+  public int getEndLine() {
+    return endLine;
+  }
+
+  public int getEndColumn() {
+    return endColumn;
+  }
+
+  public boolean isUndefined() {
+    return false;
   }
 
   @Override
   public String toString() {
-    return String.format("{line=%d, column=%d}", line, column);
+    if (startLine == endLine && startColumn == endColumn) {
+      return String.format("{line=%d, column=%d}", startLine, startColumn);
+    }
+    return String.format("{from=%d;%d, to=%d;%d}", startLine, startColumn, endLine, endColumn);
   }
 
   @Override
   public boolean equals(Object o) {
     if (this == o) { return true; }
     if (o == null || getClass() != o.getClass()) { return false; }
-
     PositionInSourceCode that = (PositionInSourceCode) o;
-    return column == that.column && line == that.line;
+    return startColumn == that.startColumn
+      && startLine == that.startLine
+      && endLine == that.endLine
+      && endColumn == that.endColumn;
   }
 
   @Override
   public int hashCode() {
-    int result = line;
-    result = 31 * result + column;
-    return result;
+    return java.util.Objects.hash(startLine, startColumn, endLine, endColumn);
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/ReferenceLookup.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ReferenceLookup.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.golo.compiler.ir;
 
-public class ReferenceLookup extends ExpressionStatement {
+public final class ReferenceLookup extends ExpressionStatement<ReferenceLookup> {
 
   private final String name;
 
@@ -18,6 +18,8 @@ public class ReferenceLookup extends ExpressionStatement {
     super();
     this.name = name;
   }
+
+  protected ReferenceLookup self() { return this; }
 
   public String getName() {
     return name;
@@ -51,7 +53,7 @@ public class ReferenceLookup extends ExpressionStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     throw cantReplace();
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/ReferenceTable.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ReferenceTable.java
@@ -42,7 +42,7 @@ public final class ReferenceTable {
     return table.containsKey(name) || parent != null && parent.hasReferenceFor(name);
   }
 
-  public void updateFrom(GoloStatement statement) {
+  public void updateFrom(GoloStatement<?> statement) {
     if (statement instanceof ReferencesHolder) {
       for (LocalReference r : ((ReferencesHolder) statement).getDeclaringReferences()) {
         this.add(r);

--- a/src/main/java/org/eclipse/golo/compiler/ir/ReturnStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ReturnStatement.java
@@ -32,8 +32,7 @@ public final class ReturnStatement extends GoloStatement<ReturnStatement> {
   }
 
   private void setExpressionStatement(GoloStatement<?> stat) {
-    this.expressionStatement = stat;
-    makeParentOf(stat);
+    this.expressionStatement = makeParentOf(stat);
   }
 
   public boolean isReturningVoid() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/ReturnStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ReturnStatement.java
@@ -12,24 +12,26 @@ package org.eclipse.golo.compiler.ir;
 
 import java.util.Objects;
 
-public final class ReturnStatement extends GoloStatement {
+public final class ReturnStatement extends GoloStatement<ReturnStatement> {
 
-  private GoloStatement expressionStatement;
+  private GoloStatement<?> expressionStatement;
   private boolean returningVoid;
   private boolean synthetic;
 
-  ReturnStatement(ExpressionStatement expression) {
+  ReturnStatement(ExpressionStatement<?> expression) {
     super();
     setExpressionStatement(expression);
     this.returningVoid = false;
     this.synthetic = false;
   }
 
-  public GoloStatement getExpressionStatement() {
+  protected ReturnStatement self() { return this; }
+
+  public GoloStatement<?> getExpressionStatement() {
     return expressionStatement;
   }
 
-  private void setExpressionStatement(GoloStatement stat) {
+  private void setExpressionStatement(GoloStatement<?> stat) {
     this.expressionStatement = stat;
     makeParentOf(stat);
   }
@@ -70,7 +72,7 @@ public final class ReturnStatement extends GoloStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (Objects.equals(original, expressionStatement) && newElement instanceof ExpressionStatement) {
       setExpressionStatement((ExpressionStatement) newElement);
     } else {

--- a/src/main/java/org/eclipse/golo/compiler/ir/ReturnStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ReturnStatement.java
@@ -74,7 +74,7 @@ public final class ReturnStatement extends GoloStatement<ReturnStatement> {
   @Override
   protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (Objects.equals(original, expressionStatement) && newElement instanceof ExpressionStatement) {
-      setExpressionStatement((ExpressionStatement) newElement);
+      setExpressionStatement(ExpressionStatement.of(newElement));
     } else {
       throw cantReplace(original, newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/Struct.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Struct.java
@@ -13,21 +13,16 @@ package org.eclipse.golo.compiler.ir;
 import org.eclipse.golo.compiler.PackageAndClass;
 
 import java.util.Set;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
 import static org.eclipse.golo.compiler.ir.Builders.*;
 
-public final class Struct extends TypeWithMembers {
+public final class Struct extends TypeWithMembers<Struct> {
 
   public static final String IMMUTABLE_FACTORY_METHOD = "$_immutable";
 
   private PackageAndClass moduleName;
 
-  @Override
-  public Struct ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected Struct self() { return this; }
 
   Struct(String name) {
     super(name);

--- a/src/main/java/org/eclipse/golo/compiler/ir/ThrowStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ThrowStatement.java
@@ -36,7 +36,7 @@ public final class ThrowStatement extends GoloStatement<ThrowStatement> {
   @Override
   protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (Objects.equals(original, expressionStatement) && newElement instanceof ExpressionStatement) {
-      setExpressionStatement((ExpressionStatement) newElement);
+      setExpressionStatement(ExpressionStatement.of(newElement));
     } else {
       throw cantReplace(original, newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/ThrowStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ThrowStatement.java
@@ -47,7 +47,6 @@ public final class ThrowStatement extends GoloStatement<ThrowStatement> {
   }
 
   private void setExpressionStatement(GoloStatement<?> stat) {
-    this.expressionStatement = stat;
-    makeParentOf(stat);
+    this.expressionStatement = makeParentOf(stat);
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/ThrowStatement.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/ThrowStatement.java
@@ -11,16 +11,17 @@
 package org.eclipse.golo.compiler.ir;
 
 import java.util.Objects;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
-public final class ThrowStatement extends GoloStatement {
+public final class ThrowStatement extends GoloStatement<ThrowStatement> {
 
-  private GoloStatement expressionStatement;
+  private GoloStatement<?> expressionStatement;
 
-  ThrowStatement(GoloStatement expressionStatement) {
+  ThrowStatement(GoloStatement<?> expressionStatement) {
     super();
     setExpressionStatement(expressionStatement);
   }
+
+  protected ThrowStatement self() { return this; }
 
   @Override
   public void accept(GoloIrVisitor visitor) {
@@ -33,7 +34,7 @@ public final class ThrowStatement extends GoloStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (Objects.equals(original, expressionStatement) && newElement instanceof ExpressionStatement) {
       setExpressionStatement((ExpressionStatement) newElement);
     } else {
@@ -41,18 +42,12 @@ public final class ThrowStatement extends GoloStatement {
     }
   }
 
-  public GoloStatement getExpressionStatement() {
+  public GoloStatement<?> getExpressionStatement() {
     return expressionStatement;
   }
 
-  private void setExpressionStatement(GoloStatement stat) {
+  private void setExpressionStatement(GoloStatement<?> stat) {
     this.expressionStatement = stat;
     makeParentOf(stat);
-  }
-
-  @Override
-  public ThrowStatement ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/TryCatchFinally.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/TryCatchFinally.java
@@ -10,10 +10,9 @@
 
 package org.eclipse.golo.compiler.ir;
 
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 import java.util.Objects;
 
-public class TryCatchFinally extends GoloStatement {
+public class TryCatchFinally extends GoloStatement<TryCatchFinally> {
 
   private final String exceptionId;
   private Block tryBlock;
@@ -25,11 +24,7 @@ public class TryCatchFinally extends GoloStatement {
     this.exceptionId = exceptionId;
   }
 
-  @Override
-  public TryCatchFinally ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected TryCatchFinally self() { return this; }
 
   public String getExceptionId() {
     return exceptionId;
@@ -103,7 +98,7 @@ public class TryCatchFinally extends GoloStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (Objects.equals(original, tryBlock)) {
       trying(newElement);
     } else if (Objects.equals(original, catchBlock)) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/TryCatchFinally.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/TryCatchFinally.java
@@ -35,8 +35,7 @@ public class TryCatchFinally extends GoloStatement<TryCatchFinally> {
   }
 
   public TryCatchFinally trying(Object block) {
-    tryBlock = (Block) block;
-    makeParentOf(tryBlock);
+    this.tryBlock = makeParentOf((Block) block);
     return this;
   }
 
@@ -45,9 +44,8 @@ public class TryCatchFinally extends GoloStatement<TryCatchFinally> {
   }
 
   public TryCatchFinally catching(Object block) {
-    catchBlock = (Block) block;
-    makeParentOf(catchBlock);
-    catchBlock.getReferenceTable().add(Builders.localRef(exceptionId).synthetic());
+    this.catchBlock = makeParentOf((Block) block);
+    this.catchBlock.getReferenceTable().add(Builders.localRef(exceptionId).synthetic());
     return this;
   }
 
@@ -56,8 +54,7 @@ public class TryCatchFinally extends GoloStatement<TryCatchFinally> {
   }
 
   public TryCatchFinally finalizing(Object block) {
-    finallyBlock = (Block) block;
-    makeParentOf(finallyBlock);
+    this.finallyBlock = makeParentOf((Block) block);
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/TryCatchFinally.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/TryCatchFinally.java
@@ -35,7 +35,7 @@ public class TryCatchFinally extends GoloStatement<TryCatchFinally> {
   }
 
   public TryCatchFinally trying(Object block) {
-    this.tryBlock = makeParentOf((Block) block);
+    this.tryBlock = makeParentOf(Block.of(block));
     return this;
   }
 
@@ -44,7 +44,7 @@ public class TryCatchFinally extends GoloStatement<TryCatchFinally> {
   }
 
   public TryCatchFinally catching(Object block) {
-    this.catchBlock = makeParentOf((Block) block);
+    this.catchBlock = makeParentOf(Block.of(block));
     this.catchBlock.getReferenceTable().add(Builders.localRef(exceptionId).synthetic());
     return this;
   }
@@ -54,7 +54,7 @@ public class TryCatchFinally extends GoloStatement<TryCatchFinally> {
   }
 
   public TryCatchFinally finalizing(Object block) {
-    this.finallyBlock = makeParentOf((Block) block);
+    this.finallyBlock = makeParentOf(Block.of(block));
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/TypeWithMembers.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/TypeWithMembers.java
@@ -59,8 +59,7 @@ abstract class TypeWithMembers<T extends TypeWithMembers<T>> extends GoloElement
   }
 
   protected void addMember(Member member) {
-    this.members.add(member);
-    makeParentOf(member);
+    this.members.add(makeParentOf(member));
   }
 
   void addMembers(Iterable<Member> members) {

--- a/src/main/java/org/eclipse/golo/compiler/ir/TypeWithMembers.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/TypeWithMembers.java
@@ -23,7 +23,8 @@ import static java.util.stream.Collectors.toList;
 /**
  * An abstract class for struct-like types.
  */
-abstract class TypeWithMembers extends GoloElement {
+abstract class TypeWithMembers<T extends TypeWithMembers<T>> extends GoloElement<T> {
+
   private final Set<Member> members = new LinkedHashSet<>();
   private final String name;
 
@@ -46,11 +47,11 @@ abstract class TypeWithMembers extends GoloElement {
     return getPackageAndClass().toString();
   }
 
-  public TypeWithMembers members(Object... members) {
+  public T members(Object... members) {
     for (Object member : members) {
       withMember(member);
     }
-    return this;
+    return self();
   }
 
   public boolean hasMembers() {
@@ -66,13 +67,13 @@ abstract class TypeWithMembers extends GoloElement {
     members.forEach(this::addMember);
   }
 
-  public TypeWithMembers withMember(Object member) {
+  public T withMember(Object member) {
     if (member instanceof Member) {
       addMember((Member) member);
     } else {
       addMember(new Member(member.toString()));
     }
-    return this;
+    return self();
   }
 
   protected List<String> getMemberNames() {
@@ -118,7 +119,7 @@ abstract class TypeWithMembers extends GoloElement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     throw cantReplace();
   }
 }

--- a/src/main/java/org/eclipse/golo/compiler/ir/UnaryOperation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/UnaryOperation.java
@@ -12,22 +12,24 @@ package org.eclipse.golo.compiler.ir;
 
 import org.eclipse.golo.runtime.OperatorType;
 
-public class UnaryOperation extends ExpressionStatement {
+public final class UnaryOperation extends ExpressionStatement<UnaryOperation> {
 
   private final OperatorType type;
-  private ExpressionStatement expressionStatement;
+  private ExpressionStatement<?> expressionStatement;
 
-  UnaryOperation(OperatorType type, ExpressionStatement expressionStatement) {
+  UnaryOperation(OperatorType type, ExpressionStatement<?> expressionStatement) {
     super();
     this.type = type;
     setExpressionStatement(expressionStatement);
   }
 
-  public ExpressionStatement getExpressionStatement() {
+  protected UnaryOperation self() { return this; }
+
+  public ExpressionStatement<?> getExpressionStatement() {
     return expressionStatement;
   }
 
-  private void setExpressionStatement(ExpressionStatement statement) {
+  private void setExpressionStatement(ExpressionStatement<?> statement) {
     this.expressionStatement = statement;
     makeParentOf(statement);
   }
@@ -47,7 +49,7 @@ public class UnaryOperation extends ExpressionStatement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (expressionStatement.equals(original)) {
       setExpressionStatement((ExpressionStatement) newElement);
     } else {

--- a/src/main/java/org/eclipse/golo/compiler/ir/UnaryOperation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/UnaryOperation.java
@@ -51,7 +51,7 @@ public final class UnaryOperation extends ExpressionStatement<UnaryOperation> {
   @Override
   protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (expressionStatement.equals(original)) {
-      setExpressionStatement((ExpressionStatement) newElement);
+      setExpressionStatement(ExpressionStatement.of(newElement));
     } else {
       throw cantReplace(original, newElement);
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/UnaryOperation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/UnaryOperation.java
@@ -30,8 +30,7 @@ public final class UnaryOperation extends ExpressionStatement<UnaryOperation> {
   }
 
   private void setExpressionStatement(ExpressionStatement<?> statement) {
-    this.expressionStatement = statement;
-    makeParentOf(statement);
+    this.expressionStatement = makeParentOf(statement);
   }
 
   public OperatorType getType() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/Union.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Union.java
@@ -45,7 +45,7 @@ public final class Union extends GoloElement<Union> {
   }
 
   public UnionValue createValue(String name) {
-    return new UnionValue(this, name);
+    return new UnionValue(name);
   }
 
   public boolean addValue(UnionValue value) {
@@ -57,9 +57,9 @@ public final class Union extends GoloElement<Union> {
   }
 
   public Union value(String name, Member... members) {
-    UnionValue value = new UnionValue(this, name);
+    UnionValue value = new UnionValue(name);
     value.addMembers(asList(members));
-    values.add(value);
+    addValue(value);
     return this;
   }
 

--- a/src/main/java/org/eclipse/golo/compiler/ir/Union.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Union.java
@@ -15,12 +15,11 @@ import org.eclipse.golo.compiler.PackageAndClass;
 import java.util.Collection;
 import java.util.Set;
 import java.util.LinkedHashSet;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableSet;
 
-public final class Union extends GoloElement {
+public final class Union extends GoloElement<Union> {
 
   private PackageAndClass moduleName;
   private final String name;
@@ -31,11 +30,7 @@ public final class Union extends GoloElement {
     this.name = name;
   }
 
-  @Override
-  public Union ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected Union self() { return this; }
 
   public String getName() {
     return name;
@@ -82,7 +77,7 @@ public final class Union extends GoloElement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (values.contains(original) && newElement instanceof UnionValue) {
       values.remove(original);
       addValue((UnionValue) newElement);

--- a/src/main/java/org/eclipse/golo/compiler/ir/Union.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/Union.java
@@ -49,8 +49,7 @@ public final class Union extends GoloElement<Union> {
   }
 
   public boolean addValue(UnionValue value) {
-    makeParentOf(value);
-    return values.add(value);
+    return values.add(makeParentOf(value));
   }
 
   public Collection<UnionValue> getValues() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/UnionValue.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/UnionValue.java
@@ -11,21 +11,15 @@
 package org.eclipse.golo.compiler.ir;
 
 import org.eclipse.golo.compiler.PackageAndClass;
-import org.eclipse.golo.compiler.parser.GoloASTNode;
 
-
-public final class UnionValue extends TypeWithMembers {
+public final class UnionValue extends TypeWithMembers<UnionValue> {
 
   UnionValue(Union union, String name) {
     super(name);
     setParentNode(union);
   }
 
-  @Override
-  public UnionValue ofAST(GoloASTNode node) {
-    super.ofAST(node);
-    return this;
-  }
+  protected UnionValue self() { return this; }
 
   @Override
   public PackageAndClass getPackageAndClass() {
@@ -41,7 +35,7 @@ public final class UnionValue extends TypeWithMembers {
   }
 
   @Override
-  protected void setParentNode(GoloElement parent) {
+  protected void setParentNode(GoloElement<?> parent) {
     if (!(parent instanceof Union)) {
       throw new IllegalArgumentException("UnionValue can only be defined in a Union");
     }

--- a/src/main/java/org/eclipse/golo/compiler/ir/UnionValue.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/UnionValue.java
@@ -14,9 +14,8 @@ import org.eclipse.golo.compiler.PackageAndClass;
 
 public final class UnionValue extends TypeWithMembers<UnionValue> {
 
-  UnionValue(Union union, String name) {
+  UnionValue(String name) {
     super(name);
-    setParentNode(union);
   }
 
   protected UnionValue self() { return this; }
@@ -32,14 +31,6 @@ public final class UnionValue extends TypeWithMembers<UnionValue> {
 
   protected String getFactoryDelegateName() {
     return getUnion().getPackageAndClass().toString() + "." + getName();
-  }
-
-  @Override
-  protected void setParentNode(GoloElement<?> parent) {
-    if (!(parent instanceof Union)) {
-      throw new IllegalArgumentException("UnionValue can only be defined in a Union");
-    }
-    super.setParentNode(parent);
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/compiler/ir/UnionValue.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/UnionValue.java
@@ -27,7 +27,7 @@ public final class UnionValue extends TypeWithMembers<UnionValue> {
   }
 
   public Union getUnion() {
-    return (Union) getParentNode().get();
+    return (Union) parent();
   }
 
   protected String getFactoryDelegateName() {

--- a/src/main/java/org/eclipse/golo/compiler/ir/WhenClause.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/WhenClause.java
@@ -15,8 +15,7 @@ public final class WhenClause<T extends GoloElement<?>> extends GoloElement<When
   private T action;
 
   WhenClause(ExpressionStatement<?> condition, T action) {
-    this.condition = condition;
-    makeParentOf(condition);
+    this.condition = makeParentOf(condition);
     setAction(action);
   }
 
@@ -27,8 +26,7 @@ public final class WhenClause<T extends GoloElement<?>> extends GoloElement<When
   public T action() { return this.action; }
 
   public void setAction(T a) {
-    this.action = a;
-    makeParentOf(a);
+    this.action = makeParentOf(a);
   }
 
   @Override
@@ -42,8 +40,7 @@ public final class WhenClause<T extends GoloElement<?>> extends GoloElement<When
       if (!(newElement instanceof ExpressionStatement)) {
         throw cantConvert("ExpressionStatement", newElement);
       }
-      this.condition = ExpressionStatement.of(newElement);
-      makeParentOf(this.condition);
+      this.condition = makeParentOf(ExpressionStatement.of(newElement));
     } else if (this.action.equals(original)) {
       @SuppressWarnings("unchecked")
       T element = (T) newElement;

--- a/src/main/java/org/eclipse/golo/compiler/ir/WhenClause.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/WhenClause.java
@@ -10,17 +10,19 @@
 
 package org.eclipse.golo.compiler.ir;
 
-public final class WhenClause<T extends GoloElement> extends GoloElement {
-  private ExpressionStatement condition;
+public final class WhenClause<T extends GoloElement<?>> extends GoloElement<WhenClause<T>> {
+  private ExpressionStatement<?> condition;
   private T action;
 
-  WhenClause(ExpressionStatement condition, T action) {
+  WhenClause(ExpressionStatement<?> condition, T action) {
     this.condition = condition;
     makeParentOf(condition);
     setAction(action);
   }
 
-  public ExpressionStatement condition() { return this.condition; }
+  protected WhenClause<T> self() { return this; }
+
+  public ExpressionStatement<?> condition() { return this.condition; }
 
   public T action() { return this.action; }
 
@@ -35,7 +37,7 @@ public final class WhenClause<T extends GoloElement> extends GoloElement {
   }
 
   @Override
-  protected void replaceElement(GoloElement original, GoloElement newElement) {
+  protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
     if (condition.equals(original)) {
       if (!(newElement instanceof ExpressionStatement)) {
         throw cantConvert("ExpressionStatement", newElement);

--- a/src/main/java/org/eclipse/golo/compiler/ir/WhenClause.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/WhenClause.java
@@ -38,13 +38,13 @@ public final class WhenClause<T extends GoloElement<?>> extends GoloElement<When
 
   @Override
   protected void replaceElement(GoloElement<?> original, GoloElement<?> newElement) {
-    if (condition.equals(original)) {
+    if (this.condition.equals(original)) {
       if (!(newElement instanceof ExpressionStatement)) {
         throw cantConvert("ExpressionStatement", newElement);
       }
-      this.condition = (ExpressionStatement) newElement;
+      this.condition = ExpressionStatement.of(newElement);
       makeParentOf(this.condition);
-    } else if (action.equals(original)) {
+    } else if (this.action.equals(original)) {
       @SuppressWarnings("unchecked")
       T element = (T) newElement;
       setAction(element);

--- a/src/main/java/org/eclipse/golo/compiler/parser/GoloASTNode.java
+++ b/src/main/java/org/eclipse/golo/compiler/parser/GoloASTNode.java
@@ -10,7 +10,6 @@
 
 package org.eclipse.golo.compiler.parser;
 
-import org.eclipse.golo.compiler.ir.GoloElement;
 import org.eclipse.golo.compiler.ir.PositionInSourceCode;
 
 public class GoloASTNode extends SimpleNode {

--- a/src/main/java/org/eclipse/golo/compiler/parser/GoloASTNode.java
+++ b/src/main/java/org/eclipse/golo/compiler/parser/GoloASTNode.java
@@ -15,16 +15,7 @@ import org.eclipse.golo.compiler.ir.PositionInSourceCode;
 
 public class GoloASTNode extends SimpleNode {
 
-  private GoloElement irElement;
   private String documentation;
-
-  public void setIrElement(GoloElement element) {
-    this.irElement = element;
-  }
-
-  public GoloElement getIrElement() {
-    return irElement;
-  }
 
   public GoloASTNode(int i) {
     super(i);

--- a/src/main/java/org/eclipse/golo/compiler/parser/GoloASTNode.java
+++ b/src/main/java/org/eclipse/golo/compiler/parser/GoloASTNode.java
@@ -20,15 +20,6 @@ public class GoloASTNode extends SimpleNode {
 
   public void setIrElement(GoloElement element) {
     this.irElement = element;
-
-    if (jjtGetFirstToken() != null) {
-      // Only add a reverse weak ref to this ASTNode if it was constructed by
-      // the parser and is  really part of the AST (on the contrary, temporary
-      // AST elements used in the ParseTreeToGoloIR visitor to create IR
-      // elements should not be referenced, since they can be garbage collected
-      // at any moment and they don't reflect the source code exactly
-      element.setASTNode(this);
-    }
   }
 
   public GoloElement getIrElement() {
@@ -52,7 +43,10 @@ public class GoloASTNode extends SimpleNode {
   }
 
   public PositionInSourceCode getPositionInSourceCode() {
-    return new PositionInSourceCode(getLineInSourceCode(), getColumnInSourceCode());
+    if (jjtGetFirstToken() != null) {
+      return new PositionInSourceCode(getLineInSourceCode(), getColumnInSourceCode());
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/compiler/parser/GoloASTNode.java
+++ b/src/main/java/org/eclipse/golo/compiler/parser/GoloASTNode.java
@@ -43,10 +43,20 @@ public class GoloASTNode extends SimpleNode {
   }
 
   public PositionInSourceCode getPositionInSourceCode() {
-    if (jjtGetFirstToken() != null) {
-      return new PositionInSourceCode(getLineInSourceCode(), getColumnInSourceCode());
+    Token firstToken = this.jjtGetFirstToken();
+    if (firstToken == null) {
+      return PositionInSourceCode.undefined();
     }
-    return null;
+    int startLine = firstToken.beginLine;
+    int startColumn = firstToken.beginColumn;
+    int endLine = firstToken.endLine;
+    int endColumn = firstToken.endColumn;
+    Token lastToken = this.jjtGetLastToken();
+    if (lastToken != null) {
+      endLine = lastToken.endLine;
+      endColumn = lastToken.endColumn;
+    }
+    return PositionInSourceCode.of(startLine, startColumn, endLine, endColumn);
   }
 
   @Override

--- a/src/main/java/org/eclipse/golo/doc/ModuleDocumentation.java
+++ b/src/main/java/org/eclipse/golo/doc/ModuleDocumentation.java
@@ -164,7 +164,7 @@ public class ModuleDocumentation implements DocumentationElement {
       functionContext.push(functions);
       parents.push(ModuleDocumentation.this);
       moduleName = module.getPackageAndClass().toString();
-      moduleDefLine = module.positionInSourceCode().getLine();
+      moduleDefLine = module.positionInSourceCode().getStartLine();
       moduleDocumentation = module.documentation();
       module.walk(this);
     }
@@ -172,7 +172,7 @@ public class ModuleDocumentation implements DocumentationElement {
     @Override
     public void visitModuleImport(ModuleImport moduleImport) {
       if (!moduleImport.isImplicit()) {
-        imports.put(moduleImport.getPackageAndClass().toString(), moduleImport.positionInSourceCode().getLine());
+        imports.put(moduleImport.getPackageAndClass().toString(), moduleImport.positionInSourceCode().getStartLine());
       }
     }
 
@@ -182,7 +182,7 @@ public class ModuleDocumentation implements DocumentationElement {
               .parent(parents.peek())
               .name(struct.getName())
               .documentation(struct.documentation())
-              .line(struct.positionInSourceCode().getLine());
+              .line(struct.positionInSourceCode().getStartLine());
       structs.add(doc);
       currentMemberHolder = doc;
       parents.push(doc);
@@ -197,7 +197,7 @@ public class ModuleDocumentation implements DocumentationElement {
           .parent(parents.peek())
           .name(union.getName())
           .documentation(union.documentation())
-          .line(union.positionInSourceCode().getLine());
+          .line(union.positionInSourceCode().getStartLine());
       unions.add(this.currentUnion);
       parents.push(currentUnion);
       union.walk(this);
@@ -209,7 +209,7 @@ public class ModuleDocumentation implements DocumentationElement {
       UnionDocumentation.UnionValueDocumentation doc = this.currentUnion.addValue(value.getName())
           .parent(parents.peek())
           .documentation(value.documentation())
-          .line(value.positionInSourceCode().getLine());
+          .line(value.positionInSourceCode().getStartLine());
       currentMemberHolder = doc;
       parents.push(doc);
       value.walk(this);
@@ -225,7 +225,7 @@ public class ModuleDocumentation implements DocumentationElement {
                 .target(target)
                 .parent(parents.peek())
                 .augmentationNames(augment.getNames())
-                .line(augment.positionInSourceCode().getLine())
+                .line(augment.positionInSourceCode().getStartLine())
         );
       }
       AugmentationDocumentation ad = augmentations.get(target);
@@ -245,7 +245,7 @@ public class ModuleDocumentation implements DocumentationElement {
           .parent(parents.peek())
           .name(augment.getName())
           .documentation(augment.documentation())
-          .line(augment.positionInSourceCode().getLine());
+          .line(augment.positionInSourceCode().getStartLine());
       namedAugmentations.add(augmentDoc);
       functionContext.push(augmentDoc);
       parents.push(augmentDoc);
@@ -262,7 +262,7 @@ public class ModuleDocumentation implements DocumentationElement {
             .name(function.getName())
             .documentation(function.documentation())
             .augmentation(function.isInAugment())
-            .line(function.positionInSourceCode().getLine())
+            .line(function.positionInSourceCode().getStartLine())
             .local(function.isLocal())
             .arguments(function.getParameterNames())
             .varargs(function.isVarargs()));
@@ -272,7 +272,7 @@ public class ModuleDocumentation implements DocumentationElement {
     @Override
     public void visitLocalReference(LocalReference localRef) {
       if (localRef.isModuleState()) {
-        moduleStates.put(localRef.getName(), localRef.positionInSourceCode().getLine());
+        moduleStates.put(localRef.getName(), localRef.positionInSourceCode().getStartLine());
       }
     }
 
@@ -281,7 +281,7 @@ public class ModuleDocumentation implements DocumentationElement {
       currentMemberHolder.addMember(member.getName())
         .parent(parents.peek())
         .documentation(member.documentation())
-        .line(member.positionInSourceCode().getLine());
+        .line(member.positionInSourceCode().getStartLine());
     }
 
     @Override

--- a/src/main/java/org/eclipse/golo/doc/ModuleDocumentation.java
+++ b/src/main/java/org/eclipse/golo/doc/ModuleDocumentation.java
@@ -164,15 +164,15 @@ public class ModuleDocumentation implements DocumentationElement {
       functionContext.push(functions);
       parents.push(ModuleDocumentation.this);
       moduleName = module.getPackageAndClass().toString();
-      moduleDefLine = module.getPositionInSourceCode().getLine();
-      moduleDocumentation = module.getDocumentation();
+      moduleDefLine = module.positionInSourceCode().getLine();
+      moduleDocumentation = module.documentation();
       module.walk(this);
     }
 
     @Override
     public void visitModuleImport(ModuleImport moduleImport) {
       if (!moduleImport.isImplicit()) {
-        imports.put(moduleImport.getPackageAndClass().toString(), moduleImport.getPositionInSourceCode().getLine());
+        imports.put(moduleImport.getPackageAndClass().toString(), moduleImport.positionInSourceCode().getLine());
       }
     }
 
@@ -181,8 +181,8 @@ public class ModuleDocumentation implements DocumentationElement {
       StructDocumentation doc = new StructDocumentation()
               .parent(parents.peek())
               .name(struct.getName())
-              .documentation(struct.getDocumentation())
-              .line(struct.getPositionInSourceCode().getLine());
+              .documentation(struct.documentation())
+              .line(struct.positionInSourceCode().getLine());
       structs.add(doc);
       currentMemberHolder = doc;
       parents.push(doc);
@@ -196,8 +196,8 @@ public class ModuleDocumentation implements DocumentationElement {
       this.currentUnion = new UnionDocumentation()
           .parent(parents.peek())
           .name(union.getName())
-          .documentation(union.getDocumentation())
-          .line(union.getPositionInSourceCode().getLine());
+          .documentation(union.documentation())
+          .line(union.positionInSourceCode().getLine());
       unions.add(this.currentUnion);
       parents.push(currentUnion);
       union.walk(this);
@@ -208,8 +208,8 @@ public class ModuleDocumentation implements DocumentationElement {
     public void visitUnionValue(UnionValue value) {
       UnionDocumentation.UnionValueDocumentation doc = this.currentUnion.addValue(value.getName())
           .parent(parents.peek())
-          .documentation(value.getDocumentation())
-          .line(value.getPositionInSourceCode().getLine());
+          .documentation(value.documentation())
+          .line(value.positionInSourceCode().getLine());
       currentMemberHolder = doc;
       parents.push(doc);
       value.walk(this);
@@ -225,12 +225,12 @@ public class ModuleDocumentation implements DocumentationElement {
                 .target(target)
                 .parent(parents.peek())
                 .augmentationNames(augment.getNames())
-                .line(augment.getPositionInSourceCode().getLine())
+                .line(augment.positionInSourceCode().getLine())
         );
       }
       AugmentationDocumentation ad = augmentations.get(target);
-      if (augment.getDocumentation() != null && !augment.getDocumentation().isEmpty()) {
-        ad.documentation(String.join("\n", ad.documentation(), augment.getDocumentation()));
+      if (augment.documentation() != null && !augment.documentation().isEmpty()) {
+        ad.documentation(String.join("\n", ad.documentation(), augment.documentation()));
       }
       functionContext.push(ad);
       parents.push(ad);
@@ -244,8 +244,8 @@ public class ModuleDocumentation implements DocumentationElement {
       NamedAugmentationDocumentation augmentDoc = new NamedAugmentationDocumentation()
           .parent(parents.peek())
           .name(augment.getName())
-          .documentation(augment.getDocumentation())
-          .line(augment.getPositionInSourceCode().getLine());
+          .documentation(augment.documentation())
+          .line(augment.positionInSourceCode().getLine());
       namedAugmentations.add(augmentDoc);
       functionContext.push(augmentDoc);
       parents.push(augmentDoc);
@@ -260,9 +260,9 @@ public class ModuleDocumentation implements DocumentationElement {
         functionContext.peek().add(new FunctionDocumentation()
             .parent(parents.peek())
             .name(function.getName())
-            .documentation(function.getDocumentation())
+            .documentation(function.documentation())
             .augmentation(function.isInAugment())
-            .line(function.getPositionInSourceCode().getLine())
+            .line(function.positionInSourceCode().getLine())
             .local(function.isLocal())
             .arguments(function.getParameterNames())
             .varargs(function.isVarargs()));
@@ -272,7 +272,7 @@ public class ModuleDocumentation implements DocumentationElement {
     @Override
     public void visitLocalReference(LocalReference localRef) {
       if (localRef.isModuleState()) {
-        moduleStates.put(localRef.getName(), localRef.getPositionInSourceCode().getLine());
+        moduleStates.put(localRef.getName(), localRef.positionInSourceCode().getLine());
       }
     }
 
@@ -280,8 +280,8 @@ public class ModuleDocumentation implements DocumentationElement {
     public void visitMember(Member member) {
       currentMemberHolder.addMember(member.getName())
         .parent(parents.peek())
-        .documentation(member.getDocumentation())
-        .line(member.getPositionInSourceCode().getLine());
+        .documentation(member.documentation())
+        .line(member.positionInSourceCode().getLine());
     }
 
     @Override

--- a/src/main/java/org/eclipse/golo/runtime/MethodInvocationSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/MethodInvocationSupport.java
@@ -260,9 +260,9 @@ public final class MethodInvocationSupport {
           methodType(Object.class, Object.class, Object.class, Object[].class),
           false);
       Object[] fallbackArgs = new Object[]{
-          args[0],
-          inlineCache.name,
-          Arrays.copyOfRange(args, 1, args.length)
+        args[0],
+        inlineCache.name,
+        Arrays.copyOfRange(args, 1, args.length)
       };
       target = lookupTarget(receiverClass, fallbackCallSite, fallbackArgs);
       if (target != null) {

--- a/src/main/java/org/eclipse/golo/runtime/adapters/JavaBytecodeAdapterGenerator.java
+++ b/src/main/java/org/eclipse/golo/runtime/adapters/JavaBytecodeAdapterGenerator.java
@@ -146,9 +146,9 @@ public class JavaBytecodeAdapterGenerator {
   private void makeConstructors(ClassWriter classWriter, AdapterDefinition adapterDefinition) {
     try {
       Class<?> parentClass = Class.forName(adapterDefinition.getParent(), true, adapterDefinition.getClassLoader());
-      for (Constructor constructor : parentClass.getDeclaredConstructors()) {
+      for (Constructor<?> constructor : parentClass.getDeclaredConstructors()) {
         if (Modifier.isPublic(constructor.getModifiers()) || Modifier.isProtected(constructor.getModifiers())) {
-          Class[] parameterTypes = constructor.getParameterTypes();
+          Class<?>[] parameterTypes = constructor.getParameterTypes();
           Type[] adapterParameterTypes = new Type[parameterTypes.length + 1];
           adapterParameterTypes[0] = Type.getType(AdapterDefinition.class);
           for (int i = 1; i < adapterParameterTypes.length; i++) {
@@ -163,7 +163,7 @@ public class JavaBytecodeAdapterGenerator {
               "Lorg/eclipse/golo/runtime/adapters/AdapterDefinition;");
           methodVisitor.visitVarInsn(ALOAD, 0);
           int argIndex = 2;
-          for (Class parameterType : parameterTypes) {
+          for (Class<?> parameterType : parameterTypes) {
             argIndex = loadArgument(methodVisitor, parameterType, argIndex);
           }
           methodVisitor.visitMethodInsn(INVOKESPECIAL, Type.getInternalName(parentClass), "<init>", Type.getConstructorDescriptor(constructor), false);

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -17,8 +17,6 @@ import org.eclipse.golo.compiler.parser.ParseException;
 import org.eclipse.golo.compiler.testing.support.ClassWithOverloadedMethods;
 import org.eclipse.golo.runtime.AmbiguousFunctionReferenceException;
 import gololang.*;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -218,9 +216,9 @@ public class CompileAndRunTest {
       List<GoloCompilationException.Problem> problems = expected.getProblems();
       assertThat(problems.size(), is(1));
       GoloCompilationException.Problem problem = problems.get(0);
-      assertThat(problem.getType(), Matchers.is(GoloCompilationException.Problem.Type.UNDECLARED_REFERENCE));
-      assertThat(problem.getSource().getIrElement(), instanceOf(ReferenceLookup.class));
-      ReferenceLookup lookup = (ReferenceLookup) problem.getSource().getIrElement();
+      assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.UNDECLARED_REFERENCE));
+      assertThat(problem.getSource(), instanceOf(ReferenceLookup.class));
+      ReferenceLookup lookup = (ReferenceLookup) problem.getSource();
       assertThat(lookup.getName(), is("some_parameter"));
       assertThat(lookup.positionInSourceCode().getStartLine(), is(4));
       assertThat(lookup.positionInSourceCode().getEndLine(), is(4));
@@ -239,7 +237,7 @@ public class CompileAndRunTest {
       List<GoloCompilationException.Problem> problems = expected.getProblems();
       assertThat(problems.size(), is(1));
       GoloCompilationException.Problem problem = problems.get(0);
-      assertThat(problem.getType(), Matchers.is(GoloCompilationException.Problem.Type.UNDECLARED_REFERENCE));
+      assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.UNDECLARED_REFERENCE));
       assertThat(problem.getSource(), instanceOf(ASTAssignment.class));
       ASTAssignment assignment = (ASTAssignment) problem.getSource();
       assertThat(assignment.getName(), is("bar"));
@@ -258,9 +256,9 @@ public class CompileAndRunTest {
       List<GoloCompilationException.Problem> problems = expected.getProblems();
       assertThat(problems.size(), is(1));
       GoloCompilationException.Problem problem = problems.get(0);
-      assertThat(problem.getType(), Matchers.is(GoloCompilationException.Problem.Type.ASSIGN_CONSTANT));
-      assertThat(problem.getSource().getIrElement(), instanceOf(AssignmentStatement.class));
-      AssignmentStatement statement = (AssignmentStatement) problem.getSource().getIrElement();
+      assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.ASSIGN_CONSTANT));
+      assertThat(problem.getSource(), instanceOf(AssignmentStatement.class));
+      AssignmentStatement statement = (AssignmentStatement) problem.getSource();
       assertThat(statement.getLocalReference().getName(), is("foo"));
       assertThat(statement.positionInSourceCode().getStartLine(), is(7));
       assertThat(statement.positionInSourceCode().getEndLine(), is(7));
@@ -279,7 +277,7 @@ public class CompileAndRunTest {
       List<GoloCompilationException.Problem> problems = expected.getProblems();
       assertThat(problems.size(), is(1));
       GoloCompilationException.Problem problem = problems.get(0);
-      assertThat(problem.getType(), Matchers.is(GoloCompilationException.Problem.Type.UNDECLARED_REFERENCE));
+      assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.UNDECLARED_REFERENCE));
       throw expected;
     }
   }
@@ -293,7 +291,7 @@ public class CompileAndRunTest {
       List<GoloCompilationException.Problem> problems = expected.getProblems();
       assertThat(problems.size(), is(1));
       GoloCompilationException.Problem problem = problems.get(0);
-      assertThat(problem.getType(), Matchers.is(GoloCompilationException.Problem.Type.REFERENCE_ALREADY_DECLARED_IN_BLOCK));
+      assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.REFERENCE_ALREADY_DECLARED_IN_BLOCK));
       throw expected;
     }
   }
@@ -526,12 +524,10 @@ public class CompileAndRunTest {
     } catch (GoloCompilationException expected) {
       List<GoloCompilationException.Problem> problems = expected.getProblems();
       assertThat(problems.size(), is(1));
-      MatcherAssert.assertThat(problems.get(0).getFirstToken(), notNullValue());
-      assertThat(problems.get(0).getFirstToken().startOffset, greaterThan(-1));
-      assertThat(problems.get(0).getFirstToken().endOffset, greaterThan(-1));
-      MatcherAssert.assertThat(problems.get(0).getLastToken(), notNullValue());
-      assertThat(problems.get(0).getLastToken().startOffset, greaterThan(-1));
-      assertThat(problems.get(0).getLastToken().endOffset, greaterThan(-1));
+      assertThat(problems.get(0).getPositionInSourceCode().getStartLine(), is(8));
+      assertThat(problems.get(0).getPositionInSourceCode().getEndLine(), is(8));
+      assertThat(problems.get(0).getPositionInSourceCode().getStartColumn(), is(3));
+      assertThat(problems.get(0).getPositionInSourceCode().getEndColumn(), is(18));
       throw expected;
     }
   }
@@ -1202,7 +1198,7 @@ public class CompileAndRunTest {
     } catch (GoloCompilationException e) {
       assertThat(e.getProblems().size(), is(1));
       GoloCompilationException.Problem problem = e.getProblems().get(0);
-      assertThat(problem.getType(), Matchers.is(GoloCompilationException.Problem.Type.BREAK_OR_CONTINUE_OUTSIDE_LOOP));
+      assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.BREAK_OR_CONTINUE_OUTSIDE_LOOP));
     }
   }
 
@@ -1239,7 +1235,7 @@ public class CompileAndRunTest {
     } catch (GoloCompilationException e) {
       assertThat(e.getProblems().size(), is(1));
       GoloCompilationException.Problem problem = e.getProblems().get(0);
-      assertThat(problem.getType(), Matchers.is(GoloCompilationException.Problem.Type.PARSING));
+      assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.PARSING));
     }
   }
 
@@ -1251,7 +1247,7 @@ public class CompileAndRunTest {
     } catch (GoloCompilationException e) {
       assertThat(e.getProblems().size(), is(1));
       GoloCompilationException.Problem problem = e.getProblems().get(0);
-      assertThat(problem.getType(), Matchers.is(GoloCompilationException.Problem.Type.PARSING));
+      assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.PARSING));
     }
   }
 
@@ -1783,7 +1779,7 @@ public class CompileAndRunTest {
     } catch (GoloCompilationException e) {
       assertThat(e.getProblems().size(), is(1));
       GoloCompilationException.Problem problem = e.getProblems().get(0);
-      assertThat(problem.getType(), Matchers.is(GoloCompilationException.Problem.Type.INCOMPLETE_NAMED_ARGUMENTS_USAGE));
+      assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.INCOMPLETE_NAMED_ARGUMENTS_USAGE));
     }
 
     Method golo_decoratored = moduleClass.getMethod("golo_decoratored");
@@ -1839,12 +1835,8 @@ public class CompileAndRunTest {
     } catch (GoloCompilationException expected) {
       List<GoloCompilationException.Problem> problems = expected.getProblems();
       assertThat(problems.size(), is(1));
-      MatcherAssert.assertThat(problems.get(0).getFirstToken(), notNullValue());
-      assertThat(problems.get(0).getFirstToken().startOffset, greaterThan(-1));
-      assertThat(problems.get(0).getFirstToken().endOffset, greaterThan(-1));
-      MatcherAssert.assertThat(problems.get(0).getLastToken(), notNullValue());
-      assertThat(problems.get(0).getLastToken().startOffset, greaterThan(-1));
-      assertThat(problems.get(0).getLastToken().endOffset, greaterThan(-1));
+      assertThat(problems.get(0).getPositionInSourceCode().getStartLine(), is(7));
+      assertThat(problems.get(0).getPositionInSourceCode().getStartColumn(), is(16));
       throw expected;
     }
   }

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -222,8 +222,10 @@ public class CompileAndRunTest {
       assertThat(problem.getSource().getIrElement(), instanceOf(ReferenceLookup.class));
       ReferenceLookup lookup = (ReferenceLookup) problem.getSource().getIrElement();
       assertThat(lookup.getName(), is("some_parameter"));
-      assertThat(lookup.positionInSourceCode().getLine(), is(4));
-      assertThat(lookup.positionInSourceCode().getColumn(), is(13));
+      assertThat(lookup.positionInSourceCode().getStartLine(), is(4));
+      assertThat(lookup.positionInSourceCode().getEndLine(), is(4));
+      assertThat(lookup.positionInSourceCode().getStartColumn(), is(13));
+      assertThat(lookup.positionInSourceCode().getEndColumn(), is(26));
       throw expected;
     }
   }
@@ -260,8 +262,10 @@ public class CompileAndRunTest {
       assertThat(problem.getSource().getIrElement(), instanceOf(AssignmentStatement.class));
       AssignmentStatement statement = (AssignmentStatement) problem.getSource().getIrElement();
       assertThat(statement.getLocalReference().getName(), is("foo"));
-      assertThat(statement.positionInSourceCode().getLine(), is(7));
-      assertThat(statement.positionInSourceCode().getColumn(), is(3));
+      assertThat(statement.positionInSourceCode().getStartLine(), is(7));
+      assertThat(statement.positionInSourceCode().getEndLine(), is(7));
+      assertThat(statement.positionInSourceCode().getStartColumn(), is(3));
+      assertThat(statement.positionInSourceCode().getEndColumn(), is(12));
       throw expected;
     }
   }

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -222,8 +222,8 @@ public class CompileAndRunTest {
       assertThat(problem.getSource().getIrElement(), instanceOf(ReferenceLookup.class));
       ReferenceLookup lookup = (ReferenceLookup) problem.getSource().getIrElement();
       assertThat(lookup.getName(), is("some_parameter"));
-      assertThat(lookup.getPositionInSourceCode().getLine(), is(4));
-      assertThat(lookup.getPositionInSourceCode().getColumn(), is(13));
+      assertThat(lookup.positionInSourceCode().getLine(), is(4));
+      assertThat(lookup.positionInSourceCode().getColumn(), is(13));
       throw expected;
     }
   }
@@ -260,8 +260,8 @@ public class CompileAndRunTest {
       assertThat(problem.getSource().getIrElement(), instanceOf(AssignmentStatement.class));
       AssignmentStatement statement = (AssignmentStatement) problem.getSource().getIrElement();
       assertThat(statement.getLocalReference().getName(), is("foo"));
-      assertThat(statement.getPositionInSourceCode().getLine(), is(7));
-      assertThat(statement.getPositionInSourceCode().getColumn(), is(3));
+      assertThat(statement.positionInSourceCode().getLine(), is(7));
+      assertThat(statement.positionInSourceCode().getColumn(), is(3));
       throw expected;
     }
   }

--- a/src/test/java/org/eclipse/golo/compiler/CompilerTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompilerTest.java
@@ -67,7 +67,7 @@ public class CompilerTest {
 
       problem = e.getProblems().get(0);
       assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.UNDECLARED_REFERENCE));
-      assertThat(problem.getSource().getLineInSourceCode(), is(4));
+      assertThat(problem.getPositionInSourceCode().getStartLine(), is(4));
     }
   }
 
@@ -87,7 +87,7 @@ public class CompilerTest {
 
       problem = e.getProblems().get(0);
       assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.PARSING));
-      assertThat(problem.getSource().getLineInSourceCode(), is(3));
+      assertThat(problem.getPositionInSourceCode().getStartLine(), is(3));
     }
   }
 
@@ -107,13 +107,13 @@ public class CompilerTest {
 
       problem = e.getProblems().get(0);
       assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.UNINITIALIZED_REFERENCE_ACCESS));
-      assertThat(problem.getSource().getLineInSourceCode(), is(4));
-      assertThat(problem.getSource().getColumnInSourceCode(), is(13));
+      assertThat(problem.getPositionInSourceCode().getStartLine(), is(4));
+      assertThat(problem.getPositionInSourceCode().getStartColumn(), is(13));
 
       problem = e.getProblems().get(1);
       assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.UNINITIALIZED_REFERENCE_ACCESS));
-      assertThat(problem.getSource().getLineInSourceCode(), is(5));
-      assertThat(problem.getSource().getColumnInSourceCode(), is(20));
+      assertThat(problem.getPositionInSourceCode().getStartLine(), is(5));
+      assertThat(problem.getPositionInSourceCode().getStartColumn(), is(20));
     }
   }
 
@@ -144,7 +144,7 @@ public class CompilerTest {
 
         problem = e.getProblems().get(0);
         assertThat(problem.getType(), is(GoloCompilationException.Problem.Type.AMBIGUOUS_DECLARATION));
-        assertThat(problem.getSource().getLineInSourceCode(), is(9));
+        assertThat(problem.getPositionInSourceCode().getStartLine(), is(9));
       }
     }
   }


### PR DESCRIPTION
Completely remove the link between the AST and the IR objects. This decouple the IR and the AST.
Also introduce the simulated self-type pattern to ease the definition of builder-like methods that returns the object itself on IR elements.

*NOTE*: this will probably break some IDE integration that works on / expect AST elements. However, as far as I can tell, these IDE plugins are already out of date and no more maintained (e.g. eclipse and netbeans ones still use the 'fr.insalyon.citi.golo' namespace). As a side note, maybe we should remove them from the documentation since they do not work anymore with the current golo version.