### PR TITLE
FIX #543: Upgrade some dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,13 +86,13 @@ configurations.all {
 }
 
 dependencies {
-  compile 'org.ow2.asm:asm:7.0'
+  compile 'org.ow2.asm:asm:8.0'
   compile 'com.beust:jcommander:1.60'
   compile 'com.github.rjeschke:txtmark:0.13'
   compile 'com.googlecode.json-simple:json-simple:1.1.1'
 
-  testCompile 'org.ow2.asm:asm-util:7.0'
-  testCompile 'org.ow2.asm:asm-analysis:7.0'
+  testCompile 'org.ow2.asm:asm-util:8.0'
+  testCompile 'org.ow2.asm:asm-analysis:8.0'
   testCompile 'org.hamcrest:hamcrest-all:1.3'
   testCompile 'org.skyscreamer:jsonassert:1.5.0'
   testCompile 'org.testng:testng:6.11'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
   id 'maven-publish'
   id 'com.jfrog.bintray' version '1.8.4'
   id 'ca.coglinc.javacc' version '2.4.0'
-  id 'org.asciidoctor.convert' version '1.5.9.1'
+  id 'org.asciidoctor.jvm.convert' version '3.1.0'
   id 'net.nemerosa.versioning' version '2.8.2'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'com.adarshr.test-logger' version '1.6.0'
@@ -160,15 +160,18 @@ processResources {
 // .................................................................................................................. //
 
 asciidoctorj {
-  version = '1.5.4'
+  version = '2.4.0'
 }
 
 asciidoctor {
-  sourceDir 'doc'
+  sourceDir file('doc')
+  baseDirFollowsSourceDir()
   sources {
     include 'golo-guide.adoc'
   }
-  backends 'html5'
+  outputOptions {
+    backends = ['html5']
+  }
 }
 
 task assembleAsciidoc(type: Copy, dependsOn: asciidoctor) {

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ dependencies {
   testCompile 'org.hamcrest:hamcrest:2.2'
   testCompile 'org.skyscreamer:jsonassert:1.5.0'
   testCompile 'org.testng:testng:7.3.0'
-  testCompile 'com.google.inject:guice:4.1.0:no_aop' // for TestNG
+  testCompile 'com.google.inject:guice:4.2.3:no_aop' // for TestNG
 }
 
 // .................................................................................................................. //

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ configurations.all {
 
 dependencies {
   compile 'org.ow2.asm:asm:8.0'
-  compile 'com.beust:jcommander:1.60'
+  compile 'com.beust:jcommander:1.71'
   compile 'com.github.rjeschke:txtmark:0.13'
   compile 'com.googlecode.json-simple:json-simple:1.1.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ dependencies {
 
   testCompile 'org.ow2.asm:asm-util:8.0'
   testCompile 'org.ow2.asm:asm-analysis:8.0'
-  testCompile 'org.hamcrest:hamcrest-all:1.3'
+  testCompile 'org.hamcrest:hamcrest:2.2'
   testCompile 'org.skyscreamer:jsonassert:1.5.0'
   testCompile 'org.testng:testng:7.3.0'
   testCompile 'com.google.inject:guice:4.1.0:no_aop' // for TestNG

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,12 @@ plugins {
   id 'jacoco'
   id 'application'
   id 'maven-publish'
-  id 'com.jfrog.bintray' version '1.8.4'
+  id 'com.jfrog.bintray' version '1.8.5'
   id 'ca.coglinc.javacc' version '2.4.0'
   id 'org.asciidoctor.jvm.convert' version '3.1.0'
-  id 'net.nemerosa.versioning' version '2.8.2'
-  id 'com.github.ben-manes.versions' version '0.20.0'
-  id 'com.adarshr.test-logger' version '1.6.0'
+  id 'net.nemerosa.versioning' version '2.14.0'
+  id 'com.github.ben-manes.versions' version '0.29.0'
+  id 'com.adarshr.test-logger' version '1.7.1'
 }
 
 // .................................................................................................................. //

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ dependencies {
   testCompile 'org.ow2.asm:asm-analysis:8.0'
   testCompile 'org.hamcrest:hamcrest-all:1.3'
   testCompile 'org.skyscreamer:jsonassert:1.5.0'
-  testCompile 'org.testng:testng:6.11'
+  testCompile 'org.testng:testng:7.3.0'
   testCompile 'com.google.inject:guice:4.1.0:no_aop' // for TestNG
 }
 

--- a/src/test/java/gololang/ir/ReferenceTableTest.java
+++ b/src/test/java/gololang/ir/ReferenceTableTest.java
@@ -14,8 +14,8 @@ import org.testng.annotations.Test;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
+import static org.hamcrest.core.IsIterableContaining.hasItems;
 
 public class ReferenceTableTest {
 

--- a/src/test/java/org/eclipse/golo/compiler/SymbolGeneratorTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/SymbolGeneratorTest.java
@@ -14,8 +14,8 @@ import org.testng.annotations.Test;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
+import static org.hamcrest.core.IsIterableContaining.hasItems;
 
 public class SymbolGeneratorTest {
 


### PR DESCRIPTION
Upgrade some dependencies (#543)

- no change in JSONAssert since 2017 :scream:
- txtmark and JSONSimple has not change in a while, but other project share the name, not sure if its forks, we need to check
- test-logger >2.0 causes errors, upgrade to 1.7.1