### PR TITLE
Make method invocation left associative

### DIFF
--- a/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
+++ b/src/main/java/org/eclipse/golo/compiler/ir/BinaryOperation.java
@@ -50,6 +50,9 @@ public final class BinaryOperation extends ExpressionStatement<BinaryOperation> 
 
   public BinaryOperation right(Object expr) {
     this.rightExpression = makeParentOf(ExpressionStatement.of(expr));
+    if (this.type == OperatorType.ELVIS_METHOD_CALL && this.rightExpression instanceof MethodInvocation) {
+      ((MethodInvocation) this.rightExpression).setNullSafeGuarded(true);
+    }
     return this;
   }
 


### PR DESCRIPTION
Previously, golo code such as
```golo
a: f(): g(): h()
```

created an IR like
```
Binary operator: :
  Reference lookup: a
  Binary operator: :
    Method invocation: f, null safe? -> false
    Binary operator: :
      Method invocation: g, null safe? -> false
      Method invocation: h, null safe? -> false
```

The IR is now
```
Binary operator: :
  Binary operator: :
    Binary operator: :
      Reference lookup: a
      Method invocation: f, null safe? -> false
    Method invocation: g, null safe? -> false
  Method invocation: h, null safe? -> false
```

which is equivalent to 
```golo
((a: f()): g()): h()
```

