### PR TITLE
FIX 340: Issues with imported functions resolution

### DIFF
--- a/src/test/java/org/eclipse/golo/runtime/FunctionCallSupportTest.java
+++ b/src/test/java/org/eclipse/golo/runtime/FunctionCallSupportTest.java
@@ -158,4 +158,44 @@ public class FunctionCallSupportTest {
     CallSite callSite = FunctionCallSupport.bootstrap(lookup, name, type, 0);
     assertThat(callSite.dynamicInvoker().invokeWithArguments(new FunctionReference(plopFunc)), is((Object) "Plop!"));
   }
+
+  @Test
+  public void test_import_and_call_merging() throws Throwable {
+    String[] is = {"", "a.b.c", "a.b", "a", "a.b.c.d"};
+    String[] fs = {"a.b.c.d", "b.c.d", "c.d", "d"};
+    String[] results = {
+      "a.b.c.d",
+      "b.c.d",
+      "c.d",
+      "d",
+      "a.b.c.d",
+      "a.b.c.d",
+      "a.b.c.d",
+      "a.b.c.d",
+      "a.b.c.d",
+      "a.b.c.d",
+      "a.b.c.d",
+      "a.b.d",
+      "a.b.c.d",
+      "a.b.c.d",
+      "a.c.d",
+      "a.d",
+      "a.b.c.d",
+      "a.b.c.d",
+      "a.b.c.d",
+      "a.b.c.d"
+    };
+
+    int r = 0;
+    for (int i = 0; i < is.length; i++) {
+      for (int f = 0; f < fs.length; f++) {
+        assertThat(
+            FunctionCallSupport.mergeImportAndCall(is[i], fs[f]),
+            is(results[r]));
+        r++;
+      }
+    }
+    assertThat(FunctionCallSupport.mergeImportAndCall("a.b.c", "e.c.d"), is("a.b.c.e.c.d"));
+    assertThat(FunctionCallSupport.mergeImportAndCall("a.b.c", "b.e.d"), is("a.b.c.b.e.d"));
+  }
 }

--- a/src/test/java/org/eclipse/golo/runtime/ImportedFunctionResolutionTest.java
+++ b/src/test/java/org/eclipse/golo/runtime/ImportedFunctionResolutionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-2018 Institut National des Sciences Appliquées de Lyon (INSA Lyon) and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.golo.runtime;
+
+import org.testng.annotations.Test;
+import org.eclipse.golo.internal.testing.GoloTest;
+
+public class ImportedFunctionResolutionTest extends GoloTest {
+
+  private static final String[] MODS = {
+    "v0",
+    "v1b",
+    "v1",
+    "v2b",
+    "v2c",
+    "v2",
+    "v2inv",
+    "v3-1-1",
+    "v3-1-2",
+    "v3-1-3",
+    "v3-2-1",
+    "v3-2-2",
+    "v3-3"
+  };
+
+
+  @Override
+  protected String srcDir() {
+    return "for-execution/call-resolution/";
+  }
+
+  @Test
+  public void with_package() throws Throwable {
+    load("foo");
+    load("bar");
+    load("plop");
+    for (String m : MODS) {
+      run(m);
+    }
+    run("v4");
+  }
+
+  @Test
+  public void without_package() throws Throwable {
+    load("foo");
+    load("bar");
+    for (String m : MODS) {
+      run(m);
+    }
+  }
+}
+

--- a/src/test/resources/for-execution/call-resolution/bar.golo
+++ b/src/test/resources/for-execution/call-resolution/bar.golo
@@ -1,0 +1,5 @@
+
+module plop.Bar
+
+function doit = -> "Bar::doit"
+function polymorphic = |x| -> "Bar::polymorphic"

--- a/src/test/resources/for-execution/call-resolution/foo.golo
+++ b/src/test/resources/for-execution/call-resolution/foo.golo
@@ -1,0 +1,6 @@
+
+module plop.Foo
+
+function doit = -> "Foo::doit"
+
+function polymorphic = -> "Foo::polymorphic"

--- a/src/test/resources/for-execution/call-resolution/plop.golo
+++ b/src/test/resources/for-execution/call-resolution/plop.golo
@@ -1,0 +1,5 @@
+module plop
+
+function doit = -> "plop::doit"
+
+function delegate = -> Foo.doit()

--- a/src/test/resources/for-execution/call-resolution/v0.golo
+++ b/src/test/resources/for-execution/call-resolution/v0.golo
@@ -1,0 +1,10 @@
+
+module test0
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(plop.Foo.doit(), `is("Foo::doit"))
+  assertThat(plop.Bar.doit(), `is("Bar::doit"))
+}

--- a/src/test/resources/for-execution/call-resolution/v1.golo
+++ b/src/test/resources/for-execution/call-resolution/v1.golo
@@ -1,0 +1,12 @@
+
+module test1
+
+import plop
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(Foo.doit(), `is("Foo::doit"))
+  assertThat(Bar.doit(), `is("Bar::doit"))
+}

--- a/src/test/resources/for-execution/call-resolution/v1b.golo
+++ b/src/test/resources/for-execution/call-resolution/v1b.golo
@@ -1,0 +1,12 @@
+
+module test1b
+
+import plop
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(plop.Foo.doit(), `is("Foo::doit"))
+  assertThat(plop.Bar.doit(), `is("Bar::doit"))
+}

