### PR TITLE
FIX: bug in FunctionReference::acceptArity

### DIFF
--- a/src/main/java/gololang/FunctionReference.java
+++ b/src/main/java/gololang/FunctionReference.java
@@ -150,7 +150,7 @@ public class FunctionReference {
    * Check if this function can be invoked with the given number of arguments.
    */
   public boolean acceptArity(int nb) {
-    return arity() == nb || (arity() == nb + 1 && isVarargsCollector());
+    return arity() == nb || (nb >= arity() - 1 && isVarargsCollector());
   }
 
   public Object invoke(Object... args) throws Throwable {

--- a/src/test/resources/for-test/functions.golo
+++ b/src/test/resources/for-test/functions.golo
@@ -224,6 +224,24 @@ function test_arity = {
   assertEquals((|a, b...| -> "dhoo"): arity(), 2)
 }
 
+function test_accept_arity = {
+  assertEquals(( -> null): acceptArity(0), true)
+  assertEquals(( -> null): acceptArity(1), false)
+  assertEquals((|a| -> null): acceptArity(0), false)
+  assertEquals((|a| -> null): acceptArity(1), true)
+  assertEquals((|a| -> null): acceptArity(2), false)
+
+  assertEquals((|a...| -> null): acceptArity(0), true)
+  assertEquals((|a...| -> null): acceptArity(1), true)
+  assertEquals((|a...| -> null): acceptArity(2), true)
+
+  assertEquals((|a, b...| -> null): acceptArity(0), false)
+  assertEquals((|a, b...| -> null): acceptArity(1), true)
+  assertEquals((|a, b...| -> null): acceptArity(2), true)
+  assertEquals((|a, b...| -> null): acceptArity(3), true)
+  assertEquals((|a, b...| -> null): acceptArity(42), true)
+}
+
 function test_iob = {
   assertEquals(^bar: invokeOrBind("a"): invokeOrBind("b"): invokeOrBind("c"),
                "abc")


### PR DESCRIPTION
Bug in dealing with variadic functions that can accept more arguments than the number of formal parameters