### PR TITLE
Fix bugs on frozen DynamicObject

### DIFF
--- a/src/main/java/gololang/DynamicObject.java
+++ b/src/main/java/gololang/DynamicObject.java
@@ -102,6 +102,7 @@ public final class DynamicObject {
    * @return the same dynamic object.
    */
   public DynamicObject undefine(String name) {
+    frozenMutationCheck();
     properties.remove(name);
     return this;
   }
@@ -147,7 +148,7 @@ public final class DynamicObject {
    * @return {@code true} if frozen, {@code false} otherwise.
    */
   public boolean isFrozen() {
-    return frozen;
+    return this.frozen;
   }
 
   /**
@@ -354,7 +355,7 @@ public final class DynamicObject {
   }
 
   private void frozenMutationCheck() {
-    if (frozen) {
+    if (this.frozen) {
       throw new IllegalStateException("the object is frozen");
     }
   }

--- a/src/main/java/org/eclipse/golo/runtime/MethodInvocationSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/MethodInvocationSupport.java
@@ -89,6 +89,7 @@ public final class MethodInvocationSupport {
       add("fallback");
       add("hasKind");
       add("sameKind");
+      add("isFrozen");
     }
   };
 

--- a/src/test/java/gololang/DynamicObjectTest.java
+++ b/src/test/java/gololang/DynamicObjectTest.java
@@ -286,4 +286,25 @@ public class DynamicObjectTest {
         "dynamic-objects.golo",
         classLoader(this));
   }
+
+  @Test
+  public void test_isFrozen() throws Throwable {
+    DynamicObject o = new DynamicObject();
+    assertThat(o.isFrozen(), is(false));
+    o.freeze();
+    assertThat(o.isFrozen(), is(true));
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void test_defined_frozen() throws Throwable {
+    DynamicObject o = new DynamicObject().freeze();
+    o.define("answer", 42);
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void test_undefined_frozen() throws Throwable {
+    DynamicObject o = new DynamicObject().define("answer", 42).freeze();
+    o.undefine("answer");
+  }
+
 }

--- a/src/test/java/gololang/DynamicObjectTest.java
+++ b/src/test/java/gololang/DynamicObjectTest.java
@@ -23,6 +23,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.testng.Assert.fail;
 
+import static org.eclipse.golo.internal.testing.TestUtils.classLoader;
+import static org.eclipse.golo.internal.testing.TestUtils.runTests;
+
 public class DynamicObjectTest {
 
   static Object foo(Object receiver) {
@@ -274,5 +277,13 @@ public class DynamicObjectTest {
     assertThat(obj.sameKind(new DynamicObject(Kinds.BAR)), is(false));
 
     assertThat(obj.copy().hasKind(Kinds.FOO), is(true));
+  }
+
+  @Test
+  public void test_execution() throws Throwable {
+    runTests(
+        "src/test/resources/for-execution/",
+        "dynamic-objects.golo",
+        classLoader(this));
   }
 }

--- a/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/CompileAndRunTest.java
@@ -1138,51 +1138,6 @@ public class CompileAndRunTest {
   }
 
   @Test
-  public void dynamic_objects() throws Throwable {
-    Class<?> moduleClass = compileAndLoadGoloModule(SRC, "dynamic-objects.golo");
-
-    Method get_value = moduleClass.getMethod("get_value");
-    assertThat((String) get_value.invoke(null), is("foo"));
-
-    Method set_then_get_value = moduleClass.getMethod("set_then_get_value");
-    assertThat((String) set_then_get_value.invoke(null), is("foo"));
-
-    Method call_as_method = moduleClass.getMethod("call_as_method");
-    assertThat((String) call_as_method.invoke(null), is("w00t"));
-
-    Method person_to_str = moduleClass.getMethod("person_to_str");
-    assertThat((String) person_to_str.invoke(null), is("Mr Bean <mrbean@outlook.com>"));
-
-    Method with_function_update = moduleClass.getMethod("with_function_update");
-    assertThat((Integer) with_function_update.invoke(null), is(40));
-
-    Method mixins = moduleClass.getMethod("mixins");
-    assertThat((String) mixins.invoke(null), is("4[plop]"));
-
-    Method copying = moduleClass.getMethod("copying");
-    assertThat((Integer) copying.invoke(null), is(3));
-
-    Method mrfriz = moduleClass.getMethod("mrfriz");
-    assertThat((String) mrfriz.invoke(null), is("OK"));
-
-    Method propz = moduleClass.getMethod("propz");
-    // Damn ordering on sets...
-    assertThat((String) propz.invoke(null), either(is("foo:foobar:bar")).or(is("bar:barfoo:foo")));
-
-    Method with_varargs = moduleClass.getMethod("with_varargs");
-    assertThat((String) with_varargs.invoke(null), is("||@1|@2@3|@4@5|[foo]@1[foo]@2@3[foo]@4@5[foo][fallback:jhon_doe][fallback:jhon_doe]@2@3"));
-
-    Method kinds = moduleClass.getMethod("kinds");
-    assertThat((Boolean) kinds.invoke(null), is(true));
-
-    Method checkToString = moduleClass.getMethod("checkToString");
-    assertThat((Boolean) checkToString.invoke(null), is(true));
-
-    Method checkDelegate = moduleClass.getMethod("checkDelegate");
-    assertThat((Boolean) checkDelegate.invoke(null), is(true));
-  }
-
-  @Test
   public void continue_and_break() throws Throwable {
     Class<?> moduleClass = compileAndLoadGoloModule(SRC, "continue-and-break.golo");
 

--- a/src/test/resources/for-execution/dynamic-objects.golo
+++ b/src/test/resources/for-execution/dynamic-objects.golo
@@ -182,3 +182,32 @@ function check_delegate = {
     assertThat(e, isA(UnsupportedOperationException.class))
   }
 }
+
+function test_isFrozen = {
+  let o = DynamicObject()
+  assertThat(o: isFrozen(), `is(false))
+  o: freeze()
+  assertThat(o: isFrozen(), `is(true))
+}
+
+function test_defined_frozen = {
+  let o = DynamicObject(): freeze()
+  try {
+    o: define("answer", 42)
+    raise("should fail")
+  } catch(e) {
+    assertThat(e, isA(IllegalStateException.class))
+  }
+}
+
+function test_undefined_frozen = {
+  let o = DynamicObject(): define("answer", 42): freeze()
+  try {
+    o: undefine("answer")
+    raise("should fail")
+  } catch(e) {
+    assertThat(e, isA(IllegalStateException.class))
+  }
+}
+
+


### PR DESCRIPTION
I found two bugs in the frozen `DynamicObject` behavior:
- the state was not checked in `undefine`, so one could undefine a property on a frozen object
- the `isFrozen` returned `null`, because is was not considered a reserved method name