--- a/src/test/resources/for-execution/call-resolution/v2.golo
+++ b/src/test/resources/for-execution/call-resolution/v2.golo
@@ -1,0 +1,12 @@
+
+module test2a
+
+import plop.Foo
+import plop.Bar
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(doit(), `is("Foo::doit"))
+}

--- a/src/test/resources/for-execution/call-resolution/v2b.golo
+++ b/src/test/resources/for-execution/call-resolution/v2b.golo
@@ -1,0 +1,13 @@
+
+module test2b
+
+import plop.Foo
+import plop.Bar
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(Foo.doit(), `is("Foo::doit"))
+  assertThat(Bar.doit(), `is("Bar::doit"))
+}

--- a/src/test/resources/for-execution/call-resolution/v2c.golo
+++ b/src/test/resources/for-execution/call-resolution/v2c.golo
@@ -1,0 +1,13 @@
+
+module test2c
+
+import plop.Foo
+import plop.Bar
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(plop.Foo.doit(), `is("Foo::doit"))
+  assertThat(plop.Bar.doit(), `is("Bar::doit"))
+}
+

--- a/src/test/resources/for-execution/call-resolution/v2inv.golo
+++ b/src/test/resources/for-execution/call-resolution/v2inv.golo
@@ -1,0 +1,14 @@
+
+module test2ainv
+
+import plop.Bar
+import plop.Foo
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(doit(), `is("Bar::doit"))
+}
+function main = |args| {
+  require(doit() == "Bar::doit", "err")
+}

--- a/src/test/resources/for-execution/call-resolution/v3-1-1.golo
+++ b/src/test/resources/for-execution/call-resolution/v3-1-1.golo
@@ -1,0 +1,15 @@
+----
+Import both modules, call with only module name.
+----
+module Test311
+
+import plop.Foo
+import plop.Bar
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(Foo.polymorphic(), `is("Foo::polymorphic"))
+  assertThat(Bar.polymorphic(42), `is("Bar::polymorphic"))
+}

--- a/src/test/resources/for-execution/call-resolution/v3-1-2.golo
+++ b/src/test/resources/for-execution/call-resolution/v3-1-2.golo
@@ -1,0 +1,14 @@
+----
+import both modules, call FQN
+----
+module Test312
+
+import plop.Foo
+import plop.Bar
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(plop.Foo.polymorphic(), `is("Foo::polymorphic"))
+  assertThat(plop.Bar.polymorphic(42), `is("Bar::polymorphic"))
+}

--- a/src/test/resources/for-execution/call-resolution/v3-1-3.golo
+++ b/src/test/resources/for-execution/call-resolution/v3-1-3.golo
@@ -1,0 +1,15 @@
+
+----
+import both modules, call with only function name
+----
+module Test313
+
+import plop.Foo
+import plop.Bar
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(polymorphic(), `is("Foo::polymorphic"))
+  assertThat(polymorphic(42), `is("Bar::polymorphic"))
+}

--- a/src/test/resources/for-execution/call-resolution/v3-2-1.golo
+++ b/src/test/resources/for-execution/call-resolution/v3-2-1.golo
@@ -1,0 +1,15 @@
+----
+import only common package, call with module
+----
+module Test321
+
+import plop
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(Foo.polymorphic(), `is("Foo::polymorphic"))
+  assertThat(Bar.polymorphic(42), `is("Bar::polymorphic"))
+}
+

--- a/src/test/resources/for-execution/call-resolution/v3-2-2.golo
+++ b/src/test/resources/for-execution/call-resolution/v3-2-2.golo
@@ -1,0 +1,14 @@
+
+----
+import only common package, call FQN
+----
+module Test322
+
+import plop
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(plop.Foo.polymorphic(), `is("Foo::polymorphic"))
+  assertThat(plop.Bar.polymorphic(42), `is("Bar::polymorphic"))
+}

--- a/src/test/resources/for-execution/call-resolution/v3-3.golo
+++ b/src/test/resources/for-execution/call-resolution/v3-3.golo
@@ -1,0 +1,11 @@
+----
+no import, call FQN
+----
+module Test33
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(plop.Foo.polymorphic(), `is("Foo::polymorphic"))
+  assertThat(plop.Bar.polymorphic(42), `is("Bar::polymorphic"))
+}

--- a/src/test/resources/for-execution/call-resolution/v4.golo
+++ b/src/test/resources/for-execution/call-resolution/v4.golo
@@ -1,0 +1,11 @@
+module test4
+
+import plop
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+function test_ = {
+  assertThat(delegate(), `is("Foo::doit"))
+}
+

--- a/src/test/resources/for-execution/dynamic-evaluation.golo
+++ b/src/test/resources/for-execution/dynamic-evaluation.golo
@@ -19,3 +19,8 @@ function run_plop = {
     return f(a, b)
   """)
 }
+
+function main = |args| {
+  require(maxer() == 10, "err: maxer")
+  require(run_plop() == 3, "err: run_plop")
+}


### PR DESCRIPTION
Fix #340 

The issue was in the way the imported namespace was merged with the
specified function name, in particular when the called name was relative
to an imported namespace.

Added debug infos in function call resolution.