### PR TITLE
FIX #513: issue with implicit upcast of primitive

### DIFF
--- a/src/main/java/org/eclipse/golo/runtime/Extractors.java
+++ b/src/main/java/org/eclipse/golo/runtime/Extractors.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Modifier;
 import java.util.function.Predicate;
 
 import static org.eclipse.golo.runtime.TypeMatching.argumentsNumberMatches;
+import static org.eclipse.golo.runtime.TypeMatching.compareTypes;
 import static org.eclipse.golo.runtime.DecoratorsHelper.isMethodDecorated;
 
 public final class Extractors {
@@ -45,7 +46,7 @@ public final class Extractors {
         if (m2.isVarArgs() && !m1.isVarArgs()) {
           return -1;
         }
-        return 0;
+        return compareTypes(m1.getParameterTypes(), m2.getParameterTypes());
       });
   }
 

--- a/src/test/java/org/eclipse/golo/runtime/PrimitiveOverloadingTest.java
+++ b/src/test/java/org/eclipse/golo/runtime/PrimitiveOverloadingTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2012-2018 Institut National des Sciences Appliquées de Lyon (INSA Lyon) and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.golo.runtime;
+
+import org.testng.annotations.Test;
+import org.eclipse.golo.internal.testing.GoloTest;
+
+public class PrimitiveOverloadingTest extends GoloTest {
+
+  public static class Lib {
+
+    public String onInt(int i) {
+      return "int";
+    }
+
+    public String onLong(long l) {
+      return "long";
+    }
+
+    public String onFloat(float f) {
+      return "float";
+    }
+
+    public String onDouble(double d) {
+      return "double";
+    }
+
+    public String overloaded(float a, int b) {
+      return "floatxint";
+    }
+
+    public String overloaded(int a, float b) {
+      return "intxfloat";
+    }
+
+    public String overloaded2(int a, int b) {
+      return "intxint";
+    }
+
+    public String overloaded2(float a, float b) {
+      return "floatxfloat";
+    }
+
+    public String overloaded(int a) {
+      return "int";
+    }
+
+    public String overloaded(float a) {
+      return "float";
+    }
+
+    public static String soverloaded(int a) {
+      return "int";
+    }
+
+    public static String soverloaded(float a) {
+      return "float";
+    }
+
+    public static String soverloaded2(int a, int b) {
+      return "intxint";
+    }
+
+    public static String soverloaded2(float a, float b) {
+      return "floatxfloat";
+    }
+
+    public static String soverloaded(float a, int b) {
+      return "floatxint";
+    }
+
+    public static String soverloaded(int a, float b) {
+      return "intxfloat";
+    }
+
+    public static long getLong() {
+      return 42L;
+    }
+
+    public static int getInt() {
+      return 42;
+    }
+
+    public static float getFloat() {
+      return 42.0f;
+    }
+
+    public static double getDouble() {
+      return 42.0d;
+    }
+  }
+
+  @Override
+  protected String srcDir() {
+    return "for-execution/";
+  }
+
+  @Test
+  public void primitiveOverloading() throws Throwable {
+    run("primitive-overloading");
+  }
+}

--- a/src/test/java/org/eclipse/golo/runtime/TypeMatchingTest.java
+++ b/src/test/java/org/eclipse/golo/runtime/TypeMatchingTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012-2017 Institut National des Sciences Appliquées de Lyon (INSA-Lyon)
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.golo.runtime;
+
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+import static org.eclipse.golo.runtime.TypeMatching.compareSubstituable;
+import static org.eclipse.golo.runtime.TypeMatching.compareTypes;
+
+public class TypeMatchingTest {
+  @Test
+  public void compareSubstituable_numbers() {
+    assertThat(compareSubstituable(int.class, int.class) == 0, is(true));
+    assertThat(compareSubstituable(int.class, float.class) < 0, is(true));
+    assertThat(compareSubstituable(float.class, int.class) > 0, is(true));
+    assertThat(compareSubstituable(int.class, Object.class) < 0, is(true));
+    assertThat(compareSubstituable(int.class, Integer.class) == 0, is(true));
+    assertThat(compareSubstituable(int.class, Float.class) < 0, is(true));
+    assertThat(compareSubstituable(Integer.class, Float.class) < 0, is(true));
+    assertThat(compareSubstituable(Integer.class, float.class) < 0, is(true));
+  }
+
+  @Test
+  public void compareSubstituable_objects() {
+    assertThat(compareSubstituable(java.util.ArrayList.class, java.util.ArrayList.class) == 0, is(true));
+    assertThat(compareSubstituable(java.util.ArrayList.class, java.util.List.class) < 0, is(true));
+    assertThat(compareSubstituable(java.util.ArrayList.class, java.util.Collection.class) < 0, is(true));
+    assertThat(compareSubstituable(java.util.List.class, java.util.Collection.class) < 0, is(true));
+    assertThat(compareSubstituable(java.util.Collection.class, java.util.ArrayList.class) > 0, is(true));
+    assertThat(compareSubstituable(java.util.List.class, Object.class) < 0, is(true));
+  }
+
+  @Test
+  public void compareSubstituable_not_comparable() {
+    assertThat(compareSubstituable(java.util.List.class, int.class) == 0, is(true));
+    assertThat(compareSubstituable(int.class, java.util.List.class) == 0, is(true));
+    assertThat(compareSubstituable(String.class, java.util.List.class) == 0, is(true));
+  }
+
+  @Test
+  public void compareTypes_numbers() {
+    assertThat(compareTypes(ta(int.class, float.class), ta(int.class, float.class)) == 0, is(true));
+    assertThat(compareTypes(ta(int.class, int.class), ta(int.class, float.class)) < 0, is(true));
+    assertThat(compareTypes(ta(int.class, int.class), ta(float.class, float.class)) < 0, is(true));
+  }
+
+  private static Class<?>[] ta(Class<?>... c) {
+    return c;
+  }
+}

