### PR TITLE
Package index documentation

### DIFF
--- a/doc/documenting.adoc
+++ b/doc/documenting.adoc
@@ -12,7 +12,7 @@ text.
 Here is a quick example:
 
 [source,golo]
---
+....
 ----
 This is a *nice* module that does a bunch of useless things.
 
@@ -34,13 +34,13 @@ The following snipped prints `3`:
 Impressive!
 ----
 function adder = |x, y| -> x + y
---
+....
 
 Sections can be added in the documentation using the normal markdown syntax. The level of the titles is adapted to the generated documentation.
 For instance:
 
 [source,golo]
---
+....
 ----
 Encode a linked list as cons cells.
 
@@ -72,7 +72,28 @@ union List = {
     tail
   }
 }
---
+....
+
+The first sentence of a module documentation is displayed in module indexes.
+
+=== Package documentation
+
+Packages does not exists per se in Golo, but are represented in the form of module qualified names. However, it is common practice to group the modules of the same namespace into a common directory. There exists several ways to document such packages. The first is to create an empty golo module named after the package, containing the documentation. This file can have any name and be in any directory. For instance, given several modules `pkg.MyModule` and `pkg.OtherModule`, one can document the `pkg` package by creating a module containing:
+
+[source,golo]
+....
+----
+Here goes the package documentation
+----
+module pkg
+....
+
+No class will be compiled from this module, only a documentation page.
+
+The other way to document the `pkg` package, assuming that both modules are in `src/pkg/MyModule.golo` and `src/pkg/OtherModule.golo` respectively, is to create pure markdown file, containing the documentation for the package. This file *must* be named either `src/pkg/README.md`, `src/pkg/package.md` or `src/pkg.md`. If a golo file corresponding to the package exists, these files are ignored.
+
+[[warning-multiple-package-desc]]
+If several candidates are found, only the *first one* is used, and a warning is printed. It can be disabled by setting the `golo.warnings.doc.multiple-package-desc` system property to `false`.
 
 === Rendering documentation
 
@@ -88,7 +109,7 @@ editors such as Vim or emacs. In this mode, the special output target `-` can
 be used to print the tags on standard output, which is needed by some editors
 or extensions.
 
-Please consult `golo help` for more details.
+Please consult `golo --usage doc` for more details.
 
 === Alignment
 
@@ -96,7 +117,7 @@ It is sometimes necessary to indent documentation blocks to match the surroundin
 Documentation blocks erase indentation based on the indentation level of the opening block:
 
 [source,golo]
---
+....
 ----
 The most useful augmentation *ever*.
 ----
@@ -107,7 +128,7 @@ augment java.lang.String {
   ----
   function toURL = |this| -> java.net.URL(this)
 }
---
+....
 
 When generating documentation from the code above, the documentation block of the `toURL` function
 is unindented of 2 spaces.

--- a/src/main/golo/gololang/ir.golo
+++ b/src/main/golo/gololang/ir.golo
@@ -80,7 +80,7 @@ augment gololang.ir.GoloElement {
   function dump = |this| -> this: accept(IrTreeDumper())
 }
 
-#== ## Types
+#== ## Types -----------------------------------------------------------------
 
 ----
 Creates a structure
