### PR TITLE
Adds Java annotation to golo elements

### DIFF
--- a/src/main/golo/decorators.golo
+++ b/src/main/golo/decorators.golo
@@ -150,7 +150,7 @@ function lengthIs = |l| -> |v| {
 
 # .. Checkers .. #
 
-#XXX: checkers defined here need to be functions returning the actuall
+#XXX: checkers defined here need to be functions returning the actual
 # checkers, otherwise they are not accessible on import. Not very elegant.
 # Must be a better solution.
 

--- a/src/main/golo/decorators.golo
+++ b/src/main/golo/decorators.golo
@@ -150,7 +150,7 @@ function lengthIs = |l| -> |v| {
 
 # .. Checkers .. #
 
-#XXX: checkers defined here need to be functions returning the actual
+# NOTE: checkers defined here need to be functions returning the actual
 # checkers, otherwise they are not accessible on import. Not very elegant.
 # Must be a better solution.
 

--- a/src/main/golo/gololang/macros.golo
+++ b/src/main/golo/gololang/macros.golo
@@ -15,6 +15,7 @@ This module defines the set of predefined macros. It is `&use`d by default.
 module gololang.macros
 
 import gololang.ir
+import gololang.macros.Utils
 
 ----
 Don't expand the result of a macro.
@@ -103,4 +104,39 @@ macro use = |visitor, mod, args...| {
   if visitor: macroExists(init) {
     return init
   }
+}
+
+----
+Macro to mark an element as deprecated.
+
+Can be used as a toplevel macro decorator.
+For instance, to mark a function as deprecated:
+
+```golo
+@deprecated
+function foo = |a, b| -> a + b
+```
+
+Moreover, some additional informations can be provided. They are used to modify the element documentation.
+
+```golo
+@deprecated(since="3.4", comment="Use `gololang.Functions::add` instead")
+function foo = |a, b| -> a + b
+```
+
+- *param* `since`: the version since the element is deprecated
+- *param* `comment`: a comment explaining the reasons of the deprecation or the element to use instead
+- *returns* the element itself
+
+See also [`gololang.meta.Annotations::makeDeprecated`](meta/Annotations.html#makeDeprecated_3v)
+----
+macro deprecated = |args...| {
+  # TODO: generate a list of deprecated functions and types (a la javadoc) ?
+  # TODO: when swithching to java >= 9, adds the `since` and `forRemoval` arguments to the annotation
+  let positional, named = parseArguments(args)
+  require(positional: size() > 0, "`deprecated` macro must be applied on an element")
+  return gololang.meta.Annotations.makeDeprecated(
+      named: get("since")?: value(),
+      named: get("comment")?: value(),
+      positional)
 }

--- a/src/main/golo/gololang/meta/Annotations.golo
+++ b/src/main/golo/gololang/meta/Annotations.golo
@@ -1,0 +1,379 @@
+# ............................................................................................... #
+#
+# Copyright (c) 2012-2020 Institut National des Sciences Appliquées de Lyon (INSA Lyon) and others
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# ............................................................................................... #
+----
+Module to deal with java annotations.
+
+To flag a golo element with a Java annotation, one must add some metadata to the IR element.
+The metadata will be used by the compiler to add the required bytecode.
+
+To add such metadata, the most direct way is to create a macro that modify the IR node.
+
+This module provides functions to ease the creation of such macros by:
+
+- adding the annotation metadata ([`annotateElements`](#annotateElements_3v))
+- parsing the macro arguments and match them with the annotation fields ([`extractAnnotationArguments`](#extractAnnotationArguments_2))
+- checking that the target has a valid type w.r.t. the annotation definition ([`checkApplicableTo`](#checkApplicableTo_2))
+
+Moreover, since the creation of simple macro that only adds the metadata to the element is just boilerplate code,
+macros to generate such macros are provided (
+[`annotationWrapper`](#annotationWrapper_1),
+[`annotationWrapper`](#annotationWrapper_2) and
+[`annotationWrapper`](#annotationWrapper_3))
+
+Finally, a helper function to mark a element as deprecated is also provided.
+----
+module gololang.meta.Annotations
+
+import gololang.ir
+import gololang.ir.DSL
+import gololang.macros.Utils
+
+----
+Adds an annotation metadata to an element.
+
+This is a low-level function, no check is done.
+
+See [`annotateElements`](#annotateElements_3v) for a higher level function.
+
+- *param* `annotationClass`: the class of the annotation to add
+- *param* `args`: a map representing the annotation arguments
+- *param* `target`: the element to annotate
+- *returns* the element itself
+
+See [`extractAnnotationArguments`](#extractAnnotationArguments_2).
+----
+function addAnnotationMetadata = |annotationClass, args, target| {
+  if target: metadata("annotations") is null {
+    target: metadata("annotations", set[])
+  }
+  target: metadata("annotations"): add([
+    org.eclipse.golo.compiler.PackageAndClass.of(annotationClass: name()): toJVMRef(),
+    annotationClass: getAnnotation(java.lang.annotation.Retention.class)?: value() is java.lang.annotation.RetentionPolicy.RUNTIME(),
+    args])
+  return target
+}
+
+----
+Mark the element as deprecated, by setting the `deprecated` metadata and adding
+the `java.lang.Deprecated` annotation.
+Indeed, the annotation by itself is not sufficient, since a bytecode flag must also be set for the element to be
+considered deprecated by the Java compiler. The bytecode generator use the `deprecated` metadata to set this flag.
+
+Moreover, the documentation of the concerned element is also updated to document the deprecation.
+
+Can be applied to function declarations, types, or augmentations.
+Otherwise, the element is returned unchanged.
+
+- *param* `since`: the version in which the element became deprecated.
+- *param* `comment`: a comment to append to the element documentation.
+- *param* `elts`: the element to mark as deprecated.
+- *returns* the elements, wrapped in a `ToplevelElements` if required
+
+This function should not need to be called directly.
+Use the [`gololang.macros::deprecated`](../macros.html#deprecated_1v) macro instead
+----
+function makeDeprecated = |since, comment, elts...|  {
+  # TODO: when using java >= 9, add since and removal arguments to the annotation
+  let elt = wrapToplevel(elts)
+  elt: accept(Visitors.visitor!(|v,a,e| {
+    if e: isOneOf(GoloFunction.class, GoloType.class, GoloModule.class) {
+      annotateElement(e, java.lang.Deprecated.class, null)
+      e: metadata("deprecated", true)
+      e: documentation(generateDeprecatedDocumentation(e: documentation(), since, comment))
+    }
+    if e: isOneOf(GoloModule.class, NamedAugmentation.class, Augmentation.class, ToplevelElements.class) {
+      e: walk(v)
+    }
+  }, Visitors$Walk.NONE()))
+  return elt
+}
+
+local function generateDeprecatedDocumentation = |eltDoc, since, comment| {
+  let doc = StringBuilder(eltDoc orIfNull "")
+  doc: append("\n\n*Deprecated*")
+  if since isnt null {
+    doc: append(" since "): append(since): append(".")
+  }
+  if comment isnt null {
+    doc: append(" "): append(comment)
+  }
+  return doc: toString()
+}
+
+----
+Macro to generate a macro to add a Java annotation to a golo element.
+
+The name of the macro is the simple name of the annotation class, its documentation is auto-generated.
+
+- *param* `annotation`: the litteral fully qualified class reference to the annotation to use.
+- *returns* a macro that will add the given annotation to a golo element
+
+See [`annotationWrapper`](#annotationWrapper_3)
+----
+macro annotationWrapper = |annotation| -> generateWrapper(
+  annotation: value(): getName(): split("\\."): last(),
+  annotation)
+  : documentation(generateDocForWrapper(annotation: value()))
+
+----
+Macro to generate a macro to add a Java annotation to a golo element.
+
+The name of the generated macro is given and its documentation is auto-generated.
+
+- *param* `annotation`: the litteral fully qualified class reference to the annotation to use.
+- *param* `name`: the name of the generated macro (as a reference lookup, i.e. a name, not a string).
+- *returns* a macro that will add the given annotation to a golo element
+
+See [`annotationWrapper`](#annotationWrapper_3)
+----
+macro annotationWrapper = |annotation, name| -> generateWrapper(
+  name: value(),
+  annotation)
+  : documentation(generateDocForWrapper(annotation: value()))
+
+----
+Macro to generate a macro to add a Java annotation to a golo element.
+
+For instance, to create a macro to apply the `mypackage.MyAnnotation` Java annotation, one must create a macro such as:
+
+    ---
+    Apply the `MyAnnotation` annotation
+    ---
+    macro annotation = |args...| {
+      let a, u, e = extractAnnotationArguments(mypackage.MyAnnotation.class, args)
+      return annotateElements(mypackage.MyAnnotation.class, a, e)
+    }
+
+used as
+
+```golo
+@annotation(prop1="hello", prop2=42)
+function foo = -> null
+```
+(given the annotation has the `prop1` and `prop2` properties.
+
+This macro generate the corresponding macro, thus allowing to simply write
+
+```golo
+&annotationWrapper(
+    mypackage.MyAnnotation.class,
+    annotation,
+    "Apply the `MyAnnotation` annotation")
+```
+
+- *param* `annotation`: the litteral fully qualified class reference to the annotation to use.
+- *param* `name`: the name of the generated macro (as a reference lookup, i.e. a name, not a string).
+- *param* `doc`: the litteral string of the documentation for the generated macro.
+- *returns* a macro that will add the given annotation to a golo element
+
+See also [`extractAnnotationArguments`](#extractAnnotationArguments_2) and [`annotateElements`](#annotateElements_3v)
+----
+macro annotationWrapper = |annotation, name, doc| -> generateWrapper(
+  name: value(), annotation): documentation(doc: value())
+
+local function generateWrapper = |macroName, annotationClassReference| -> `macro(macroName)
+  : withParameters("args"): varargs()
+  : body(
+    `let(["a", "u", "e"], call("gololang.meta.Annotations.extractAnnotationArguments"): withArgs(
+        annotationClassReference, refLookup("args"))),
+    `return(call("gololang.meta.Annotations.annotateElements"): withArgs(
+        annotationClassReference, refLookup("a"), refLookup("e")))
+  )
+
+local function generateDocForWrapper = |ref| {
+  let doc = StringBuilder("Generated macro to apply the `"):append(ref: name()):append("` java annotation to golo elements.")
+            : append(System.lineSeparator())
+  var annotationClass = null
+  try {
+    foreach fieldName, type, default in extractAnnotationFields(ref: dereference()) {
+      doc: append(System.lineSeparator()): append("- *param* `"): append(fieldName): append("`")
+      if default isnt null {
+        doc: append(": default "): append(default)
+      }
+    }
+  } catch (e) {
+    if e oftype ClassNotFoundException.class {
+      Messages.warning("Annotation class %s not found": format(ref: name()))
+    } else {
+      throw e
+    }
+  }
+  doc: append(System.lineSeparator())
+  : append("- *returns* the annotated element wrapped in a `ToplevelElements` if required")
+  return doc: toString()
+}
+
+----
+Adds an annotation to the given elements.
+
+This function correctly deal with several elements by returning a `ToplevelElements`, and can therefore be used directly
+by a macro.
+
+The properties of the annotation are given in a map as returned by [`extractAnnotationArguments`](#extractAnnotationArguments_2).
+For instance, to have the equivalent of the Java code:
+```java
+@mypackage.MyAnnotation(prop1="hello", prop2=42)
+public static Object foo() {
+  return null;
+}
+```
+one should annotate the `foo` function definition IR with:
+```golo
+annotateElements(
+    mypackage.MyAnnotation.class,
+    map[
+      ["prop1", "hello"],
+      ["prop2", 42]
+    ],
+    theFooIR)
+```
+
+- *param* `annotationClass`: The class of the annotation.
+- *param* `args`: a map of the properties of the annotation.
+- *param* `elts`: the IR elements to annotate.
+- *returns* the annotated element itself if there is only one, or a `ToplevelElements` if there are several.
+
+See [`annotationWrapper`](#annotationWrapper_3), [`extractAnnotationArguments`](#extractAnnotationArguments_2)
+----
+function annotateElements = |annotationClass, args, elts...| -> annotateElement(
+  wrapToplevel(elts), annotationClass, args)
+
+local function annotateElement = |elt, annotationClass, args| {
+  if elt oftype gololang.ir.ToplevelElements.class {
+    foreach e in elt {
+      annotateElement(e, annotationClass, args)
+    }
+  } else {
+    checkApplicableTo(annotationClass, elt)
+    addAnnotationMetadata(annotationClass, args, elt)
+  }
+  return elt
+}
+
+# TODO: mapping for other types: fields, variables
+local function isApplicableTo = |annotationClass, target| {
+  let annotationTargets = annotationClass: getAnnotation(java.lang.annotation.Target.class)?: value()
+  let targetType = match {
+    when target oftype gololang.ir.GoloFunction.class then java.lang.annotation.ElementType.METHOD()
+    when target oftype gololang.ir.GoloType.class then java.lang.annotation.ElementType.TYPE()
+    when target oftype gololang.ir.GoloModule.class then java.lang.annotation.ElementType.TYPE()
+    when target oftype gololang.ir.NamedAugmentation.class then java.lang.annotation.ElementType.TYPE()
+    when target oftype gololang.ir.Augmentation.class and target: hasFunctions() then java.lang.annotation.ElementType.TYPE()
+    otherwise null
+  }
+  return annotationTargets is null
+         or (targetType isnt null
+             and java.util.Arrays.asList(annotationTargets): contains(targetType))
+}
+
+
+----
+Checks if a Java annotation can be applied to a golo element.
+
+Inspect the annotation's `Target` annotation.
+
+- *param* `annotationClass`: the class of the Java annotation
+- *param* `target`: the golo IR element to annotate
+- *throws* an exception if the element can't be annotated.
+----
+function checkApplicableTo = |annotationClass, target| {
+  require(annotationClass: getAnnotation(java.lang.annotation.Retention.class)?:value()
+          isnt java.lang.annotation.RetentionPolicy.SOURCE(),
+    "Golo can't deal with SOURCE retention annotations")
+  require(isApplicableTo(annotationClass, target),
+          "Annotation %s not applicable on a %s": format(annotationClass: getName(), target: getClass(): getName()))
+}
+
+local function extractAnnotationFields =|annotationClass| {
+  return array[
+    [
+      meth: getName(),
+      org.eclipse.golo.runtime.TypeMatching.boxed(meth: getReturnType()),
+      meth: getDefaultValue()
+    ] foreach meth in annotationClass: getDeclaredMethods()
+  ]
+}
+
+local function extractAnnotationNamedArguments = |annotClass, namedArgs| {
+  let annotationFields = map[]
+  foreach field in extractAnnotationFields(annotClass) {
+    fillArgumentsMap(annotationFields, field, getLiteralValue(namedArgs: get(field: get(0))))
+    namedArgs: remove(field: get(0))
+  }
+  let unknown = map[]
+  foreach k, v in namedArgs: entrySet() {
+    unknown: put(k, getLiteralValue(v))
+  }
+  return [annotationFields, unknown]
+}
+
+local function filterPositionnalArguments = |args| {
+  let arguments = vector[]
+  let elements = vector[]
+  foreach arg in args {
+    let value = getLiteralValue(arg)
+    if value is null {
+      continue
+    }
+    if value oftype gololang.ir.GoloElement.class {
+      elements: add(value)
+    } else {
+      arguments: add(value)
+    }
+  }
+  require(not (elements: isEmpty()), "No element to annotate")
+  return [arguments, elements: toArray()]
+}
+
+local function fillArgumentsMap = |map, field, value| {
+  let name, t, d = field
+  if (value isnt null) {
+    map: put(name, value)
+  }
+}
+
+----
+Parse the macro arguments according to an annotation class.
+
+The named arguments of the macro are matched with the annotation fields.
+If the annotation has at most one field, positional argument can be used.
+The named is extracted using reflection on the annotation class.
+The annotation fields are returned in a map of the name and values
+
+- *param* `annotation`: the annotation class
+- *param* `args`: the full array of arguments of the macro
+- *returns* a tuple containing a map of named arguments,
+            a map of named arguments not recognized by the annotation,
+            and an array of elements to annotate
+
+See [`parseArguments`](../macros/Utils.html#parseArguments_1),
+    [`getLiteralValue`](../macros/Utils.html#getLiteralValue_1)
+----
+function extractAnnotationArguments = |annotation, args| {
+  let p, n = parseArguments(args)
+  let namedMap, unknown = extractAnnotationNamedArguments(annotation, n)
+  let positionnals, elements = filterPositionnalArguments(p)
+  let fields = extractAnnotationFields(annotation)
+  require(not (fields: isEmpty())
+          or (namedMap: isEmpty() and positionnals: isEmpty()),
+      "The annotation %s has no field": format(annotation: name()))
+  require(fields: size() <= 1 or positionnals: isEmpty(),
+      "The annotation %s has several fields. Use the named arguments syntax": format(annotation: name()))
+  require((fields: size() != 1 or fields: get(0): get(2) isnt null) or not (namedMap: isEmpty()) or not (positionnals: isEmpty()),
+      "The annotation %s has 1 field with no default and no argument was provided": format(annotation: name()))
+
+  if fields: size() == 1 and namedMap: isEmpty() and not (positionnals: isEmpty()) {
+    fillArgumentsMap(namedMap, fields: get(0), positionnals: get(0))
+  }
+  return [namedMap, unknown, elements]
+}
+

--- a/src/main/golo/gololang/meta/README.md
+++ b/src/main/golo/gololang/meta/README.md
@@ -1,0 +1,5 @@
+# Meta programmation package
+
+This package contains modules that deal with meta-programmation.
+
+

--- a/src/main/java/gololang/DynamicObject.java
+++ b/src/main/java/gololang/DynamicObject.java
@@ -232,7 +232,7 @@ public final class DynamicObject {
         }
       }
     }
-    // XXX: should we try the fallback method here ?
+    // NOTE: should we try the fallback method here ?
     return object.define(property, arg);
   }
 

--- a/src/main/java/gololang/ir/ClassReference.java
+++ b/src/main/java/gololang/ir/ClassReference.java
@@ -40,6 +40,10 @@ public final class ClassReference {
     return this.name.replaceAll("\\.", "#");
   }
 
+  public Class<?> dereference() throws ClassNotFoundException {
+    return Class.forName(this.name, true, gololang.Runtime.classLoader());
+  }
+
   @Override
   public String toString() {
     return "Class<" + name + ">";

--- a/src/main/java/gololang/ir/CollectionLiteral.java
+++ b/src/main/java/gololang/ir/CollectionLiteral.java
@@ -84,7 +84,7 @@ public final class CollectionLiteral extends ExpressionStatement<CollectionLiter
   }
 
   public List<ExpressionStatement<?>> getExpressions() {
-    return expressions;
+    return Collections.unmodifiableList(expressions);
   }
 
   @Override

--- a/src/main/java/gololang/ir/ToplevelElements.java
+++ b/src/main/java/gololang/ir/ToplevelElements.java
@@ -40,8 +40,28 @@ public final class ToplevelElements extends GoloElement<ToplevelElements> implem
    * Creates a top-level elements container.
    *
    * <p>Mainly used to return several nodes from a top-level macro.
+   * <p>If only a {@code ToplevelElements} instance is given, it is returned unchanged.
    */
   public static ToplevelElements of(Object... elements) {
+    if (elements.length == 1 && elements[0] instanceof ToplevelElements) {
+      return (ToplevelElements) elements[0];
+    }
+    if (elements.length == 1 && elements[0] instanceof Iterable) {
+      return fromIterable((Iterable<Object>) elements[0]);
+    }
+    ToplevelElements tl = new ToplevelElements();
+    for (Object e : elements) {
+      tl.add(e);
+    }
+    return tl;
+  }
+
+/**
+   * Creates a top-level elements container.
+   *
+   * <p>Mainly used to return several nodes from a top-level macro.
+   */
+  public static ToplevelElements fromIterable(Iterable<Object> elements) {
     ToplevelElements tl = new ToplevelElements();
     for (Object e : elements) {
       tl.add(e);

--- a/src/main/java/gololang/ir/Visitors.java
+++ b/src/main/java/gololang/ir/Visitors.java
@@ -14,7 +14,7 @@ public final class Visitors {
   /**
    * Define how to walk the tree.
    */
-  enum Walk {
+  public enum Walk {
     /**
      * Walk the tree <em>before</em> dealing with the current element.
      */

--- a/src/main/java/org/eclipse/golo/cli/command/ClasspathOption.java
+++ b/src/main/java/org/eclipse/golo/cli/command/ClasspathOption.java
@@ -86,7 +86,6 @@ public class ClasspathOption {
       classpath = getFromEnv(System.getenv(ENV));
     }
     if (classpath.isEmpty()) {
-      // XXX: should "." be used in any case or only if no other path is given?
       classpath = DEFAULT;
     }
     System.setProperty(PROPERTY, String.join(SEP, classpath));

--- a/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
+++ b/src/main/java/org/eclipse/golo/compiler/JavaBytecodeUtils.java
@@ -12,7 +12,12 @@ package org.eclipse.golo.compiler;
 
 import gololang.ir.GoloElement;
 import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.MethodVisitor;
+import java.util.Map;
+import gololang.Tuple;
+import java.util.function.BiFunction;
+import org.objectweb.asm.AnnotationVisitor;
 
 import static org.objectweb.asm.Opcodes.*;
 
@@ -67,4 +72,62 @@ final class JavaBytecodeUtils {
     }
     return label;
   }
+
+  static boolean isDeprecated(GoloElement<?> element) {
+    return element.metadata("deprecated") != null && (boolean) element.metadata("deprecated");
+  }
+
+  static int deprecatedFlag(GoloElement<?> element) {
+    if (isDeprecated(element)) {
+      return ACC_DEPRECATED;
+    }
+    return 0;
+  }
+
+  static void addAnnotations(GoloElement<?> element, BiFunction<String, Boolean, AnnotationVisitor> factory) {
+    addAnnotations(element.metadata("annotations"), factory);
+  }
+
+  /**
+   * Adds the annotations to a element's bytecode
+   *
+   * @param annotationsMeta a Map containing annotations metadata
+   * @param factory the function adding the annotation bytecode (ASM visitor method)
+   */
+  static void addAnnotations(Object annotationsMeta, BiFunction<String, Boolean, AnnotationVisitor> factory) {
+    if (annotationsMeta instanceof Iterable) {
+      @SuppressWarnings("unchecked")
+      Iterable<Tuple> annotations = (Iterable<Tuple>) annotationsMeta;
+      for (Tuple annotation : annotations) {
+        String annotationClassName = (String) annotation.get(0);
+        boolean annotationVisible = (boolean) annotation.get(1);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> annotationArguments = (Map<String, Object>) annotation.get(2);
+        AnnotationVisitor av = factory.apply(annotationClassName, annotationVisible);
+        if (annotationArguments != null) {
+          for (Map.Entry<String, Object> entry : annotationArguments.entrySet()) {
+            addAnnotationValue(av, entry.getKey(), entry.getValue());
+          }
+        }
+        av.visitEnd();
+      }
+    }
+  }
+
+  private static void addAnnotationValue(AnnotationVisitor visitor, String name, Object value) {
+    if (value instanceof Class<?>) {
+      visitor.visit(name, Type.getType((Class) value));
+    } else if (value.getClass().isArray()) {
+      AnnotationVisitor arrayVisitor = visitor.visitArray(name);
+      for (Object val: (Object[]) value) {
+        addAnnotationValue(arrayVisitor, null, val);
+      }
+      arrayVisitor.visitEnd();
+    } else if (value.getClass().isEnum()) {
+      visitor.visitEnum(name, value.getClass().getName(), ((Enum) value).name());
+    } else {
+      visitor.visit(name, value);
+    }
+  }
+
 }

--- a/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
+++ b/src/main/java/org/eclipse/golo/compiler/ParseTreeToGoloIrVisitor.java
@@ -472,7 +472,7 @@ public class ParseTreeToGoloIrVisitor implements GoloParserVisitor {
       ASTBlock astBlock = new ASTBlock(0);
       astBlock.jjtAddChild(astReturn, 0);
       astBlock.jjtAccept(this, data);
-      // XXX
+      // FIXME ?
       // if (function.isSynthetic()) {
       //   context.pop();
       // }

--- a/src/main/java/org/eclipse/golo/runtime/TypeMatching.java
+++ b/src/main/java/org/eclipse/golo/runtime/TypeMatching.java
@@ -151,7 +151,10 @@ public final class TypeMatching {
     return 0;
   }
 
-  private static Class<?> boxed(Class<?> t) {
+  /**
+   * @return the boxed version of the given type, and class itself otherwise.
+   */
+  public static Class<?> boxed(Class<?> t) {
     if (!t.isPrimitive()) {
       return t;
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -79,8 +79,8 @@ struct_private_member = Private member of `{0}`
 # Runtime warnings ============================================================
 no_parameter_names = The function `{0}` has no parameter names but is called with {1} as argument names.\n\tSee <{2}#warning-no-parameter-names> for more information.
 unavailable_class = `{0}` used in `{1}` can\u2019t be loaded.\n\tSee <{2}#warning-unavailable-class> for more information.
-deprecated_element = `{0}` used in `{1}` is deprecated.\n\tSee <{2}#warning-deprecated> for more information.
+
+deprecated_element = `{0}` in `{1}` is deprecated.\n\tSee <{2}#warning-deprecated> for more information.
 
 # Documentation warnings and errors ===========================================
 multiple_package_desc = Multiple description files found for package `{0}`; using the first one.\n\tSee <{1}#warning-multiple-package-desc> for more information.
-

--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -80,7 +80,7 @@ struct_private_member = Membre priv\u00e9 de `{0}`
 # Runtime warnings ============================================================
 no_parameter_names = La fonction `{0}` n\u2019a pas de param\u00e8tre nomm\u00e9 mais est appel\u00e9e avec {1} comme noms d\u2019arguments.\n\tVoir <{2}#warning-no-parameter-names> pour plus d\u2019informations.
 unavailable_class = `{0}` utilis\u00e9e dans `{1}` ne peut pas \u00eatre charg\u00e9e.\n\tVoir <{2}#warning-unavailable-class> pour plus d\u2019informations.
-deprecated_element = `{0}` utilis\u00e9e dans `{1}` est obsol\u00e8te.\n\tVoir <{2}#warning-deprecated> pour plus d\u2019informations.
+deprecated_element = `{0}` dans `{1}` est obsol\u00e8te.\n\tVoir <{2}#warning-deprecated> pour plus d\u2019informations.
 
 # Documentation warnings and errors ===========================================
 multiple_package_desc = Fichiers de description surnum\u00e9raires pour le paquet `{0}`; utilisation du premier.\n\tVoir <{1}#warning-multiple-package-desc> pour plus d\u2019informations.

--- a/src/test/java/golo/test/annotations/Complex.java
+++ b/src/test/java/golo/test/annotations/Complex.java
@@ -1,0 +1,13 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Complex {
+  Values[] vals() default {Values.FIRST, Values.OTHER};
+
+  Class<?>[] cls();
+
+}
+
+

--- a/src/test/java/golo/test/annotations/OnAll.java
+++ b/src/test/java/golo/test/annotations/OnAll.java
@@ -1,0 +1,8 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OnAll {
+}
+

--- a/src/test/java/golo/test/annotations/OnBoth.java
+++ b/src/test/java/golo/test/annotations/OnBoth.java
@@ -1,0 +1,9 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface OnBoth {
+}
+

--- a/src/test/java/golo/test/annotations/OnClass.java
+++ b/src/test/java/golo/test/annotations/OnClass.java
@@ -1,0 +1,9 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OnClass {
+}
+

--- a/src/test/java/golo/test/annotations/OnClassInherit.java
+++ b/src/test/java/golo/test/annotations/OnClassInherit.java
@@ -1,0 +1,10 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface OnClassInherit {
+}
+

--- a/src/test/java/golo/test/annotations/OnMethod.java
+++ b/src/test/java/golo/test/annotations/OnMethod.java
@@ -1,0 +1,9 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface OnMethod {
+}
+

--- a/src/test/java/golo/test/annotations/Values.java
+++ b/src/test/java/golo/test/annotations/Values.java
@@ -1,0 +1,7 @@
+package golo.test.annotations;
+
+public enum Values {
+  FIRST,
+  OTHER;
+}
+

--- a/src/test/java/golo/test/annotations/WithArrayArg.java
+++ b/src/test/java/golo/test/annotations/WithArrayArg.java
@@ -1,0 +1,8 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithArrayArg {
+  String[] strings();
+}

--- a/src/test/java/golo/test/annotations/WithEnumArg.java
+++ b/src/test/java/golo/test/annotations/WithEnumArg.java
@@ -1,0 +1,9 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithEnumArg {
+  Values val();
+}
+

--- a/src/test/java/golo/test/annotations/WithIntArg.java
+++ b/src/test/java/golo/test/annotations/WithIntArg.java
@@ -1,0 +1,8 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithIntArg {
+  int val() default 1;
+}

--- a/src/test/java/golo/test/annotations/WithNamedArg.java
+++ b/src/test/java/golo/test/annotations/WithNamedArg.java
@@ -1,0 +1,10 @@
+package golo.test.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithNamedArg {
+  int a();
+  String b() default "answer";
+  Class<?> c() default Float.class;
+}

--- a/src/test/java/gololang/meta/AnnotationsTest.java
+++ b/src/test/java/gololang/meta/AnnotationsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012-2020 Institut National des Sciences Appliquées de Lyon (INSA-Lyon) and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package gololang.meta;
+
+import org.testng.annotations.Test;
+import org.eclipse.golo.internal.testing.GoloTest;
+
+public class AnnotationsTest extends GoloTest {
+
+  @Override
+  public String srcDir() {
+    return "for-macros/";
+  }
+
+  @Test
+  public void tests() throws Throwable {
+    load("annotation-macros");
+    load("Annotate");
+    run("annotation");
+  }
+}
+

--- a/src/test/java/org/eclipse/golo/compiler/MacroTest.java
+++ b/src/test/java/org/eclipse/golo/compiler/MacroTest.java
@@ -14,8 +14,6 @@ import org.testng.annotations.Test;
 
 import org.eclipse.golo.internal.testing.GoloTest;
 
-import static org.eclipse.golo.internal.testing.TestUtils.compileAndLoadGoloModule;
-
 public class MacroTest extends GoloTest {
 
   @Override

--- a/src/test/resources/for-macros/Annotate.golo
+++ b/src/test/resources/for-macros/Annotate.golo
@@ -1,0 +1,135 @@
+
+@OnClass
+module golo.test.Annotate
+
+&use("golo.test.AnnotationMacros")
+
+@OnMethod
+function plop = -> null
+
+
+@OnClass
+struct Foo = {x}
+
+@OnClassInherit
+union Bar = {
+  @OnClass
+  A
+  B = {a,b}
+}
+
+@OnClass
+union Egg = {
+  Spam
+}
+
+@OnClass
+augmentation Aaa = {
+  function spam =  |this| -> null
+}
+
+@OnClass
+augment java.lang.String {
+  function foo = |this| -> 42
+}
+
+@OnBoth
+function both = -> null
+
+@OnBoth
+struct Both = {on}
+
+@OnAll
+function all = -> null
+
+@OnAll
+struct All = {on}
+
+&OnMultiple {
+function multi1 = -> null
+function multi2 = -> null
+struct Multi = {on}
+}
+
+@OnMultiple
+function multi3 = -> null
+
+@OnMultiple
+struct Multi2 = {on}
+
+&OnMethod {
+
+@OnBoth
+function stack1 = -> null
+
+@OnAll
+function stack2 = -> null
+
+}
+
+&OnMethod {
+&OnAll {
+function stack3 = -> null
+function stack4 = -> null
+}
+}
+
+@OnMethod
+@OnBoth
+function stack5 = -> null
+
+@WithIntArg(42)
+function withInt = -> null
+
+&WithIntArg(12) {
+  function withIntA = -> null
+  function withIntB = -> null
+}
+
+@WithIntArg
+function withIntDefault = -> null
+
+&WithIntArg {
+function withIntDefaultA = -> null
+function withIntDefaultB = -> null
+}
+
+@WithNamedArg(a=42, b="hello", c=java.lang.String.class)
+function namedA = -> null
+
+@WithNamedArg(a=42)
+function namedB = -> null
+
+&WithNamedArg(a=42, b="hello") {
+function namedC1 = -> null
+function namedC2 = -> null
+}
+
+@WithArrayArg(["a", "b", "c"])
+function stringArray = -> null
+
+
+@WithEnumArg(golo.test.annotations.Values.FIRST())
+function enum = -> null
+
+&WithEnumArg(golo.test.annotations.Values.OTHER()) {
+function enumA = -> null
+function enumB = -> null
+}
+
+@Complex(cls=[java.lang.String.class, java.lang.Integer.class])
+function complexA = -> null
+
+@Complex(cls=[java.lang.String.class], vals=array[golo.test.annotations.Values.OTHER()])
+function complexB= -> null
+
+&Complex(cls=[java.lang.String.class, java.lang.Integer.class]) {
+function complexC = -> null
+function complexD = -> null
+}
+
+&Complex(cls=[java.lang.String.class, java.lang.Integer.class], vals=[golo.test.annotations.Values.OTHER(),
+golo.test.annotations.Values.FIRST(), golo.test.annotations.Values.OTHER()]) {
+function complexE = -> null
+function complexF = -> null
+}

--- a/src/test/resources/for-macros/annotation-macros.golo
+++ b/src/test/resources/for-macros/annotation-macros.golo
@@ -1,0 +1,17 @@
+
+module golo.test.AnnotationMacros
+
+&use("gololang.meta.Annotations")
+
+&annotationWrapper(golo.test.annotations.OnMethod.class)
+&annotationWrapper(golo.test.annotations.OnClass.class)
+&annotationWrapper(golo.test.annotations.OnClassInherit.class)
+&annotationWrapper(golo.test.annotations.OnBoth.class)
+&annotationWrapper(golo.test.annotations.OnAll.class)
+&annotationWrapper(golo.test.annotations.OnAll.class, "OnMultiple")
+&annotationWrapper(golo.test.annotations.WithIntArg.class)
+&annotationWrapper(golo.test.annotations.WithNamedArg.class)
+&annotationWrapper(golo.test.annotations.WithArrayArg.class)
+&annotationWrapper(golo.test.annotations.WithEnumArg.class)
+&annotationWrapper(golo.test.annotations.Complex.class, "Complex", "Documentation of the complex macro")
+

--- a/src/test/resources/for-macros/annotation.golo
+++ b/src/test/resources/for-macros/annotation.golo
@@ -1,0 +1,191 @@
+
+module golo.test.AnnotationTest
+
+import golo.test
+import golo.test.annotations
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+
+import gololang.meta.Annotations
+import gololang.ir.DSL
+
+local function getAnnotationFor = |a, f| {
+  let r = Annotate.class: getDeclaredMethod(f): getAnnotation(a)
+  assertThat("The annotation %s is present on fonction ": format(a: getSimpleName(), f), `is(notNullValue()))
+  return r
+}
+
+function test_on_method = {
+  getAnnotationFor(OnMethod.class, "plop")
+}
+
+function test_on_classes = {
+  let present = |cls| -> cls: isAnnotationPresent(OnClass.class)
+  assertThat("The annotation is present on the module itself", present(Annotate.class))
+  assertThat("The annotation is present on the struct", present(Annotate.types.Foo.class))
+  assertThat("The annotation is present on the union", present(Annotate.types.Egg.class))
+  assertThat("The annotation is not present on the union value", not present(Annotate.types.Egg$Spam.class))
+  assertThat("The annotation is present on the value", present(Annotate.types.Bar$A.class))
+  assertThat("The annotation is present on the named augmentation", present(Annotate$Aaa.class))
+  assertThat("The annotation is present on the augmentation", present(Annotate$java$lang$String.class))
+}
+
+function test_on_union_inherit = {
+  let present = |cls| -> cls: isAnnotationPresent(OnClassInherit.class)
+  assertThat("The annotation is inherited", present(Annotate.types.Bar.class))
+  assertThat("The annotation is inherited", present(Annotate.types.Bar$A.class))
+  assertThat("The annotation is inherited", present(Annotate.types.Bar$B.class))
+}
+
+function test_on_both = {
+  assertThat("The annotation OnBoth is on the type", Annotate.types.Both.class: isAnnotationPresent(OnBoth.class))
+  getAnnotationFor(OnBoth.class, "both")
+}
+
+function test_on_all = {
+  assertThat("The annotation OnAll is on the type", Annotate.types.All.class: isAnnotationPresent(OnAll.class))
+  getAnnotationFor(OnAll.class, "all")
+}
+
+function test_on_multiple = {
+  assertThat("The annotation is on the types", Annotate.types.Multi.class: isAnnotationPresent(OnAll.class))
+  assertThat("The annotation is on the types", Annotate.types.Multi2.class: isAnnotationPresent(OnAll.class))
+  getAnnotationFor(OnAll.class, "multi1")
+  getAnnotationFor(OnAll.class, "multi2")
+  getAnnotationFor(OnAll.class, "multi3")
+}
+
+function test_stack = {
+  getAnnotationFor(OnMethod.class, "stack1")
+  getAnnotationFor(OnBoth.class, "stack1")
+  getAnnotationFor(OnMethod.class, "stack2")
+  getAnnotationFor(OnAll.class, "stack2")
+  getAnnotationFor(OnMethod.class, "stack3")
+  getAnnotationFor(OnAll.class, "stack3")
+  getAnnotationFor(OnMethod.class, "stack4")
+  getAnnotationFor(OnAll.class, "stack4")
+  getAnnotationFor(OnMethod.class, "stack5")
+  getAnnotationFor(OnBoth.class, "stack5")
+}
+
+function test_simple_value = {
+  assertThat(getAnnotationFor(WithIntArg.class, "withInt"): val(), `is(42))
+}
+
+function test_simple_value_multi = {
+  assertThat(getAnnotationFor(WithIntArg.class, "withIntA"): val(), `is(12))
+  assertThat(getAnnotationFor(WithIntArg.class, "withIntB"): val(), `is(12))
+}
+
+function test_simple_value_default = {
+  assertThat(getAnnotationFor(WithIntArg.class, "withIntDefault"): val(), `is(1))
+  assertThat(getAnnotationFor(WithIntArg.class, "withIntDefaultA"): val(), `is(1))
+  assertThat(getAnnotationFor(WithIntArg.class, "withIntDefaultB"): val(), `is(1))
+}
+
+function test_args = {
+  let a = getAnnotationFor(WithNamedArg.class, "namedA")
+  assertThat(a: a(), `is(42))
+  assertThat(a: b(), `is("hello"))
+  assertThat(a: c(), `is(equalTo(String.class)))
+}
+
+function test_args_default = {
+  let a = getAnnotationFor(WithNamedArg.class, "namedB")
+  assertThat(a: a(), `is(42))
+  assertThat(a: b(), `is("answer"))
+  assertThat(a: c(), `is(equalTo(Float.class)))
+}
+
+function test_args_multi = {
+  foreach f in array["namedC1", "namedC2"] {
+    let a = getAnnotationFor(WithNamedArg.class, f)
+    assertThat(a: a(), `is(42))
+    assertThat(a: b(), `is("hello"))
+    assertThat(a: c(), `is(equalTo(Float.class)))
+  }
+}
+
+function test_array_args = {
+  let a = getAnnotationFor(WithArrayArg.class, "stringArray")
+  assertThat(a: strings(), `is(arrayContaining("a", "b", "c")))
+}
+
+function test_enum_args = {
+  foreach name, value in array[["enum", golo.test.annotations.Values.FIRST()],
+                               ["enumA", golo.test.annotations.Values.OTHER()],
+                               ["enumB", golo.test.annotations.Values.OTHER()]] {
+    let a = getAnnotationFor(WithEnumArg.class, name)
+    assertThat(a: val(), `is(value))
+  }
+}
+
+function test_complex = {
+  let get = |fn| -> getAnnotationFor(Complex.class, fn)
+  let def = array[golo.test.annotations.Values.FIRST(), golo.test.annotations.Values.OTHER()]
+
+  var a = get("complexA")
+  assertThat(a: vals(), `is(arrayContaining(def)))
+  assertThat(a: cls(), `is(arrayContaining(java.lang.String.class, java.lang.Integer.class)))
+
+  a = get("complexB")
+  assertThat(a: vals(), `is(arrayContaining(golo.test.annotations.Values.OTHER())))
+  assertThat(a: cls(), `is(arrayContaining(java.lang.String.class)))
+
+  foreach n in array["complexC", "complexD"] {
+    a = get(n)
+    assertThat(a: vals(), `is(arrayContaining(def)))
+    assertThat(a: cls(), `is(arrayContaining(java.lang.String.class, java.lang.Integer.class)))
+  }
+
+  foreach n in array["complexE", "complexF"] {
+    a = get(n)
+    assertThat(a: vals(), `is(arrayContaining(
+          golo.test.annotations.Values.OTHER(),
+          golo.test.annotations.Values.FIRST(),
+          golo.test.annotations.Values.OTHER())))
+    assertThat(a: cls(), `is(arrayContaining(
+          java.lang.String.class,
+          java.lang.Integer.class)))
+  }
+}
+
+function test_arguments_extraction = {
+  let f = `function("foo"): returns(constant(null))
+  let b = `function("bar"): returns(constant(null))
+  let a, u, e = extractAnnotationArguments(WithNamedArg.class, array[
+    namedArgument("a", constant(42)),
+    namedArgument("b", constant("hello")),
+    namedArgument("c", constant(null)),
+    namedArgument("u", constant("surprise")),
+    f, b
+  ])
+
+  assertThat(a, `is(aMapWithSize(2)))
+  assertThat(a, hasEntry("a", 42))
+  assertThat(a, hasEntry("b", "hello"))
+
+  assertThat(u, `is(aMapWithSize(1)))
+  assertThat(u, hasEntry("u", "surprise"))
+  assertThat(e, `is(arrayContaining(f, b)))
+}
+
+
+function main = |args| {
+  test_on_method()
+  test_on_classes()
+  test_on_union_inherit()
+  test_on_both()
+  test_on_all()
+  test_stack()
+  test_simple_value()
+  test_simple_value_default()
+  test_simple_value_multi()
+  test_args()
+  test_args_default()
+  test_args_multi()
+  test_array_args()
+  test_enum_args()
+  test_complex()
+  println("ok")
+}

--- a/src/test/resources/for-test/macro-utils.golo
+++ b/src/test/resources/for-test/macro-utils.golo
@@ -69,7 +69,7 @@ function test_parseArguments = {
   assertThat(
     parseArguments(array[], false),
   arrayContaining(
-    list[], map[], null
+    array[], map[], null
   ))
 
   assertRaises(
@@ -79,37 +79,37 @@ function test_parseArguments = {
   assertThat(
     parseArguments(array[42], false),
   arrayContaining(
-    list[42], map[], null
+    array[42], map[], null
   ))
 
   assertThat(
     parseArguments(array[42]),
   arrayContaining(
-    list[42], map[], null
+    array[42], map[], null
   ))
 
   assertThat(
     parseArguments(array[42], true),
   arrayContaining(
-    list[], map[], 42
+    array[], map[], 42
   ))
 
   assertThat(
     parseArguments(array[42], null),
   arrayContaining(
-    list[], map[], 42
+    array[], map[], 42
   ))
 
   assertThat(
     parseArguments(array[42], Integer.class),
   arrayContaining(
-    list[], map[], 42
+    array[], map[], 42
   ))
 
   assertThat(
     parseArguments(array[42], String.class),
   arrayContaining(
-    list[42], map[], null
+    array[42], map[], null
   ))
 
   let args = array[
@@ -124,9 +124,9 @@ function test_parseArguments = {
 
   l, m = parseArguments(args, false)
   assertThat(
-    l: map(|c| -> c: value()),
+    array[c: value() foreach c in l],
   `is(
-    list["answer", 42, "last"]
+    array["answer", 42, "last"]
   ))
 
   assertThat(
@@ -140,9 +140,9 @@ function test_parseArguments = {
 
   l, m, r = parseArguments(args, true)
   assertThat(
-    l: map(|c| -> c: value()),
+    array[c: value() foreach c in l],
   `is(
-    list["answer", 42]
+    array["answer", 42]
   ))
 
   assertThat(

--- a/src/test/resources/for-test/result.golo
+++ b/src/test/resources/for-test/result.golo
@@ -56,7 +56,6 @@ function test_or = {
   assertEquals(err1:`or(err2), Result.fail("err2"))
   assertEquals(err1:`or(nop), Result.empty())
 
-  # XXX: check semantic empty or ok(1)?
   assertEquals(nop:`or(ok1), Result.empty())
   assertEquals(nop:`or(err1), Result.empty())
   assertEquals(nop:`or(nop), Result.empty())


### PR DESCRIPTION
Allows to annotate golo functions or types with Java annotations:
- generates bytecode for the annotations based on metadata attached to IR elements
- provides utility functions to ease the creation of macro adding such metadata
- provides a "meta-macro" generating such macros using reflexion on the annotation class
- define a `deprecated` macro to mark elements as deprecated (annotating with `java.lang.Deprecated` is not enough, the bytecode flag needs to be set)