--- a/src/test/resources/for-execution/primitive-overloading.golo
+++ b/src/test/resources/for-execution/primitive-overloading.golo
@@ -1,0 +1,89 @@
+module Test
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+import org.eclipse.golo.runtime
+import org.eclipse.golo.runtime.PrimitiveOverloadingTest$Lib
+
+function test_onInt = {
+  let l = PrimitiveOverloadingTest$Lib()
+  assertThat(l: onInt(getInt()), `is("int"))
+}
+
+function test_onLong = {
+  let l = PrimitiveOverloadingTest$Lib()
+  assertThat(l: onLong(getLong()), `is("long"))
+  assertThat(l: onLong(getInt()), `is("long"))
+}
+
+function test_onFloat = {
+  let l = PrimitiveOverloadingTest$Lib()
+  assertThat(l: onFloat(getFloat()), `is("float"))
+  assertThat(l: onFloat(getLong()), `is("float"))
+  assertThat(l: onFloat(getInt()), `is("float"))
+}
+
+function test_unary_overloaded = {
+  let l = PrimitiveOverloadingTest$Lib()
+  assertThat(l: overloaded(getInt()), `is("int"))
+  assertThat(l: overloaded(getFloat()), `is("float"))
+}
+
+function test_binary_overloaded = {
+  let l = PrimitiveOverloadingTest$Lib()
+  assertThat(l: overloaded(getInt(), getFloat()), `is("intxfloat"))
+  assertThat(l: overloaded(getFloat(), getInt()), `is("floatxint"))
+  assertThat(l: overloaded(getInt(), getInt()), `is("intxfloat"))
+}
+
+function test_cast_float_to_int = {
+  # must fail since we can't cast an float into an int
+  let l = PrimitiveOverloadingTest$Lib()
+  try {
+    l: overloaded(getFloat(), getFloat())
+    throw AssertionError("should fail")
+  } catch(e) {
+    if not (e oftype NoSuchMethodError.class) {
+      throw e
+    }
+  }
+}
+
+function test_overloaded2 = {
+  let l = PrimitiveOverloadingTest$Lib()
+  assertThat(l: overloaded2(getInt(), getInt()), `is("intxint"))
+  assertThat(l: overloaded2(getFloat(), getFloat()), `is("floatxfloat"))
+  assertThat(l: overloaded2(getFloat(), getInt()), `is("floatxfloat"))
+  assertThat(l: overloaded2(getInt(), getFloat()), `is("floatxfloat"))
+}
+
+function test_static_overloaded2 = {
+  assertThat(soverloaded2(getInt(), getInt()), `is("intxint"))
+  assertThat(soverloaded2(getFloat(), getFloat()), `is("floatxfloat"))
+  assertThat(soverloaded2(getFloat(), getInt()), `is("floatxfloat"))
+  assertThat(soverloaded2(getInt(), getFloat()), `is("floatxfloat"))
+}
+
+function test_static_binary_overloaded = {
+  assertThat(soverloaded(getInt(), getFloat()), `is("intxfloat"))
+  assertThat(soverloaded(getFloat(), getInt()), `is("floatxint"))
+  assertThat(soverloaded(getInt(), getInt()), `is("intxfloat"))
+}
+
+function test_cast_float_to_int_static = {
+  # must fail since we can't cast an float into an int
+  try {
+    soverloaded(getFloat(), getFloat())
+    throw AssertionError("should fail")
+  } catch(e) {
+    if not (e oftype NoSuchMethodError.class) {
+      throw e
+    }
+  }
+}
+
+function test_static_unary_overloaded = {
+  assertThat(soverloaded(getInt()), `is("int"))
+  assertThat(soverloaded(getFloat()), `is("float"))
+}


### PR DESCRIPTION
When java method expect e.g. a float and it is called with a int, the
method is not found (since the big method resolution refactoring).

- adds a substituability comparison for method params
- use Extractors in function call resolution