@@ -103,7 +103,7 @@ However, this builder can be useful if one wants to customize the member (e.g. b
 function member = |name| -> Member.of(name)
 
 
-#== ## Functions
+#== ## Functions -------------------------------------------------------------
 
 ----
 Create a function decorator from the given expression.
@@ -131,7 +131,7 @@ and [`lambda`](#lambda_1v)
 function `function = |name| -> GoloFunction.`function(name)
 
 
-#== ## Augmentations
+#== ## Augmentations ---------------------------------------------------------
 
 ----
 Creates an augmentation on the target name.

--- a/src/main/java/gololang/ir/Struct.java
+++ b/src/main/java/gololang/ir/Struct.java
@@ -10,8 +10,6 @@
 
 package gololang.ir;
 
-import org.eclipse.golo.compiler.PackageAndClass;
-
 import java.util.Set;
 
 /**

--- a/src/main/java/gololang/ir/TypeWithMembers.java
+++ b/src/main/java/gololang/ir/TypeWithMembers.java
@@ -11,7 +11,6 @@
 package gololang.ir;
 
 import java.util.*;
-import org.eclipse.golo.compiler.PackageAndClass;
 
 import static gololang.ir.GoloFunction.function;
 import static java.util.stream.Collectors.toList;

--- a/src/main/java/gololang/ir/Visitors.java
+++ b/src/main/java/gololang/ir/Visitors.java
@@ -1,7 +1,6 @@
 package gololang.ir;
 
 import gololang.FunctionReference;
-import gololang.Tuple;
 import java.util.*;
 import java.util.function.BiFunction;
 

--- a/src/main/java/org/eclipse/golo/cli/command/DocCommand.java
+++ b/src/main/java/org/eclipse/golo/cli/command/DocCommand.java
@@ -60,7 +60,7 @@ public class DocCommand implements CliCommand {
   public void execute() throws Throwable {
     compiler = classpath.initGoloClassLoader().getCompiler();
     AbstractProcessor processor = FORMATS.get(this.format).get();
-    HashMap<String, ModuleDocumentation> modules = new HashMap<>();
+    HashSet<ModuleDocumentation> modules = new HashSet<>();
     for (String source : this.sources) {
       loadGoloFile(source, modules);
     }
@@ -71,7 +71,7 @@ public class DocCommand implements CliCommand {
     }
   }
 
-  private void loadGoloFile(String goloFile, HashMap<String, ModuleDocumentation> modules) {
+  private void loadGoloFile(String goloFile, HashSet<ModuleDocumentation> modules) {
     File file = new File(goloFile);
     if (file.isDirectory()) {
       File[] directoryFiles = file.listFiles();
@@ -82,7 +82,7 @@ public class DocCommand implements CliCommand {
       }
     } else if (file.getName().endsWith(".golo")) {
       try {
-        modules.put(goloFile, ModuleDocumentation.load(goloFile, compiler));
+        modules.add(ModuleDocumentation.load(goloFile, compiler));
       } catch (IOException e) {
         error(message("file_not_found", goloFile));
         return;

--- a/src/main/java/org/eclipse/golo/compiler/GoloCompiler.java
+++ b/src/main/java/org/eclipse/golo/compiler/GoloCompiler.java
@@ -105,6 +105,9 @@ public class GoloCompiler {
     ASTCompilationUnit compilationUnit = parse(goloSourceFilename,
                                           initParser(goloSourceFilename, sourceCodeInputStream));
     GoloModule goloModule = check(compilationUnit);
+    if (goloModule.isEmpty()) {
+      return Collections.emptyList();
+    }
     return generate(goloModule, goloSourceFilename);
   }
 

--- a/src/main/java/org/eclipse/golo/doc/CtagsProcessor.java
+++ b/src/main/java/org/eclipse/golo/doc/CtagsProcessor.java
@@ -13,8 +13,7 @@ package org.eclipse.golo.doc;
 import gololang.IO;
 
 import java.nio.file.Path;
-import java.util.LinkedList;
-import java.util.Map;
+import java.util.*;
 
 public class CtagsProcessor extends AbstractProcessor {
 
@@ -180,7 +179,7 @@ public class CtagsProcessor extends AbstractProcessor {
   }
 
   @Override
-  public void process(Map<String, ModuleDocumentation> modules, Path targetFolder) throws Throwable {
+  public void process(Collection<ModuleDocumentation> modules, Path targetFolder) throws Throwable {
     Path targetFile = null;
     if ("-".equals(targetFolder.toString())) {
       targetFile = targetFolder;
@@ -188,9 +187,9 @@ public class CtagsProcessor extends AbstractProcessor {
       targetFile = targetFolder.resolve("tags");
     }
     ctags.clear();
-    for (Map.Entry<String, ModuleDocumentation> src : modules.entrySet()) {
-      file = src.getKey();
-      render(src.getValue());
+    for (ModuleDocumentation doc : modules) {
+      file = doc.sourceFile();
+      render(doc);
     }
     IO.textToFile(ctagsAsString(), targetFile);
   }

--- a/src/main/java/org/eclipse/golo/doc/DocumentationElement.java
+++ b/src/main/java/org/eclipse/golo/doc/DocumentationElement.java
@@ -23,6 +23,21 @@ public interface DocumentationElement extends Comparable<DocumentationElement> {
   String documentation();
 
   /**
+   * Chech if this element has a documentation.
+   * <p>
+   * An element has a documentation if its {@link #documentation()} method returns a non null non empty (when trimmed)
+   * string.
+   */
+  default boolean hasDocumentation() {
+    String doc = documentation();
+    if (doc == null) {
+      return false;
+    }
+    doc = doc.trim();
+    return !doc.isEmpty();
+  }
+
+  /**
    * The line where the element is defined.
    */
   int line();

--- a/src/main/java/org/eclipse/golo/doc/MarkdownProcessor.java
+++ b/src/main/java/org/eclipse/golo/doc/MarkdownProcessor.java
@@ -14,7 +14,7 @@ import gololang.FunctionReference;
 import gololang.IO;
 
 import java.nio.file.Path;
-import java.util.Map;
+import java.util.Collection;
 
 public class MarkdownProcessor extends AbstractProcessor {
 
@@ -31,9 +31,9 @@ public class MarkdownProcessor extends AbstractProcessor {
   }
 
   @Override
-  public void process(Map<String, ModuleDocumentation> modules, Path targetFolder) throws Throwable {
+  public void process(Collection<ModuleDocumentation> modules, Path targetFolder) throws Throwable {
     setTargetFolder(targetFolder);
-    for (ModuleDocumentation doc : modules.values()) {
+    for (ModuleDocumentation doc : modules) {
       IO.textToFile(render(doc), outputFile(doc.moduleName()));
     }
     renderIndex("index");

--- a/src/main/java/org/eclipse/golo/runtime/AugmentationMethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/AugmentationMethodFinder.java
@@ -15,12 +15,10 @@ import java.lang.reflect.Method;
 import java.util.stream.Stream;
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.List;
 import org.eclipse.golo.runtime.augmentation.DefiningModule;
 
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.reflect.Modifier.*;
-import static org.eclipse.golo.runtime.NamedArgumentsHelper.checkArgumentPosition;
 
 class AugmentationMethodFinder extends MethodFinder {
 

--- a/src/main/java/org/eclipse/golo/runtime/ClosureCallSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/ClosureCallSupport.java
@@ -17,9 +17,7 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.util.Arrays;
 
 import static java.lang.invoke.MethodHandles.guardWithTest;
-import static java.lang.invoke.MethodHandles.permuteArguments;
 import static java.lang.invoke.MethodType.methodType;
-import static org.eclipse.golo.runtime.NamedArgumentsHelper.checkArgumentPosition;
 
 public final class ClosureCallSupport {
 

--- a/src/main/java/org/eclipse/golo/runtime/FunctionCallSupport.java
+++ b/src/main/java/org/eclipse/golo/runtime/FunctionCallSupport.java
@@ -15,10 +15,8 @@ import gololang.FunctionReference;
 import java.lang.invoke.*;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.*;
-import java.util.List;
 import java.util.Optional;
 
-import static java.lang.invoke.MethodHandles.permuteArguments;
 import static java.lang.invoke.MethodType.methodType;
 import static java.lang.reflect.Modifier.isPrivate;
 import static java.lang.reflect.Modifier.isStatic;

--- a/src/main/java/org/eclipse/golo/runtime/MethodFinder.java
+++ b/src/main/java/org/eclipse/golo/runtime/MethodFinder.java
@@ -13,15 +13,11 @@ package org.eclipse.golo.runtime;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Method;
 import java.util.Optional;
-import java.util.List;
 import static org.eclipse.golo.runtime.DecoratorsHelper.getDecoratedMethodHandle;
 import static org.eclipse.golo.runtime.DecoratorsHelper.isMethodDecorated;
 
-import static java.lang.invoke.MethodHandles.permuteArguments;
 import static java.lang.invoke.MethodHandles.Lookup;
-import static org.eclipse.golo.runtime.NamedArgumentsHelper.hasNamedParameters;
 import static org.eclipse.golo.runtime.NamedArgumentsHelper.getParameterNames;
-import static org.eclipse.golo.runtime.NamedArgumentsHelper.checkArgumentPosition;
 
 abstract class MethodFinder {
 

--- a/src/main/java/org/eclipse/golo/runtime/Warnings.java
+++ b/src/main/java/org/eclipse/golo/runtime/Warnings.java
@@ -30,10 +30,17 @@ public final class Warnings {
   private static final boolean NO_PARAMETER_NAMES = load("golo.warnings.no-parameter-names", "true");
   private static final boolean UNAVAILABLE_CLASS = load("golo.warnings.unavailable-class", "false");
   private static final boolean DEPRECATED = load("golo.warnings.deprecated", "true");
+  private static final boolean MULTIPLE_PACKAGE_DESCRIPTION = load("golo.warnings.doc.multiple-package-desc", "true");
   private static final HashSet<Tuple> SEEN_DEPRECATIONS = new HashSet<>();
 
   private static boolean load(String property, String def) {
     return Boolean.valueOf(System.getProperty(property, def));
+  }
+
+  public static void multiplePackageDescription(String packageName) {
+    if (MULTIPLE_PACKAGE_DESCRIPTION) {
+      warning(message("multiple_package_desc", packageName, GUIDE_BASE));
+    }
   }
 
   public static void noParameterNames(String methodName, String[] argumentNames) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -77,3 +77,7 @@ struct_private_member = Private member of `{0}`
 no_parameter_names = The function `{0}` has no parameter names but is called with {1} as argument names.\n\tSee <{2}#warning-no-parameter-names> for more information.
 unavailable_class = `{0}` used in `{1}` can\u2019t be loaded.\n\tSee <{2}#warning-unavailable-class> for more information.
 deprecated_element = `{0}` used in `{1}` is deprecated.\n\tSee <{2}#warning-deprecated> for more information.
+
+# Documentation warnings and errors ===========================================
+multiple_package_desc = Multiple description files found for package `{0}`; using the first one.\n\tSee <{1}#warning-multiple-package-desc> for more information.
+

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -79,3 +79,6 @@ no_parameter_names = La fonction `{0}` n\u2019a pas de param\u00e8tre nomm\u00e9
 unavailable_class = `{0}` utilis\u00e9e dans `{1}` ne peut pas \u00eatre charg\u00e9e.\n\tVoir <{2}#warning-unavailable-class> pour plus d\u2019informations.
 deprecated_element = `{0}` utilis\u00e9e dans `{1}` est obsol\u00e8te.\n\tVoir <{2}#warning-deprecated> pour plus d\u2019informations.
 
+# Documentation warnings and errors ===========================================
+multiple_package_desc = Fichiers de description surnum\u00e9raires pour le paquet `{0}`; utilisation du premier.\n\tVoir <{1}#warning-multiple-package-desc> pour plus d\u2019informations.
+

--- a/src/main/resources/org/eclipse/golo/doc/package-html
+++ b/src/main/resources/org/eclipse/golo/doc/package-html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<%@params processor%>
+<%@params processor, doc, submodules%>
 <%@import org.eclipse.golo.doc.HtmlProcessor %>
 <html>
 <head>
-  <title>Modules index</title>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Index of <%= doc: moduleName() %></title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <link rel="icon"
         href="data:image/x-icon;base64,AAABAAEAFBQAAAEAIAC4BgAAFgAAACgAAAAUAAAAKAAAAAEAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmd/wAAAAAA/34ADf+LAET/gwBb/4MAWv+LAD7/kQAFAAAAAAOW9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaX9AAAAAAA/4kAOv+GAMn/dAD/1l8A/6xRAP+pTwD/y1sA//9xAP//hgC0/4sAJgAAAAAAjvEAAAAAAAAAAAAAAAAAAAAAAAAAAAAImfQAAAAAAP+MAJ72aQD/a0EA/3REAP92RAD/cUIA/3FCAP92RAD/dEQA/25BAP//cwD//5AAeQAAAAAHlvEAAAAAAAAAAAAAAAAADJnzAAAAAAD/iwDBmVIA/3lHAP90RgD/k08A/81fAP//bwD/+24A/8VhAP+LSgD/d0cA/3RGAP/JXAD//44AmgAAAAAAgP8AAAAAAAAAAAAAAAAA/4gAmZxWAP9+SQD/gUoA//93AP//kQDw/44ArP+LAGb/jABt/44Auv+TAPjeaQD/fEoA/3xKAP/YZgD//5MAagAAAAAAAAAAHpT3AP+TAC/zbgD/gUwA/39OAP//hgD//5EAqgAAAAAAAAAAAAAAAACA/wAAAAAAAAAAAP+TAM//dAD/fkwA/3lOAP//fgD//4MACA+d9AAAAAAA/5kAuYFPAP+BTwD//3sA//+TAKQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJofYAAAAAAP+YANPBYwD/hFIA/65eAP//mQCMAAAAAAAAAAD/fgD/hFIA/5RZAP//kQD/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASnfQA/5AAHP+LAP9/VAD/fFEA//+QAOsAAAAA/44ANup2AP+LWQH/2GwA//+TAJwAAAAAAAAAAAAAAAAlSnoAAAAAAIxbAgIAAAAAAAAAAAAAAAAAAAAA/5QAzJxcAP+IVgH//4QA//+DAAj/mABV0G8A/5FeBP/4dwD//5YAZRea7wAAAAAAAAAAAAAAAACUXASFlF8E/5BZAiMAAAAAAAAAAAAAAAD/lgCXxmsA/5FeBP/+ewD//5sAJP+TAFfQcQL/lGEH//qBAP//mQBhF6LoAAAAAAAAAAAAAAAAAJhjB6qUYQf/mGMH/5hhBB8mTn8AAAAAAP+YAJPQcQL/lGEH//p7AP//kwAm/5QAQO18Av+ZZAn/1nYF//+ZAJAAAAAAAAAAAAAAAAAySG4AAAAAAJtmCtOZZAn/mWQJ/5RhBx0AAAAA/5wAwLVpB/+WYwn//4YB//+QAA//kwAL/4sE/5ZkDP+ZZgz//5wB8wAAAAAAAAAAAAAAAAAAAAAnT4EAAAAAAJ5pDdacZwz/nGcM/85zByT/mAH/kGMM/5NkDP//lAT2AAAAAAAAAAD/oQfUnmsR/55uEf//hgn//6AJfQAAAAAAAAAAAAAAAAAAAAApUoMAAAAAAKNsD9qhbBH+oWwR/t5+Df+hbBH/rG8P//+ZBZ8AAAAAAAAAAP+jClb+hA3/pG8U/6FxFP//mwz//6EMcgAAAAAqrPcAAAAAAAAAAAAtiMUAAAAAALN0Eu+kcxT/pHMU/6FxFP//kA3//5wFHSSq9AAAAAAAAAAAAP+kDce9dxX/qHMX/6hzF///kRL//6gP3P+kEW3/ng0k/6APKf+jD4P/ow/p/6ER/7l2Ff+ocxf/yXsV//+oD5IAAAAAAAAAAAAAAAAprfcA/6MXBf+hEu21fBr+rnca/6h3Gv/Gfhn//5EU//+mFP//pBX//6MU//+jFP//oxT//6MU//+OFP//oxTHAAAAACuu9wAAAAAAAAAAAAAAAAAutf8A/6YZCv+mGdfoiRr/pnsf/7F7Hf+jeR///6gX//+kFf//pBX//6QV//+kFf//pBX//6gXtgAAAAAtrvgAAAAAAAAAAAAAAAAAAAAAAAAAAAAusvkAAAAAAP+cGWf/nh33/5Mf//+UHf//qRr//6ka//+pGv//ox3//6ka8P+jGVYAAAAALrH3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/phw0/6gfav+rHYX/qx2H/6wfbP+sHzQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gfwAPgB8ADwAPAA4ABwAMAAMACB+BAAg/wQAIf8EAAH3gAAB44AAAeGAAAHwgAAB+AQAIPwEACB+BAAwAAwAMAAcADgAPAA+AHwAP4H8AA="/>
   <style>
@@ -15,11 +15,52 @@
       background-color: #fff;
       border-color: #999999;
       border-width: 2px;
-      margin: 2em auto;
+      margin: 1em auto;
       max-width: 50em;
       text-align: left;
       padding: 0;
     }
+
+    pre {
+      background-color: #eee;
+      -webkit-border-radius: 5px;
+      -moz-border-radius: 5px;
+      border-radius: 5px;
+      overflow: auto;
+    }
+    code {
+      font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+      background-color: #eee;
+      padding: 1px 3px;
+      -webkit-border-radius: 2px;
+      -moz-border-radius: 2px;
+      border-radius: 2px;
+    }
+    pre code {
+      padding-left: 0px;
+      padding-right: 0px;
+    }
+
+    .listing:hover code[data-lang]:before {
+      display: block;
+    }
+
+    .listing code {
+      position: relative;
+    }
+
+    .listing code[data-lang]:before {
+      display: none;
+      content: attr(data-lang);
+      position: absolute;
+      font-size: 0.75em;
+      top: .5rem;
+      right: 0.5rem;
+      line-height: 1;
+      text-transform: uppercase;
+      color: #000;
+    }
+
     ul > li {
       list-style-type: disc;
     }
@@ -45,6 +86,47 @@
       font-weight: bold;
     }
 
+    h3 {
+      color: #666;
+      font-size: 180%;
+      font-style: normal;
+      font-weight: bold;
+    }
+    h4 {
+      font-size: 130%;
+      font-style: normal;
+      font-weight: bold;
+    }
+    h5 {
+      font-size: 100%;
+      font-style: normal;
+      font-weight: bold;
+    }
+    h6 {
+      font-size: 100%;
+      font-style: italic;
+      font-weight: normal;
+    }
+
+    #global-nav {
+      display: block;
+      font-size: 80%;
+    }
+
+    #global-nav > a {
+      margin: 0em;
+      padding: 0 0.5em;
+    }
+    :target {
+      background-color: yellow;
+    }
+
+    .golodoc {
+      margin: 0;
+      padding: 0;
+      padding-left: 1.5em;
+    }
+
     .modules-list dd p {
       display: inline-block;
       margin: 0 0;
@@ -53,17 +135,32 @@
 </head>
 <body>
 
-    <nav>
-    <a href="<%= processor: linkToFile("index", "index-all") %>" rel="index">Global Index</a>
+    <nav id="global-nav">
+    <a href="<%= processor: linkToFile(doc, "index") %>" rel="home">Module Index</a>
+    <a href="<%= processor: linkToFile(doc, "index-all") %>" rel="index">Global Index</a>
     </nav>
 
-<h1>Modules index</h1>
+<h1>Index of <%= doc: moduleName() %></h1>
 
+<%if doc: hasDocumentation() {%>
+<div class="golodoc">
+  <%= process(doc: moduleDocumentation(), 1) %>
+</div>
+<%}%>
+
+<% if not submodules: isEmpty() {%>
+<h2 id="modules">Modules</h2>
 <dl class="modules-list">
-  <%foreach doc in processor: modules() {%>
-    <%=moduleListItem(doc, processor: linkToDoc("index", doc))%>
+  <%foreach sub in submodules {%>
+    <%=moduleListItem(sub, processor: link(doc, sub))%>
   <%}%>
 </dl>
+<%}%>
+
+<link rel="stylesheet" href="http://golo-lang.org/documentation/next/styles/github.min.css"/>
+<script src="http://golo-lang.org/documentation/next/highlight.min.js"></script>
+<script>hljs.initHighlighting()</script>
 
 </body>
 </html>
+

--- a/src/main/resources/org/eclipse/golo/doc/template-html
+++ b/src/main/resources/org/eclipse/golo/doc/template-html
@@ -1,13 +1,6 @@
 <!DOCTYPE html>
-<%@params processor, doc, src %>
+<%@params processor, doc, src, submodules %>
 <%@import org.eclipse.golo.doc.HtmlProcessor %>
-<%
-let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
-  : forceExtentedProfile()
-  : setCodeBlockEmitter(blockHighlighter())
-  : build()
-
-%>
 <html>
 <head>
   <title><%= doc: moduleName() %> (Golo <%= doc: goloVersion() %>)</title>
@@ -71,6 +64,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     li p {
       margin: 0.3em;
     }
+
     ul > li {
       list-style-type: disc;
     }
@@ -95,6 +89,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
       font-style: normal;
       font-weight: bold;
     }
+
     h3 {
       color: #666;
       font-size: 180%;
@@ -120,6 +115,11 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     #global-nav {
       display: block;
       font-size: 80%;
+    }
+
+    #global-nav > a {
+      margin: 0em;
+      padding: 0 0.5em;
     }
 
     #toc {
@@ -204,6 +204,11 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
       color: inherit;
     }
 
+    .modules-list li p {
+      display: inline-block;
+      margin: 0 0.5em;
+    }
+
     @media (max-width: 50em) {
       #toc {
         margin: auto;
@@ -272,16 +277,21 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
 <body>
 <h1>Documentation for <%= doc: moduleName() %></h1>
 
+<% if doc: hasDocumentation() {%>
 <div class="golodoc">
-  <%= process(doc: moduleDocumentation(), 1, CONFIG) %>
+  <%= process(doc: moduleDocumentation(), 1) %>
 </div>
+<%}%>
 
 <!-- begin table of content -->
 <nav id="toc">
 <h1><%= doc: moduleName() %></h1>
   <section id="global-nav">
-  <a href="<%= processor: linkToFile(doc, "index") %>" rel="home">Module Index</a>
-<a href="<%= processor: linkToFile(doc, "index-all") %>" rel="index">Global Index</a>
+    <a href="<%= processor: linkToFile(doc, "index") %>" rel="home">Module Index</a>
+    <a href="<%= processor: linkToFile(doc, "index-all") %>" rel="index">Global Index</a>
+    <% if not doc: packageName(): isEmpty() {%>
+    <a href="<%= processor: linkToFile(doc, doc: packageName()) %>" rel="up">Package Index</a>
+    <%}%>
   </section>
 <ul>
   <% if not doc: structs(): isEmpty() { %>
@@ -335,19 +345,33 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
 </nav>
 <!-- end table of content -->
 
+<% if not submodules: isEmpty() {%>
+<h2 id="modules">Submodules</h2>
+<ul class="modules-list">
+  <% foreach sub in submodules { %>
+    <li>
+      <a href="<%= processor: link(doc, sub) %>"><%= sub: moduleName() %></a>
+      <% if sub: hasDocumentation() {%>
+      : <%= process(sub: documentation(): split("\\."): get(0): trim())%>
+      <%}%>
+    </li>
+  <% } %>
+</ul>
+<%}%>
+
 <% if not doc: structs(): isEmpty() { %>
   <h2 id="structs">Structs</h2>
   <% foreach structDoc in doc: structs() { %>
     <%= sectionTitle(3, structDoc, src) %>
 
     <div class="golodoc">
-      <%= process(structDoc: documentation(), 3, CONFIG) %>
+      <%= process(structDoc: documentation(), 3) %>
     </div>
 
     <h5>Members</h5>
     <ul>
     <% foreach member in structDoc: members() { %>
-    <li><code id="<%= member: id()%>"><%= member: name() %></code> <%= process(member: documentation(): trim(), 5, CONFIG) %>
+    <li><code id="<%= member: id()%>"><%= member: name() %></code> <%= process(member: documentation(): trim(), 5) %>
       </li>
   <% } %>
     </ul>
@@ -360,19 +384,19 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     <%= sectionTitle(3, unionDoc, src) %>
 
     <div class="golodoc">
-    <%= process(unionDoc: documentation(), 3, CONFIG) %>
+    <%= process(unionDoc: documentation(), 3) %>
     </div>
 
     <% foreach unionValueDoc in unionDoc: values() { %>
     <%= sectionTitle(4, unionValueDoc, src) %>
 
-    <div class="golodoc"><%= process(unionValueDoc: documentation(), 4, CONFIG) %></div>
+    <div class="golodoc"><%= process(unionValueDoc: documentation(), 4) %></div>
 
     <% if not unionValueDoc: members(): isEmpty() { %>
         <h5>Members</h5>
         <ul>
         <% foreach member in unionValueDoc: members() { %>
-          <li><code id="<%= member: id()%>"><%= member: name() %></code> <%= process(member: documentation(): trim(), 5, CONFIG) %>
+          <li><code id="<%= member: id()%>"><%= member: name() %></code> <%= process(member: documentation(): trim(), 5) %>
           </li>
         <% } %>
         </ul>
@@ -386,12 +410,12 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
   <% foreach namedAugmentationDoc in doc: namedAugmentations() { %>
     <%= sectionTitle(3, namedAugmentationDoc, src) %>
     <div class="golodoc">
-      <%= process(namedAugmentationDoc: documentation(), 3, CONFIG) %>
+      <%= process(namedAugmentationDoc: documentation(), 3) %>
     </div>
     <% foreach funcDoc in namedAugmentationDoc { %>
       <%= sectionTitle(4, funcDoc, src) %>
       <div class="golodoc">
-        <%= process(funcDoc: documentation(), 4, CONFIG) %>
+        <%= process(funcDoc: documentation(), 4) %>
       </div>
     <% } %>
   <% } %>
@@ -403,7 +427,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
   <% foreach augmentDoc in doc: augmentations() { %>
     <%= sectionTitle(3, augmentDoc, src) %>
     <div class="golodoc">
-      <%= process(augmentDoc: documentation(), 3, CONFIG) %>
+      <%= process(augmentDoc: documentation(), 3) %>
     </div>
     <% if not augmentDoc: augmentationNames(): isEmpty() { %>
       <h5>Named augmentations applied</h5>
@@ -422,7 +446,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
     <% foreach funcDoc in augmentDoc { %>
       <%= sectionTitle(4, funcDoc, src) %>
       <div class="golodoc">
-        <%= process(funcDoc: documentation(), 4, CONFIG) %>
+        <%= process(funcDoc: documentation(), 4) %>
       </div>
     <% } %>
   <% } %>
@@ -433,7 +457,7 @@ let CONFIG = com.github.rjeschke.txtmark.Configuration.builder()
   <% foreach funcDoc in doc: functions() { %>
     <%= sectionTitle(3, funcDoc, src) %>
     <div class="golodoc">
-      <%= process(funcDoc: documentation(), 3, CONFIG) %>
+      <%= process(funcDoc: documentation(), 3) %>
     </div>
   <% } %>
 <% } %>

--- a/src/test/resources/for-parsing-and-compilation/docpackage/MyModule.golo
+++ b/src/test/resources/for-parsing-and-compilation/docpackage/MyModule.golo
@@ -1,0 +1,3 @@
+module docpackage.MyModule
+
+function foo =  -> 42

--- a/src/test/resources/for-parsing-and-compilation/docpackage/README.md
+++ b/src/test/resources/for-parsing-and-compilation/docpackage/README.md
@@ -1,0 +1,6 @@
+
+Doc for package docpackage.
+
+ # with a title
+
+


### PR DESCRIPTION
Adds package wide documentation (like `package-info.java`) by using
empty modules (no class generated, only doc) or `README.md` in the same
directory. The package doc links to all modules in the same package.
Such a doc is generated even if no info is provided, only listing
contained modules.

Even when the module is not empty, if modules exists in a "subnamespace"
(e.g. `my.module` and `my.module.sub`), the upper module links to the
others.

Moreover, a description of the module (from the first sentence of the
module golodoc) is included in the index.